### PR TITLE
Fix session ID and encodeProjectPath collisions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1489,6 +1489,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1829,6 +1830,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2480,6 +2482,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2543,6 +2546,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3253,6 +3257,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3499,6 +3504,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3922,6 +3928,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3971,6 +3978,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4714,6 +4722,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4759,6 +4768,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4829,6 +4839,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4927,6 +4938,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -5199,6 +5211,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -21,7 +21,7 @@ const CWD = "/test/project";
 describe("Session.create", () => {
   it("returns a session with a timestamp-format id", async () => {
     const session = await Session.create(CWD);
-    expect(session.id).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$/);
+    expect(session.id).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}$/);
   });
 
   it("sets cwd correctly", async () => {
@@ -311,7 +311,7 @@ describe("Session.loadMessages — malformed JSONL resilience", () => {
     const { AGENT_DIR } = await import("./config.js");
     const { join } = await import("node:path");
 
-    const projectDir = join(AGENT_DIR, "projects", CWD.replace(/\//g, "-"));
+    const projectDir = join(AGENT_DIR, "projects", encodeURIComponent(CWD).replace(/%2F/gi, "~"));
     await mkdir(projectDir, { recursive: true });
     const id = "2025-01-01T00-00-00";
     const logPath = join(projectDir, `${id}.jsonl`);
@@ -341,7 +341,7 @@ describe("Session.loadMessages — malformed JSONL resilience", () => {
     const { AGENT_DIR } = await import("./config.js");
     const { join } = await import("node:path");
 
-    const projectDir = join(AGENT_DIR, "projects", CWD.replace(/\//g, "-"));
+    const projectDir = join(AGENT_DIR, "projects", encodeURIComponent(CWD).replace(/%2F/gi, "~"));
     await mkdir(projectDir, { recursive: true });
     const id = "2025-01-01T00-00-01";
     const logPath = join(projectDir, `${id}.jsonl`);

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -311,7 +311,7 @@ describe("Session.loadMessages — malformed JSONL resilience", () => {
     const { AGENT_DIR } = await import("./config.js");
     const { join } = await import("node:path");
 
-    const projectDir = join(AGENT_DIR, "projects", encodeURIComponent(CWD).replace(/%2F/gi, "~"));
+    const projectDir = join(AGENT_DIR, "projects", Buffer.from(CWD).toString("base64url"));
     await mkdir(projectDir, { recursive: true });
     const id = "2025-01-01T00-00-00";
     const logPath = join(projectDir, `${id}.jsonl`);
@@ -341,7 +341,7 @@ describe("Session.loadMessages — malformed JSONL resilience", () => {
     const { AGENT_DIR } = await import("./config.js");
     const { join } = await import("node:path");
 
-    const projectDir = join(AGENT_DIR, "projects", encodeURIComponent(CWD).replace(/%2F/gi, "~"));
+    const projectDir = join(AGENT_DIR, "projects", Buffer.from(CWD).toString("base64url"));
     await mkdir(projectDir, { recursive: true });
     const id = "2025-01-01T00-00-01";
     const logPath = join(projectDir, `${id}.jsonl`);
@@ -350,5 +350,56 @@ describe("Session.loadMessages — malformed JSONL resilience", () => {
 
     const { messages } = await Session.loadMessages(id, CWD);
     expect(messages).toHaveLength(0);
+  });
+});
+
+describe("Session migration", () => {
+  it("renames old directory to new directory if new does not exist", async () => {
+    const { mkdir, writeFile, stat } = await import("node:fs/promises");
+    const { AGENT_DIR } = await import("./config.js");
+    const { join } = await import("node:path");
+
+    const oldDir = join(AGENT_DIR, "projects", CWD.replace(/\//g, "-"));
+    const newDir = join(AGENT_DIR, "projects", Buffer.from(CWD).toString("base64url"));
+
+    await mkdir(oldDir, { recursive: true });
+    await writeFile(join(oldDir, "old-session.jsonl"), "{}", "utf8");
+
+    // Creating a session triggers the migration
+    await Session.create(CWD);
+
+    // Old dir should be gone
+    await expect(stat(oldDir)).rejects.toThrow();
+
+    // New dir should exist
+    const stats = await stat(newDir);
+    expect(stats.isDirectory()).toBe(true);
+  });
+
+  it("merges old directory into new directory if both exist", async () => {
+    const { mkdir, writeFile, stat, readdir } = await import("node:fs/promises");
+    const { AGENT_DIR } = await import("./config.js");
+    const { join } = await import("node:path");
+
+    const oldDir = join(AGENT_DIR, "projects", CWD.replace(/\//g, "-"));
+    const newDir = join(AGENT_DIR, "projects", Buffer.from(CWD).toString("base64url"));
+
+    await mkdir(oldDir, { recursive: true });
+    await writeFile(join(oldDir, "old-session.jsonl"), "{}", "utf8");
+
+    await mkdir(newDir, { recursive: true });
+    await writeFile(join(newDir, "new-session.jsonl"), "{}", "utf8");
+
+    // Creating a session triggers the migration
+    await Session.create(CWD);
+
+    // Old dir should still exist (we only move files, not the dir itself)
+    const oldStats = await stat(oldDir);
+    expect(oldStats.isDirectory()).toBe(true);
+
+    // New dir should contain both
+    const files = await readdir(newDir);
+    expect(files).toContain("old-session.jsonl");
+    expect(files).toContain("new-session.jsonl");
   });
 });

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -5,10 +5,10 @@
  *   ~/.opencli/projects/<encoded-cwd>/<session-id>.jsonl
  *
  * Sessions are never written to the project directory itself, keeping the
- * workspace clean. The project path is encoded by replacing "/" with "-".
+ * workspace clean. The project path is encoded using base64url to prevent collisions.
  *
- * Session ID: YYYY-MM-DDTHH-mm-ss — human-readable, lexicographically sortable,
- * no collision risk (users can't start two sessions in the same second).
+ * Session ID: YYYY-MM-DDTHH-mm-ss-SSS — human-readable, lexicographically sortable,
+ * millisecond precision to prevent collisions.
  */
 
 import { mkdir, appendFile, readdir, readFile, stat, rename } from "node:fs/promises";
@@ -19,7 +19,7 @@ import { AGENT_DIR } from "./config.js";
 import type { FunctionCallPart, FunctionResultPart, Message } from "../providers/types.js";
 
 function encodeProjectPath(cwd: string): string {
-  return encodeURIComponent(cwd).replace(/%2F/gi, "~");
+  return Buffer.from(cwd).toString("base64url");
 }
 
 function makeSessionId(): string {
@@ -34,11 +34,33 @@ async function sessionProjectDir(cwd: string): Promise<string> {
     try {
       const oldStats = await stat(oldDir);
       if (oldStats.isDirectory()) {
+        let newExists = false;
         try {
           await stat(newDir);
+          newExists = true;
         } catch {
+          // newDir doesn't exist
+        }
+
+        if (!newExists) {
           // Rename old to new if new doesn't exist
           await rename(oldDir, newDir);
+        } else {
+          // Merge: move each old session file into the new dir
+          try {
+            const files = await readdir(oldDir);
+            await Promise.all(
+              files
+                .filter((f) => f.endsWith(".jsonl"))
+                .map((f) =>
+                  rename(join(oldDir, f), join(newDir, f)).catch(() => {
+                    /* ignore rename errors */
+                  }),
+                ),
+            );
+          } catch {
+            /* ignore read errors */
+          }
         }
       }
     } catch {

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -11,7 +11,7 @@
  * no collision risk (users can't start two sessions in the same second).
  */
 
-import { mkdir, appendFile, readdir, readFile } from "node:fs/promises";
+import { mkdir, appendFile, readdir, readFile, stat, rename } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { join } from "node:path";
@@ -19,15 +19,33 @@ import { AGENT_DIR } from "./config.js";
 import type { FunctionCallPart, FunctionResultPart, Message } from "../providers/types.js";
 
 function encodeProjectPath(cwd: string): string {
-  return cwd.replace(/\//g, "-");
+  return encodeURIComponent(cwd).replace(/%2F/gi, "~");
 }
 
 function makeSessionId(): string {
-  return new Date().toISOString().slice(0, 19).replace(/:/g, "-");
+  return new Date().toISOString().slice(0, 23).replace(/[:.]/g, "-");
 }
 
-function sessionProjectDir(cwd: string): string {
-  return join(AGENT_DIR, "projects", encodeProjectPath(cwd));
+async function sessionProjectDir(cwd: string): Promise<string> {
+  const newDir = join(AGENT_DIR, "projects", encodeProjectPath(cwd));
+  const oldDir = join(AGENT_DIR, "projects", cwd.replace(/\//g, "-"));
+
+  if (newDir !== oldDir) {
+    try {
+      const oldStats = await stat(oldDir);
+      if (oldStats.isDirectory()) {
+        try {
+          await stat(newDir);
+        } catch {
+          // Rename old to new if new doesn't exist
+          await rename(oldDir, newDir);
+        }
+      }
+    } catch {
+      // Old directory doesn't exist, no migration needed
+    }
+  }
+  return newDir;
 }
 
 /** List JSONL session files for a project dir, newest first. Returns [] on ENOENT. */
@@ -175,7 +193,7 @@ export class Session {
 
   static async create(cwd: string = process.cwd()): Promise<Session> {
     const id = makeSessionId();
-    const dir = sessionProjectDir(cwd);
+    const dir = await sessionProjectDir(cwd);
     await mkdir(dir, { recursive: true });
     const logPath = join(dir, `${id}.jsonl`);
     const session = new Session(id, cwd, logPath);
@@ -188,7 +206,7 @@ export class Session {
    * Returns up to `limit` entries with the first user message as a preview.
    */
   static async list(cwd: string = process.cwd(), limit = 20): Promise<SessionSummary[]> {
-    const dir = sessionProjectDir(cwd);
+    const dir = await sessionProjectDir(cwd);
     const files = (await listSessionFiles(dir)).slice(0, limit);
     return Promise.all(
       files.map(async (file) => ({
@@ -206,7 +224,7 @@ export class Session {
     id: string,
     cwd: string = process.cwd(),
   ): Promise<{ session: Session; messages: Message[] }> {
-    const dir = sessionProjectDir(cwd);
+    const dir = await sessionProjectDir(cwd);
 
     let sessionId = id;
     if (id === "latest") {


### PR DESCRIPTION
This PR fixes issue #44 and #46 regarding session and project path collisions.

- Session IDs now have millisecond precision.
- Project paths are URL-encoded to avoid collisions with hyphens.
- A seamless migration script is included to move old directories to the new format if they exist.

Co-authored-by: Antigravity <antigravity@google.com>