### PR TITLE
fix(session): pair tool_result IDs with matching tool_call IDs on resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "opencli",
-  "version": "0.1.0",
+  "name": "@zjshen/opencli",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opencli",
-      "version": "0.1.0",
+      "name": "@zjshen/opencli",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@clack/prompts": "^0.9.0",
@@ -21,7 +22,7 @@
         "yaml": "^2.7.0"
       },
       "bin": {
-        "opencli": "dist/cli/index.js"
+        "opencli": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1487,7 +1488,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1828,7 +1828,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2480,7 +2479,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2544,7 +2542,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3255,7 +3252,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3502,7 +3498,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3905,7 +3900,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3955,7 +3949,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4699,7 +4692,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4745,7 +4737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4816,7 +4807,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4915,7 +4905,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -5188,7 +5177,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -184,6 +184,42 @@ describe("Session.loadMessages", () => {
     expect(messages[5]).toMatchObject({ role: "model", parts: [{ type: "text", text: "Done." }] });
   });
 
+  it("pairs tool_call and tool_result with matching IDs (single call)", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Do something" });
+    await session.log({ type: "tool_call", name: "bash", args: { command: "echo hi" } });
+    await session.log({ type: "tool_result", name: "bash", result: "hi" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    const callPart = messages[1].parts[0] as { type: string; id: string };
+    const resultPart = messages[2].parts[0] as { type: string; id: string };
+    expect(callPart.type).toBe("function_call");
+    expect(resultPart.type).toBe("function_result");
+    expect(resultPart.id).toBe(callPart.id);
+  });
+
+  it("pairs tool_call and tool_result IDs in parallel multi-call rounds", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Go" });
+    await session.log({ type: "tool_call", name: "glob", args: { pattern: "*.ts" } });
+    await session.log({ type: "tool_call", name: "grep", args: { pattern: "foo" } });
+    await session.log({ type: "tool_result", name: "glob", result: "a.ts" });
+    await session.log({ type: "tool_result", name: "grep", result: "a.ts:1" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    // messages[1] = model with 2 function_call parts; messages[2] = user with 2 function_result parts
+    const calls = messages[1].parts as Array<{ type: string; id: string }>;
+    const results = messages[2].parts as Array<{ type: string; id: string }>;
+    expect(calls).toHaveLength(2);
+    expect(results).toHaveLength(2);
+    expect(results[0].id).toBe(calls[0].id);
+    expect(results[1].id).toBe(calls[1].id);
+    // IDs must be distinct across the two calls
+    expect(calls[0].id).not.toBe(calls[1].id);
+  });
+
   it("ignores session_start and unknown entries", async () => {
     const session = await Session.create(CWD);
     await session.log({ type: "user", content: "Hi" });

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -78,17 +78,23 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
   // Pending batches accumulate until we know where they belong
   let pendingCalls: FunctionCallPart[] = [];
   let pendingResults: FunctionResultPart[] = [];
+  // Queue of call IDs waiting for their matching results; ensures each
+  // function_result references the same ID as its function_call (required by
+  // the Anthropic API, which validates tool_result.tool_use_id against prior tool_use blocks).
+  let pendingCallIds: string[] = [];
 
   function flushCalls(): void {
     if (pendingCalls.length === 0) return;
     messages.push({ role: "model", parts: pendingCalls });
     pendingCalls = [];
+    // pendingCallIds intentionally kept — results still need them
   }
 
   function flushResults(): void {
     if (pendingResults.length === 0) return;
     messages.push({ role: "user", parts: pendingResults });
     pendingResults = [];
+    pendingCallIds = [];
   }
 
   for (const entry of entries) {
@@ -101,6 +107,7 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
       // New tool_call batch: if there were results from a previous round, flush them first
       flushResults();
       const id = `resume-call-${++idCounter}`;
+      pendingCallIds.push(id);
       pendingCalls.push({
         type: "function_call",
         id,
@@ -110,7 +117,7 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
     } else if (entry.type === "tool_result") {
       // Results follow their calls — flush the pending call batch into a model message
       flushCalls();
-      const id = `resume-call-${++idCounter}`;
+      const id = pendingCallIds.shift() ?? `resume-call-${++idCounter}`;
       pendingResults.push({
         type: "function_result",
         id,


### PR DESCRIPTION
## Summary

Closes #10

- `reconstructMessages()` in `src/state/session.ts` was incrementing `idCounter` independently for both `tool_call` and `tool_result` log entries, so a call got `resume-call-1` while its result got `resume-call-2`.
- The Anthropic API validates that every `tool_result.tool_use_id` matches a `tool_use.id` in the preceding assistant message — the mismatch caused a `400 Bad Request` on the first prompt after resuming any Anthropic session that contained tool use.
- Fix: introduce a `pendingCallIds` FIFO queue. When a `tool_call` is processed its generated ID is enqueued; when the matching `tool_result` is processed it dequeues that ID instead of generating a new one. A fallback generates a fresh ID if the queue is unexpectedly empty (e.g. truncated log).

## Test plan

- [ ] `npm test` — all 169 tests pass, including 2 new regression tests in `src/state/session.test.ts`:
  - `pairs tool_call and tool_result with matching IDs (single call)`
  - `pairs tool_call and tool_result IDs in parallel multi-call rounds`
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `npm run format:check` — clean

https://claude.ai/code/session_011avBxFhx6wmvk53F6zrNWL

---
_Generated by [Claude Code](https://claude.ai/code/session_011avBxFhx6wmvk53F6zrNWL)_