### PR TITLE
feat: single-keypress and arrow-key selection for /plan approval

### DIFF
--- a/src/cli/input.test.ts
+++ b/src/cli/input.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { insertAtCursor, deleteBeforeCursor, deleteWordBeforeCursor } from "./input.js";
+import {
+  insertAtCursor,
+  deleteBeforeCursor,
+  deleteWordBeforeCursor,
+  renderSelectOptions,
+} from "./input.js";
 
 describe("insertAtCursor", () => {
   it("appends when cursor is at end", () => {
@@ -74,5 +79,51 @@ describe("deleteWordBeforeCursor", () => {
   it("deletes a middle word when cursor is mid-string", () => {
     const result = deleteWordBeforeCursor("foo bar baz", 7);
     expect(result).toEqual({ input: "foo  baz", cursorPos: 4 });
+  });
+});
+
+describe("renderSelectOptions", () => {
+  const opts = [
+    { key: "a", label: "Approve" },
+    { key: "e", label: "Edit" },
+    { key: "c", label: "Cancel" },
+  ];
+
+  it("contains the arrow marker only for the selected item", () => {
+    const out = renderSelectOptions(opts, 1);
+    const lines = out.split("\n").filter(Boolean);
+    // strip ANSI codes for assertions
+    // eslint-disable-next-line no-control-regex
+    const plain = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+    expect(plain[0]).not.toContain("›");
+    expect(plain[1]).toContain("›");
+    expect(plain[2]).not.toContain("›");
+  });
+
+  it("includes every option label and key", () => {
+    const out = renderSelectOptions(opts, 0);
+    // eslint-disable-next-line no-control-regex
+    const plain = out.replace(/\x1b\[[0-9;]*m/g, "");
+    expect(plain).toContain("Approve");
+    expect(plain).toContain("[a]");
+    expect(plain).toContain("Edit");
+    expect(plain).toContain("[e]");
+    expect(plain).toContain("Cancel");
+    expect(plain).toContain("[c]");
+  });
+
+  it("produces exactly one line per option", () => {
+    const out = renderSelectOptions(opts, 0);
+    const lines = out.split("\n").filter(Boolean);
+    expect(lines).toHaveLength(3);
+  });
+
+  it("keeps selection within bounds at first and last index", () => {
+    const first = renderSelectOptions(opts, 0);
+    const last = renderSelectOptions(opts, opts.length - 1);
+    // eslint-disable-next-line no-control-regex
+    const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+    expect(strip(first).split("\n")[0]).toContain("›");
+    expect(strip(last).split("\n")[2]).toContain("›");
   });
 });

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -136,6 +136,107 @@ function renderPopup(matches: SlashCommand[], selectedIdx: number): string {
   return out;
 }
 
+// ── Select widget ─────────────────────────────────────────────────────────────
+
+export interface SelectOption {
+  key: string;
+  label: string;
+}
+
+export function renderSelectOptions(options: SelectOption[], selectedIdx: number): string {
+  let out = "";
+  for (let i = 0; i < options.length; i++) {
+    const { key, label } = options[i];
+    const line = `  ${i === selectedIdx ? "›" : " "} ${label}  [${key}]`;
+    out += (i === selectedIdx ? chalk.bold(line) : chalk.dim(line)) + "\n";
+  }
+  return out;
+}
+
+/**
+ * Display a menu and return the key of the chosen option.
+ * - Pressing the option's single-character key selects immediately (no Enter).
+ * - Up / Down arrows navigate; Enter confirms the highlighted item.
+ * - Ctrl+C exits the process; returns null if the process should continue.
+ */
+export async function selectKey(prompt: string, options: SelectOption[]): Promise<string | null> {
+  emitKeypressEvents(stdin);
+  stdin.ref();
+  if (stdin.isTTY) stdin.setRawMode(true);
+
+  // prompt line + blank line + one line per option
+  const LINES = 2 + options.length;
+
+  return new Promise((resolve) => {
+    let selectedIdx = 0;
+    let rendered = false;
+
+    const render = () => {
+      let out = "";
+      if (rendered) {
+        out += A.up(LINES) + A.clearDown;
+      }
+      rendered = true;
+      out += chalk.cyan("  " + prompt) + "\n";
+      out += "\n";
+      out += renderSelectOptions(options, selectedIdx);
+      stdout.write(out);
+    };
+
+    const done = (result: string | null) => {
+      stdout.write(A.up(LINES) + A.clearDown);
+      if (stdin.isTTY) stdin.setRawMode(false);
+      stdin.removeListener("keypress", onKey);
+      stdin.unref();
+      resolve(result);
+    };
+
+    const onKey = (
+      _str: string,
+      key: { name: string; ctrl: boolean; meta: boolean; sequence: string },
+    ) => {
+      if (!key) return;
+
+      if (key.ctrl && key.name === "c") {
+        stdout.write("\n");
+        if (stdin.isTTY) stdin.setRawMode(false);
+        stdin.removeListener("keypress", onKey);
+        process.exit(0);
+      }
+
+      if (key.name === "return" || key.name === "enter") {
+        done(options[selectedIdx].key);
+        return;
+      }
+
+      if (key.name === "up") {
+        selectedIdx = Math.max(0, selectedIdx - 1);
+        render();
+        return;
+      }
+
+      if (key.name === "down") {
+        selectedIdx = Math.min(options.length - 1, selectedIdx + 1);
+        render();
+        return;
+      }
+
+      // Single-keypress shortcut — match against option keys
+      if (key.sequence && !key.ctrl && !key.meta) {
+        const pressed = key.sequence.toLowerCase();
+        const match = options.findIndex((o) => o.key.toLowerCase() === pressed);
+        if (match >= 0) {
+          done(options[match].key);
+          return;
+        }
+      }
+    };
+
+    stdin.on("keypress", onKey);
+    render();
+  });
+}
+
 // ── Main readLine ─────────────────────────────────────────────────────────────
 
 /**

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -6,7 +6,7 @@ import type { Agent, AgentRunMode } from "../agent/core.js";
 import type { SkillRegistry } from "../skills/registry.js";
 import { loadSkillFile, processBody } from "../skills/loader.js";
 import { join } from "node:path";
-import { readLine, loadHistory, saveHistory, type SlashCommand } from "./input.js";
+import { readLine, selectKey, loadHistory, saveHistory, type SlashCommand } from "./input.js";
 import { Session } from "../state/session.js";
 import {
   COMPACT_TOOLS,
@@ -93,7 +93,7 @@ export async function runRepl(
       const planText = await runAgentTurn(agent, session, planPrompt, "plan");
       if (!planText.trim()) continue;
 
-      const decision = await promptPlanApproval(history, allCommands);
+      const decision = await promptPlanApproval();
       if (decision === "cancel") {
         printInfo("Plan cancelled.");
         continue;
@@ -246,29 +246,15 @@ export async function runAgentTurn(
   return fullText;
 }
 
-async function promptPlanApproval(
-  history: string[],
-  commands: SlashCommand[],
-): Promise<"approve" | "edit" | "cancel"> {
-  process.stderr.write(
-    chalk.cyan("\n  Plan ready — what next?\n\n") +
-      chalk.bold("  [a]") +
-      "  Approve & execute\n" +
-      chalk.bold("  [e]") +
-      "  Edit in $EDITOR first\n" +
-      chalk.bold("  [c]") +
-      "  Cancel\n\n",
-  );
-  const raw = await readLine(history, commands);
-  if (raw === null) return "cancel";
-  switch (raw.trim().toLowerCase()[0]) {
-    case "a":
-      return "approve";
-    case "e":
-      return "edit";
-    default:
-      return "cancel";
-  }
+async function promptPlanApproval(): Promise<"approve" | "edit" | "cancel"> {
+  const choice = await selectKey("Plan ready — what next?", [
+    { key: "a", label: "Approve & execute" },
+    { key: "e", label: "Edit in $EDITOR first" },
+    { key: "c", label: "Cancel" },
+  ]);
+  if (choice === "a") return "approve";
+  if (choice === "e") return "edit";
+  return "cancel";
 }
 
 async function editPlanInEditor(plan: string): Promise<string | null> {


### PR DESCRIPTION
## Summary

- Adds `selectKey(prompt, options)` to `src/cli/input.ts` — a lightweight interactive menu that reuses the existing raw-mode keypress infrastructure already driving the slash-command popup.
- Pressing `a`, `e`, or `c` selects the corresponding plan-approval action immediately without requiring Enter.
- Up/Down arrows visually highlight options; Enter confirms the selection.
- Ctrl+C exits cleanly (same behaviour as `readLine`).
- Rewrites `promptPlanApproval()` in `src/cli/repl.ts` to use `selectKey`, removing the old `readLine`-based letter-then-Enter flow and its now-unnecessary `history`/`commands` parameters.
- Exports `renderSelectOptions` as a pure helper and adds 4 unit tests covering arrow placement, label/key inclusion, line count, and boundary selections.

## Test plan

- [ ] All 274 existing tests pass (`npm test`)
- [ ] Lint and format checks pass (`npm run lint && npm run format:check`)
- [ ] `/plan <task>` in the REPL shows the interactive menu; pressing `a`/`e`/`c` without Enter selects immediately
- [ ] Up/Down arrows move the highlight; Enter confirms
- [ ] Ctrl+C during the menu exits cleanly

Closes #35

https://claude.ai/code/session_01J66YGXJgXt5EhLPpHeQfuu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J66YGXJgXt5EhLPpHeQfuu)_