### PR TITLE
fix(session): skip malformed JSONL lines instead of crashing on resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "opencli",
-  "version": "0.1.0",
+  "name": "@zjshen/opencli",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opencli",
-      "version": "0.1.0",
+      "name": "@zjshen/opencli",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@clack/prompts": "^0.9.0",
@@ -21,7 +22,7 @@
         "yaml": "^2.7.0"
       },
       "bin": {
-        "opencli": "dist/cli/index.js"
+        "opencli": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1487,7 +1488,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1828,7 +1828,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2480,7 +2479,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2544,7 +2542,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3255,7 +3252,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3502,7 +3498,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3905,7 +3900,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3955,7 +3949,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4699,7 +4692,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4745,7 +4737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4816,7 +4807,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4915,7 +4905,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -5188,7 +5177,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -200,3 +200,51 @@ describe("Session.log", () => {
     await expect(session.log({ type: "custom_event", data: 42 })).resolves.toBeUndefined();
   });
 });
+
+describe("Session.loadMessages — malformed JSONL resilience", () => {
+  it("skips malformed lines and still returns valid messages", async () => {
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    const { AGENT_DIR } = await import("./config.js");
+    const { join } = await import("node:path");
+
+    const projectDir = join(AGENT_DIR, "projects", CWD.replace(/\//g, "-"));
+    await mkdir(projectDir, { recursive: true });
+    const id = "2025-01-01T00-00-00";
+    const logPath = join(projectDir, `${id}.jsonl`);
+
+    const goodEntry = (obj: object) => JSON.stringify({ ...obj, timestamp: "t" });
+    const lines = [
+      goodEntry({ type: "session_start", cwd: CWD }),
+      goodEntry({ type: "user", content: "Hello" }),
+      "{ this is not valid JSON {{{{",
+      goodEntry({ type: "assistant", content: "Hi there" }),
+      "another bad line",
+    ].join("\n");
+
+    await writeFile(logPath, lines, "utf8");
+
+    const { messages } = await Session.loadMessages(id, CWD);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ role: "user", parts: [{ type: "text", text: "Hello" }] });
+    expect(messages[1]).toMatchObject({
+      role: "model",
+      parts: [{ type: "text", text: "Hi there" }],
+    });
+  });
+
+  it("returns empty messages when all lines are malformed", async () => {
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    const { AGENT_DIR } = await import("./config.js");
+    const { join } = await import("node:path");
+
+    const projectDir = join(AGENT_DIR, "projects", CWD.replace(/\//g, "-"));
+    await mkdir(projectDir, { recursive: true });
+    const id = "2025-01-01T00-00-01";
+    const logPath = join(projectDir, `${id}.jsonl`);
+
+    await writeFile(logPath, "not json\nalso bad\n{incomplete", "utf8");
+
+    const { messages } = await Session.loadMessages(id, CWD);
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -214,7 +214,14 @@ export class Session {
     const entries: SessionEntry[] = raw
       .split("\n")
       .filter(Boolean)
-      .map((line) => JSON.parse(line));
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line) as SessionEntry];
+        } catch {
+          process.stderr.write("[opencli] skipping malformed session log entry\n");
+          return [];
+        }
+      });
 
     return {
       session: new Session(sessionId, cwd, logPath),


### PR DESCRIPTION
## Summary

- `Session.loadMessages()` previously called `JSON.parse` on every JSONL line with no error handling, so a single malformed line (partial write after SIGKILL, disk-full truncation) caused the entire session resume to throw and made the session permanently unrecoverable.
- Replaced the `.map(JSON.parse)` call with `.flatMap(try-catch)` — bad lines are skipped with a `process.stderr` warning; all valid history is still returned.
- Added two regression tests in `session.test.ts`: one that verifies a mix of valid and malformed lines returns only the valid messages, and one that verifies a fully-malformed file returns an empty message list without throwing.

Closes #9

## Test plan

- [x] `npm run typecheck` — passes (pre-existing unrelated errors in repo, none introduced)
- [x] `npm run format:check` — passes
- [x] `npm test` — 169/169 tests pass, including 2 new tests for this fix

https://claude.ai/code/session_01WCMf4FUYKiHEtVaGRuk11e

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCMf4FUYKiHEtVaGRuk11e)_