### PR TITLE
fix: persist thoughtSignature in JSONL for Gemini thinking model session resume

### DIFF
--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -9,7 +9,7 @@ import type { FunctionCallPart, Message } from "../model/types.js";
 
 export type AgentEvent =
   | { type: "text"; text: string }
-  | { type: "tool_call"; name: string; args: Record<string, unknown> }
+  | { type: "tool_call"; name: string; args: Record<string, unknown>; thoughtSignature?: string }
   | { type: "tool_result"; name: string; result: string }
   | { type: "skill_activated"; name: string }
   | { type: "error"; message: string }
@@ -130,7 +130,12 @@ export class Agent {
             args: event.args,
             thoughtSignature: event.thoughtSignature,
           });
-          yield { type: "tool_call", name: event.name, args: event.args };
+          yield {
+            type: "tool_call",
+            name: event.name,
+            args: event.args,
+            thoughtSignature: event.thoughtSignature,
+          };
         }
       }
 

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -180,7 +180,12 @@ export async function runAgentTurn(
             firstToken = false;
           }
           mdRenderer.flush();
-          void session.log({ type: "tool_call", name: event.name, args: event.args });
+          void session.log({
+            type: "tool_call",
+            name: event.name,
+            args: event.args,
+            thoughtSignature: event.thoughtSignature,
+          });
           if (COMPACT_TOOLS.has(event.name)) {
             printToolCallCompact(event.name, event.args);
           } else {

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -220,6 +220,74 @@ describe("Session.loadMessages", () => {
     expect(calls[0].id).not.toBe(calls[1].id);
   });
 
+  it("preserves thoughtSignature from tool_call through function_call and function_result parts", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Use a thinking model tool" });
+    await session.log({
+      type: "tool_call",
+      name: "bash",
+      args: { command: "ls" },
+      thoughtSignature: "sig-abc123",
+    });
+    await session.log({ type: "tool_result", name: "bash", result: "file.txt" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    expect(messages).toHaveLength(4);
+
+    const callPart = messages[1].parts[0] as { type: string; thoughtSignature?: string };
+    expect(callPart.type).toBe("function_call");
+    expect(callPart.thoughtSignature).toBe("sig-abc123");
+
+    const resultPart = messages[2].parts[0] as { type: string; thoughtSignature?: string };
+    expect(resultPart.type).toBe("function_result");
+    expect(resultPart.thoughtSignature).toBe("sig-abc123");
+  });
+
+  it("handles missing thoughtSignature gracefully (non-thinking models)", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Normal tool call" });
+    await session.log({ type: "tool_call", name: "bash", args: { command: "echo hi" } });
+    await session.log({ type: "tool_result", name: "bash", result: "hi" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    const callPart = messages[1].parts[0] as { type: string; thoughtSignature?: string };
+    expect(callPart.thoughtSignature).toBeUndefined();
+    const resultPart = messages[2].parts[0] as { type: string; thoughtSignature?: string };
+    expect(resultPart.thoughtSignature).toBeUndefined();
+  });
+
+  it("preserves thoughtSignature across parallel multi-call rounds", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Parallel calls" });
+    await session.log({
+      type: "tool_call",
+      name: "glob",
+      args: { pattern: "*.ts" },
+      thoughtSignature: "sig-1",
+    });
+    await session.log({
+      type: "tool_call",
+      name: "grep",
+      args: { pattern: "foo" },
+      thoughtSignature: "sig-2",
+    });
+    await session.log({ type: "tool_result", name: "glob", result: "a.ts" });
+    await session.log({ type: "tool_result", name: "grep", result: "a.ts:1" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    // messages[1] = model(2 calls), messages[2] = user(2 results)
+    const calls = messages[1].parts as Array<{ type: string; thoughtSignature?: string }>;
+    const results = messages[2].parts as Array<{ type: string; thoughtSignature?: string }>;
+
+    expect(calls[0].thoughtSignature).toBe("sig-1");
+    expect(calls[1].thoughtSignature).toBe("sig-2");
+    expect(results[0].thoughtSignature).toBe("sig-1");
+    expect(results[1].thoughtSignature).toBe("sig-2");
+  });
+
   it("ignores session_start and unknown entries", async () => {
     const session = await Session.create(CWD);
     await session.log({ type: "user", content: "Hi" });

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -78,10 +78,11 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
   // Pending batches accumulate until we know where they belong
   let pendingCalls: FunctionCallPart[] = [];
   let pendingResults: FunctionResultPart[] = [];
-  // Queue of call IDs waiting for their matching results; ensures each
-  // function_result references the same ID as its function_call (required by
-  // the Anthropic API, which validates tool_result.tool_use_id against prior tool_use blocks).
+  // Queue of call IDs (and their thoughtSignatures) waiting for their matching results;
+  // ensures each function_result references the same ID as its function_call (required by
+  // the Anthropic API) and echoes back thoughtSignature (required by Gemini thinking models).
   let pendingCallIds: string[] = [];
+  let pendingCallSignatures: (string | undefined)[] = [];
 
   function flushCalls(): void {
     if (pendingCalls.length === 0) return;
@@ -95,6 +96,7 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
     messages.push({ role: "user", parts: pendingResults });
     pendingResults = [];
     pendingCallIds = [];
+    pendingCallSignatures = [];
   }
 
   for (const entry of entries) {
@@ -107,22 +109,28 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
       // New tool_call batch: if there were results from a previous round, flush them first
       flushResults();
       const id = `resume-call-${++idCounter}`;
+      const thoughtSignature =
+        typeof entry.thoughtSignature === "string" ? entry.thoughtSignature : undefined;
       pendingCallIds.push(id);
+      pendingCallSignatures.push(thoughtSignature);
       pendingCalls.push({
         type: "function_call",
         id,
         name: String(entry.name ?? ""),
         args: (entry.args as Record<string, unknown>) ?? {},
+        thoughtSignature,
       });
     } else if (entry.type === "tool_result") {
       // Results follow their calls — flush the pending call batch into a model message
       flushCalls();
       const id = pendingCallIds.shift() ?? `resume-call-${++idCounter}`;
+      const resultSignature = pendingCallSignatures.shift();
       pendingResults.push({
         type: "function_result",
         id,
         name: String(entry.name ?? ""),
         result: String(entry.result ?? ""),
+        thoughtSignature: resultSignature,
       });
     } else if (entry.type === "assistant" && typeof entry.content === "string" && entry.content) {
       flushCalls();


### PR DESCRIPTION
## Summary

- Thread `thoughtSignature` through the `tool_call` AgentEvent so it is available at the logging boundary
- Log `thoughtSignature` in the `tool_call` JSONL entry (when present)
- Restore `thoughtSignature` on both `FunctionCallPart` and `FunctionResultPart` during session reconstruction, using a parallel signature queue alongside the existing call-ID queue
- Add 3 regression tests covering: signature roundtrip, graceful absence (non-thinking models), and parallel multi-call rounds

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 222/222 pass (3 new tests in `session.test.ts`)

Closes #13

https://claude.ai/code/session_01XySruXdWy4wbdgYH6ZMJVS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XySruXdWy4wbdgYH6ZMJVS)_