### PR TITLE
fix: track activated skills by name Set to prevent false-positive hasSkill()

### DIFF
--- a/src/agent/context.test.ts
+++ b/src/agent/context.test.ts
@@ -141,6 +141,14 @@ describe("ContextManager", () => {
     expect(ctx.hasSkill("debug")).toBe(false);
   });
 
+  it("hasSkill does not false-positive when skill body contains name= substring", () => {
+    const ctx = new ContextManager(STUB);
+    // Body text contains the substring that the old implementation searched for
+    ctx.addSkillContent("xml-guide", 'Use name="foo" to reference skill foo.');
+    expect(ctx.hasSkill("foo")).toBe(false);
+    expect(ctx.hasSkill("xml-guide")).toBe(true);
+  });
+
   it("wraps skill content in skill_content tags", () => {
     const ctx = new ContextManager(STUB);
     ctx.addSkillContent("test", "Test instructions.");

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SYSTEM_INSTRUCTION, getGitContext, renderSystemInstruction } fr
 export class ContextManager {
   private history: Message[] = [];
   private skillContent: string[] = []; // activated skill bodies, never pruned
+  private activatedSkills = new Set<string>();
   private maxHistoryMessages: number;
   private sessionTmpDir: string | undefined = undefined;
   private cachedSystemInstruction: string | null = null;
@@ -57,12 +58,13 @@ export class ContextManager {
   }
 
   addSkillContent(name: string, body: string): void {
+    this.activatedSkills.add(name);
     const tagged = `<skill_content name="${name}">\n${body}\n</skill_content>`;
     this.skillContent.push(tagged);
   }
 
   hasSkill(name: string): boolean {
-    return this.skillContent.some((s) => s.includes(`name="${name}"`));
+    return this.activatedSkills.has(name);
   }
 
   getMessages(): Message[] {
@@ -84,6 +86,7 @@ export class ContextManager {
   clear(): void {
     this.history = [];
     this.skillContent = [];
+    this.activatedSkills.clear();
     this.cachedSystemInstruction = null;
     this.cachedToolSignature = null;
   }


### PR DESCRIPTION
## Summary

- Adds `activatedSkills: Set<string>` to `ContextManager` to track which skill names have been activated
- `addSkillContent()` now populates this Set alongside the existing `skillContent` array
- `hasSkill()` uses `Set.has()` instead of scanning serialized XML strings for `name="foo"` substrings
- `clear()` resets the Set alongside the other state

## Why

The old `hasSkill()` searched the serialized `<skill_content name="...">` XML string for the substring `name="foo"`. Any skill whose **body text** contained `name="foo"` (e.g. a skill that teaches XML syntax or documents another skill) would cause a false-positive: `hasSkill("foo")` returned `true` even though `foo` was never activated. This silently prevented the real `foo` skill from ever being injected.

## Test plan

- [ ] Existing tests pass (`npm test` — 307 tests, all green)
- [ ] New regression test: `hasSkill does not false-positive when skill body contains name= substring`

Closes #45

https://claude.ai/code/session_014RmBCCfvJQAVQaCeYKW918

---
_Generated by [Claude Code](https://claude.ai/code/session_014RmBCCfvJQAVQaCeYKW918)_