### PR TITLE
fix: write config.json with 0o600 permissions to prevent API key exposure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "opencli",
-  "version": "0.1.0",
+  "name": "@zjshen/opencli",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opencli",
-      "version": "0.1.0",
+      "name": "@zjshen/opencli",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@clack/prompts": "^0.9.0",
@@ -21,7 +22,7 @@
         "yaml": "^2.7.0"
       },
       "bin": {
-        "opencli": "dist/cli/index.js"
+        "opencli": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1487,7 +1488,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1828,7 +1828,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2480,7 +2479,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2544,7 +2542,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3255,7 +3252,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3502,7 +3498,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3905,7 +3900,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3955,7 +3949,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4699,7 +4692,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4745,7 +4737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4816,7 +4807,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4915,7 +4905,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -5188,7 +5177,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/state/config.test.ts
+++ b/src/state/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { rm } from "node:fs/promises";
+import { rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -49,5 +49,12 @@ describe("saveConfig", () => {
     const config = await loadConfig();
     expect(config.model).toBe("gemini-2.5-flash");
     expect(config.historySize).toBe(25);
+  });
+
+  it("writes config file with owner-only permissions (0o600)", async () => {
+    await saveConfig({ model: "gemini-2.5-flash" });
+    const configFile = join(tmpHome, ".opencli", "config.json");
+    const info = await stat(configFile);
+    expect(info.mode & 0o777).toBe(0o600);
   });
 });

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -39,4 +39,5 @@ export async function saveConfig(config: Partial<Config>): Promise<void> {
   const updated = { ...current, ...config };
   await mkdir(AGENT_DIR, { recursive: true });
   await writeFile(CONFIG_FILE, JSON.stringify(updated, null, 2), "utf8");
+  await chmod(CONFIG_FILE, 0o600);
 }


### PR DESCRIPTION
Closes #8

## What changed

`saveConfig()` in `src/state/config.ts` now calls `chmod(CONFIG_FILE, 0o600)` immediately after writing `~/.opencli/config.json`. This ensures the file is owner-readable only, preventing other users on the same machine from reading stored API keys.

## Why

The default `writeFile` mode is `0o644` (world-readable). If a user stores their Gemini or Anthropic API key via `opencli config set`, that key was readable by any user on the machine. This is the same protection SSH applies to `~/.ssh/id_rsa`.

## Test

Added `src/state/config.test.ts`: _"writes config file with owner-only permissions (0o600)"_ — saves config and asserts `stat(configFile).mode & 0o777 === 0o600`.

All 168 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4UJbUoe3mEp6i3XZR7Yzv)_