### PR TITLE
fix: safe error wrapping and 500/502 retryable codes in GeminiClient and AnthropicClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "opencli",
-  "version": "0.1.0",
+  "name": "@zjshen/opencli",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opencli",
-      "version": "0.1.0",
+      "name": "@zjshen/opencli",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@clack/prompts": "^0.9.0",
@@ -21,7 +22,7 @@
         "yaml": "^2.7.0"
       },
       "bin": {
-        "opencli": "dist/cli/index.js"
+        "opencli": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1487,7 +1488,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1828,7 +1828,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2480,7 +2479,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2544,7 +2542,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3255,7 +3252,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3502,7 +3498,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3905,7 +3900,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3955,7 +3949,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4699,7 +4692,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4745,7 +4737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4816,7 +4807,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4915,7 +4905,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -5188,7 +5177,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/model/anthropic.test.ts
+++ b/src/model/anthropic.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn(),
+}));
+
+import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicClient } from "./anthropic.js";
+
+describe("AnthropicClient error handling", () => {
+  let mockStream: ReturnType<typeof vi.fn>;
+  let client: AnthropicClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockStream = vi.fn();
+    vi.mocked(Anthropic).mockImplementation(
+      () =>
+        ({
+          messages: { stream: mockStream },
+        }) as unknown as InstanceType<typeof Anthropic>,
+    );
+    client = new AnthropicClient("fake-key", "claude-sonnet-4-6");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("wraps a thrown string in an Error", async () => {
+    mockStream.mockImplementation(() => {
+      throw "string error";
+    });
+    const err = await client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("string error");
+    expect(mockStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps a thrown number in an Error", async () => {
+    mockStream.mockImplementation(() => {
+      throw 42;
+    });
+    const err = await client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("42");
+    expect(mockStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 500 and throws after max retries", async () => {
+    mockStream.mockImplementation(() => {
+      throw new Error("internal server error 500");
+    });
+    const errPromise = client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("500");
+    expect(mockStream).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on 502 and throws after max retries", async () => {
+    mockStream.mockImplementation(() => {
+      throw new Error("bad gateway 502");
+    });
+    const errPromise = client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("502");
+    expect(mockStream).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on 429 and throws after max retries", async () => {
+    mockStream.mockImplementation(() => {
+      throw new Error("rate limited 429");
+    });
+    const errPromise = client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("429");
+    expect(mockStream).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on overloaded and throws after max retries", async () => {
+    mockStream.mockImplementation(() => {
+      throw new Error("service overloaded");
+    });
+    const errPromise = client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("overloaded");
+    expect(mockStream).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on non-retryable errors", async () => {
+    mockStream.mockImplementation(() => {
+      throw new Error("400 bad request");
+    });
+    const err = await client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("400");
+    expect(mockStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/model/anthropic.ts
+++ b/src/model/anthropic.ts
@@ -63,11 +63,14 @@ export class AnthropicClient implements LLMClient {
         yield { type: "done" };
         return;
       } catch (err) {
-        lastError = err as Error;
+        lastError = err instanceof Error ? err : new Error(String(err));
+        const msg = lastError.message;
         const isRetryable =
-          lastError.message.includes("429") ||
-          lastError.message.includes("529") ||
-          lastError.message.includes("overloaded");
+          msg.includes("429") ||
+          msg.includes("500") ||
+          msg.includes("502") ||
+          msg.includes("529") ||
+          msg.includes("overloaded");
 
         if (!isRetryable || attempt === MAX_RETRIES - 1) throw lastError;
 

--- a/src/model/gemini.test.ts
+++ b/src/model/gemini.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: vi.fn(),
+}));
+
+import { GoogleGenAI } from "@google/genai";
+import { GeminiClient } from "./gemini.js";
+
+describe("GeminiClient error handling", () => {
+  let mockGenerateContentStream: ReturnType<typeof vi.fn>;
+  let client: GeminiClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGenerateContentStream = vi.fn();
+    vi.mocked(GoogleGenAI).mockImplementation(
+      () =>
+        ({
+          models: { generateContentStream: mockGenerateContentStream },
+        }) as unknown as InstanceType<typeof GoogleGenAI>,
+    );
+    client = new GeminiClient("fake-key");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("wraps a thrown string in an Error", async () => {
+    mockGenerateContentStream.mockImplementation(() => {
+      throw "string error";
+    });
+    const err = await client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("string error");
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps a thrown number in an Error", async () => {
+    mockGenerateContentStream.mockImplementation(() => {
+      throw 42;
+    });
+    const err = await client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("42");
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 500 and throws after max retries", async () => {
+    mockGenerateContentStream.mockImplementation(() => {
+      throw new Error("internal server error 500");
+    });
+    const errPromise = client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("500");
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on 502 and throws after max retries", async () => {
+    mockGenerateContentStream.mockImplementation(() => {
+      throw new Error("bad gateway 502");
+    });
+    const errPromise = client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("502");
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on 429 and throws after max retries", async () => {
+    mockGenerateContentStream.mockImplementation(() => {
+      throw new Error("rate limited 429");
+    });
+    const errPromise = client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("429");
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on non-retryable errors", async () => {
+    mockGenerateContentStream.mockImplementation(() => {
+      throw new Error("400 bad request");
+    });
+    const err = await client
+      .stream([], "sys", [])
+      .next()
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("400");
+    expect(mockGenerateContentStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/model/gemini.ts
+++ b/src/model/gemini.ts
@@ -58,11 +58,14 @@ export class GeminiClient implements LLMClient {
         yield { type: "done" };
         return;
       } catch (err) {
-        lastError = err as Error;
+        lastError = err instanceof Error ? err : new Error(String(err));
+        const msg = lastError.message;
         const isRetryable =
-          lastError.message.includes("429") ||
-          lastError.message.includes("503") ||
-          lastError.message.includes("RESOURCE_EXHAUSTED");
+          msg.includes("429") ||
+          msg.includes("500") ||
+          msg.includes("502") ||
+          msg.includes("503") ||
+          msg.includes("RESOURCE_EXHAUSTED");
 
         if (!isRetryable || attempt === MAX_RETRIES - 1) throw lastError;
 


### PR DESCRIPTION
## Summary

- Replaces the unsafe `err as Error` cast in both `GeminiClient` and `AnthropicClient` with `err instanceof Error ? err : new Error(String(err))`, so non-Error thrown values (strings, numbers, etc.) no longer cause a `TypeError` that masks the original error.
- Adds HTTP `500` and `502` to the retryable set in both clients — these are documented transient infrastructure codes that Google and Anthropic both return on spikes, matching the retry behaviour in Anthropic's own SDK.
- Adds `src/model/gemini.test.ts` and `src/model/anthropic.test.ts` to prevent regression on both fixes.

Closes #6, closes #11

## Test plan

- [ ] `npm run lint` — passes
- [ ] `npm run format:check` — passes
- [ ] `npm test` — all 180 tests pass, including 13 new tests covering non-Error wrapping, 500/502 retry, 429 retry, and non-retryable no-retry behaviour for both clients

https://claude.ai/code/session_01JzgV7S6biezjvtMG3qYbg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzgV7S6biezjvtMG3qYbg5)_