### PR TITLE
feat: add /new-skill built-in to scaffold custom skills interactively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ src/
   skills/
     registry.ts     # Discover SKILL.md files across 4 scoped directories
     loader.ts       # Parse SKILL.md frontmatter, !{cmd} preprocessing, $ARGUMENTS substitution
-    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint
+    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill
   state/
     config.ts       # ~/.opencli/config.json load/save; exports AGENT_DIR, Config (incl. anthropicApiKey)
     session.ts      # JSONL session logs at ~/.opencli/projects/<cwd>/; create, list, resume

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ src/
   skills/
     registry.ts     # Discover SKILL.md files across 4 scoped directories
     loader.ts       # Parse SKILL.md frontmatter, !{cmd} preprocessing, $ARGUMENTS substitution
-    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint
+    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill
   state/
     config.ts       # ~/.opencli/config.json load/save; exports AGENT_DIR, Config (incl. anthropicApiKey)
     session.ts      # JSONL session logs at ~/.opencli/projects/<cwd>/; create, list, resume

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -334,6 +334,9 @@ _Comprehension_
 - `/explain` — Explain selected code or a concept
 - `/test` — Write tests for a given function or module
 
+_Skill authoring_
+- `/new-skill` — Scaffold a new custom SKILL.md interactively (user-only)
+
 **Key Files:**
 ```
 src/skills/
@@ -350,7 +353,8 @@ src/skills/
       ├── typecheck/
       ├── lint/
       ├── explain/
-      └── test/
+      ├── test/
+      └── new-skill/
 ```
 
 > See [`docs/skills.md`](skills.md) for the full authoring guide (format, preprocessors, custom skills).

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -96,6 +96,7 @@ At session start, `SkillRegistry.discover()` is called and the catalog (name + d
 | `/lint` | Run linter, auto-fix what's fixable, report the rest | No |
 | `/explain` | Explain code or a concept | No |
 | `/test` | Write tests for a function or module | No |
+| `/new-skill` | Scaffold a new custom SKILL.md file interactively | Yes |
 
 ---
 

--- a/src/skills/builtin/new-skill/SKILL.md
+++ b/src/skills/builtin/new-skill/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: new-skill
+description: Scaffold a new custom SKILL.md file interactively. Use when asked to create a new skill or slash command.
+allowed-tools: Write
+disable-agent-invocation: true
+---
+
+Create a new custom skill for this project.
+
+What to build: $ARGUMENTS
+
+## Steps
+
+1. **Gather requirements** — If `$ARGUMENTS` is empty, ask the user:
+   - What should the skill do?
+   - What slash command name should invoke it (short, kebab-case, e.g. `deploy`, `summarise-pr`)?
+   - Should only the user be able to invoke it, or can the model also self-activate it?
+
+2. **Design the skill**:
+   - **name**: short kebab-case identifier matching the slash command
+   - **description**: one precise, verb-led sentence (e.g. "Run …", "Generate …", "Analyse …") — the model uses this for auto-activation, so specificity matters
+   - **allowed-tools**: space-separated, limited to what the skill genuinely needs (`Read`, `Write`, `Edit`, `Glob`, `Grep`, `Bash`)
+   - **disable-agent-invocation**: set `true` for side-effectful or destructive skills (deploy, commit, send messages); omit for general-purpose skills
+   - **Body**: numbered step-by-step instructions the model follows; reference `$ARGUMENTS` for the user-supplied target
+   - **Preprocessors**: add `!{cmd || echo "fallback"}` only when useful context should be captured at activation time (e.g. current git branch, project config); always include a fallback
+
+3. **Show the complete draft SKILL.md** to the user and ask for approval or edits before writing anything.
+
+4. **Write the file** to `.opencli/skills/<name>/SKILL.md` using the `write` tool — it will prompt for confirmation before touching the filesystem.
+
+5. **Confirm success**:
+   - Report the exact path written
+   - Remind the user the skill is discoverable after restarting the session (invoke with `/<name> [args]`)
+
+## SKILL.md format reference
+
+```yaml
+---
+name: <kebab-case-name>
+description: <one sentence — verb-led, specific enough for auto-activation>
+allowed-tools: <space-separated: Read Write Edit Glob Grep Bash>
+# disable-agent-invocation: true   # uncomment for user-only or dangerous skills
+---
+
+<Step-by-step instructions. Use $ARGUMENTS for the user's input.>
+<Optional: !{cmd || echo "fallback"} for context injected at activation time.>
+```
+
+Skills land in `.opencli/skills/<name>/SKILL.md` (project-scoped, highest priority).
+They override same-named built-ins and are discovered at the next session start.


### PR DESCRIPTION
## Summary

- Adds `src/skills/builtin/new-skill/SKILL.md` — a built-in skill that guides the user through creating a project-scoped custom skill interactively
- The skill collects requirements (name, purpose, user-only vs auto-activatable), drafts a complete `SKILL.md`, shows it for approval, then writes it to `.opencli/skills/<name>/SKILL.md` via the `write` tool (HITL confirmation fires before any filesystem change)
- Updates `docs/skills.md`, `docs/architecture.md`, `CLAUDE.md`, and `AGENTS.md` to register the new built-in per the documented update protocol

## Test plan

- [ ] All 306 existing tests pass (`npm test`)
- [ ] `npm run lint` passes
- [ ] `npm run format:check` passes
- [ ] `/new-skill` appears in the skill catalog at session start
- [ ] Running `/new-skill` with no args prompts the user for requirements before drafting
- [ ] Running `/new-skill deploy to staging` produces a complete draft `SKILL.md` and writes it after confirmation
- [ ] Generated skill is discoverable in the next session via `/<name>`

Closes #41

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjQbv6veA3MZ3Hwyx8WTqb)_