### PR TITLE
feat(observability): structured event channel for metrics and future OTel/eval

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { loadSystemInstruction } from "../core/prompt.js";
 import { resolveApiKey } from "./keys.js";
 import { runRepl, createConfirmFn } from "./repl.js";
 import { printError, printInfo } from "./renderer.js";
+import type { ObservabilityEvent } from "../core/observability.js";
 
 const program = new Command();
 
@@ -27,9 +28,10 @@ program
   .option("-r, --resume", "Resume the most recent session")
   .option("-s, --session <id>", "Resume a specific session by ID")
   .option("--max-turns <n>", "Maximum agent iterations per prompt (default: 50)", parseInt)
+  .option("--debug", "Emit structured observability events to stderr as JSON")
   .action(async (opts) => {
     const sessionId = opts.session ?? (opts.resume ? "latest" : undefined);
-    await startChat(opts.model, sessionId, opts.maxTurns);
+    await startChat(opts.model, sessionId, opts.maxTurns, opts.debug as boolean | undefined);
   });
 
 program
@@ -55,6 +57,7 @@ program
   .option("--max-turns <n>", "Maximum agent iterations (default: 50)", parseInt)
   .option("--plan", "Run a read-only planning pass first, then auto-execute the plan")
   .option("--yes", "Auto-approve all tool confirmations (skip interactive prompts)")
+  .option("--debug", "Emit structured observability events to stderr as JSON")
   .action(async (prompt: string, opts) => {
     await runSingle(
       prompt,
@@ -62,6 +65,7 @@ program
       opts.maxTurns,
       opts.plan as boolean | undefined,
       opts.yes as boolean | undefined,
+      opts.debug as boolean | undefined,
     );
   });
 
@@ -115,8 +119,9 @@ async function startChat(
   modelOverride?: string,
   resumeSessionId?: string,
   maxTurns?: number,
+  debug?: boolean,
 ): Promise<void> {
-  const { agent, skills } = await createAgent(modelOverride, maxTurns);
+  const { agent, skills } = await createAgent(modelOverride, maxTurns, debug);
   await runRepl(agent, skills, resumeSessionId);
 }
 
@@ -126,8 +131,9 @@ async function runSingle(
   maxTurns?: number,
   planMode?: boolean,
   autoApprove?: boolean,
+  debug?: boolean,
 ): Promise<void> {
-  const { agent } = await createAgent(modelOverride, maxTurns);
+  const { agent } = await createAgent(modelOverride, maxTurns, debug);
   if (autoApprove) {
     agent.setConfirmFn(async () => "allow");
   } else if (process.stdin.isTTY) {
@@ -162,7 +168,11 @@ async function runSingle(
   }
 }
 
-async function createAgent(modelOverride?: string, maxTurns?: number) {
+function makeDebugHandler(): (event: ObservabilityEvent) => void {
+  return (event) => process.stderr.write(JSON.stringify(event) + "\n");
+}
+
+async function createAgent(modelOverride?: string, maxTurns?: number, debug?: boolean) {
   const config = await loadConfig();
   const model = process.env.OPENCLI_MODEL ?? modelOverride ?? config.model;
 
@@ -174,6 +184,9 @@ async function createAgent(modelOverride?: string, maxTurns?: number) {
   await skills.discover();
 
   const systemInstruction = await loadSystemInstruction();
-  const agent = new Agent(client, tools, skills, systemInstruction, config.historySize, maxTurns);
+  const agent = new Agent(client, tools, skills, systemInstruction, config.historySize, maxTurns, {
+    model,
+    onObservability: debug ? makeDebugHandler() : undefined,
+  });
   return { agent, skills };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -178,7 +178,7 @@ async function createAgent(modelOverride?: string, maxTurns?: number, debug?: bo
 
   const provider = detectProvider(model);
   const apiKey = resolveApiKey(provider, config);
-  const client = createClient(model, apiKey);
+  const client = createClient(model, apiKey, { includeUsage: !!debug });
   const tools = createDefaultRegistry(model);
   const skills = new SkillRegistry();
   await skills.discover();

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -7,6 +7,7 @@ import { executeCalls } from "./executor.js";
 import type { ConfirmFn } from "./executor.js";
 import { buildReminder, buildPlanSuffix } from "./prompt.js";
 import type { FunctionCallPart, Message } from "../providers/types.js";
+import type { ObservabilityHandler } from "./observability.js";
 
 export type AgentEvent =
   | { type: "text"; text: string }
@@ -40,6 +41,8 @@ const PLAN_SYSTEM_SUFFIX = buildPlanSuffix(PLAN_MODE_TOOLS);
 export class Agent {
   private context: ContextManager;
   private confirmFn?: ConfirmFn;
+  private model: string;
+  private obs?: ObservabilityHandler;
 
   constructor(
     private client: LLMClient,
@@ -48,9 +51,12 @@ export class Agent {
     systemInstruction?: string,
     maxHistoryMessages?: number,
     private maxTurns: number = DEFAULT_MAX_TURNS,
+    options?: { model?: string; onObservability?: ObservabilityHandler },
   ) {
     this.context = new ContextManager(systemInstruction, maxHistoryMessages);
     this.context.setSkillCatalog(skills.catalogSummary());
+    this.model = options?.model ?? "";
+    this.obs = options?.onObservability;
   }
 
   setConfirmFn(fn: ConfirmFn): void {
@@ -93,11 +99,15 @@ export class Agent {
       const pendingCalls: FunctionCallPart[] = [];
       let responseText = "";
 
-      for await (const event of this.client.stream(
-        this.context.getMessages(),
-        systemInstruction,
-        toolDefinitions,
-      )) {
+      const messages = this.context.getMessages();
+      const estimatedTokens = Math.round(JSON.stringify(messages).length / 4);
+      this.obs?.({ type: "context_snapshot", messageCount: messages.length, estimatedTokens });
+      this.obs?.({ type: "llm_call_start", model: this.model, inputMessages: messages.length });
+      const callStart = Date.now();
+      let usageInputTokens = 0;
+      let usageOutputTokens = 0;
+
+      for await (const event of this.client.stream(messages, systemInstruction, toolDefinitions)) {
         if (event.type === "text") {
           responseText += event.text;
           yield { type: "text", text: event.text };
@@ -115,8 +125,19 @@ export class Agent {
             args: event.args,
             thoughtSignature: event.thoughtSignature,
           };
+        } else if (event.type === "usage") {
+          usageInputTokens = event.inputTokens;
+          usageOutputTokens = event.outputTokens;
         }
       }
+
+      this.obs?.({
+        type: "llm_call_end",
+        model: this.model,
+        inputTokens: usageInputTokens,
+        outputTokens: usageOutputTokens,
+        latencyMs: Date.now() - callStart,
+      });
 
       const assistantParts: Message["parts"] = [];
       if (responseText) assistantParts.push({ type: "text", text: responseText });
@@ -133,6 +154,11 @@ export class Agent {
       // Max turns guard
       turns++;
       if (turns > this.maxTurns) {
+        this.obs?.({
+          type: "guard_triggered",
+          guard: "max_turns",
+          reason: `Reached ${this.maxTurns} turns`,
+        });
         yield {
           type: "error",
           message: `Reached maximum iterations (${this.maxTurns}). Try breaking the task into smaller steps.`,
@@ -145,6 +171,11 @@ export class Agent {
       if (sig === lastCallSig) {
         stuckCount++;
         if (stuckCount >= STUCK_THRESHOLD) {
+          this.obs?.({
+            type: "guard_triggered",
+            guard: "stuck_loop",
+            reason: `${STUCK_THRESHOLD} identical consecutive call signatures`,
+          });
           yield {
             type: "error",
             message: `Detected ${STUCK_THRESHOLD} identical tool calls in a row — stopping to avoid a loop.`,
@@ -163,6 +194,7 @@ export class Agent {
         tmpDir: this.context.getSessionTmpDir(),
         readOnly: mode === "plan",
         confirmFn: this.confirmFn,
+        obs: this.obs,
       });
 
       // Append an event-driven reminder to the last tool result based on what

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -100,7 +100,9 @@ export class Agent {
       let responseText = "";
 
       const messages = this.context.getMessages();
-      const estimatedTokens = Math.round(JSON.stringify(messages).length / 4);
+      const estimatedTokens = Math.round(
+        (JSON.stringify(messages).length + systemInstruction.length) / 4,
+      );
       this.obs?.({ type: "context_snapshot", messageCount: messages.length, estimatedTokens });
       this.obs?.({ type: "llm_call_start", model: this.model, inputMessages: messages.length });
       const callStart = Date.now();

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -4,6 +4,7 @@ import type { FunctionCallPart, FunctionResultPart } from "../providers/types.js
 import type { ToolRegistry } from "../tools/registry.js";
 import type { SkillRegistry } from "../skills/registry.js";
 import type { ContextManager } from "./context.js";
+import type { ObservabilityHandler } from "./observability.js";
 
 // Tools whose output is truncated when it exceeds the limit.
 // read is excluded — it supports offset/limit pagination and agents rely on
@@ -28,6 +29,7 @@ export interface ExecutorDeps {
   tmpDir?: string;
   readOnly?: boolean;
   confirmFn?: ConfirmFn;
+  obs?: ObservabilityHandler;
 }
 
 export function truncateOutput(output: string, callId: string, tmpDir?: string): string {
@@ -66,6 +68,7 @@ async function executeOneCall(
   deps: ExecutorDeps,
 ): Promise<FunctionResultPart> {
   if (deps.readOnly && WRITE_TOOLS.has(call.name)) {
+    deps.obs?.({ type: "tool_denied", name: call.name, reason: "plan_mode" });
     return {
       type: "function_result",
       id: call.id,
@@ -81,6 +84,11 @@ async function executeOneCall(
       ? await deps.confirmFn(call.name, call.args as Record<string, unknown>)
       : "deny";
     if (decision === "deny") {
+      deps.obs?.({
+        type: "tool_denied",
+        name: call.name,
+        reason: deps.confirmFn ? "user_denied" : "non_interactive",
+      });
       return {
         type: "function_result",
         id: call.id,
@@ -93,9 +101,22 @@ async function executeOneCall(
     }
   }
 
+  deps.obs?.({
+    type: "tool_exec_start",
+    name: call.name,
+    args: call.args as Record<string, unknown>,
+  });
+  const execStart = Date.now();
   const result = await deps.tools.execute(call.name, call.args as Record<string, unknown>);
   const raw = result.error ? `Error: ${result.error}` : result.output || "(no output)";
   const output = TRUNCATE_TOOLS.has(call.name) ? truncateOutput(raw, call.id, deps.tmpDir) : raw;
+  deps.obs?.({
+    type: "tool_exec_end",
+    name: call.name,
+    latencyMs: Date.now() - execStart,
+    success: result.success,
+    outputBytes: output.length,
+  });
   return {
     type: "function_result",
     id: call.id,

--- a/src/core/observability.test.ts
+++ b/src/core/observability.test.ts
@@ -5,9 +5,8 @@ import { ToolRegistry } from "../tools/registry.js";
 import { SkillRegistry } from "../skills/registry.js";
 import { ContextManager } from "./context.js";
 import type { LLMClient } from "../providers/client.js";
-import type { Message, StreamEvent, ToolDefinition } from "../providers/types.js";
+import type { FunctionCallPart, Message, StreamEvent, ToolDefinition } from "../providers/types.js";
 import type { ObservabilityEvent } from "./observability.js";
-import type { FunctionCallPart } from "../providers/types.js";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 

--- a/src/core/observability.test.ts
+++ b/src/core/observability.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi } from "vitest";
+import { Agent } from "./agent.js";
+import { executeCalls } from "./executor.js";
+import { ToolRegistry } from "../tools/registry.js";
+import { SkillRegistry } from "../skills/registry.js";
+import { ContextManager } from "./context.js";
+import type { LLMClient } from "../providers/client.js";
+import type { Message, StreamEvent, ToolDefinition } from "../providers/types.js";
+import type { ObservabilityEvent } from "./observability.js";
+import type { FunctionCallPart } from "../providers/types.js";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeSkillRegistry(): SkillRegistry {
+  return {
+    load: vi.fn(async () => undefined),
+    has: vi.fn(() => false),
+    list: vi.fn(() => []),
+    get: vi.fn(),
+    discover: vi.fn(),
+    catalogSummary: vi.fn(() => ""),
+  } as unknown as SkillRegistry;
+}
+
+function makeClient(events: StreamEvent[]): LLMClient {
+  return {
+    async *stream(_messages: Message[], _sys: string, _tools: ToolDefinition[]) {
+      for (const e of events) yield e;
+    },
+  };
+}
+
+function makeLoopingClient(toolName = "noop"): LLMClient {
+  return {
+    async *stream(_messages: Message[], _sys: string, _tools: ToolDefinition[]) {
+      yield { type: "function_call", id: "c1", name: toolName, args: {} } as StreamEvent;
+      yield { type: "done" } as StreamEvent;
+    },
+  };
+}
+
+function makeNoopRegistry(): ToolRegistry {
+  const r = new ToolRegistry();
+  r.register({
+    name: "noop",
+    description: "",
+    parameters: { type: "object", properties: {} },
+    execute: async () => ({ success: true, output: "ok" }),
+  });
+  return r;
+}
+
+function makeToolCall(
+  name: string,
+  args: Record<string, unknown> = {},
+  id = "c1",
+): FunctionCallPart {
+  return { type: "function_call", id, name, args };
+}
+
+function makeAgent(client: LLMClient, tools: ToolRegistry, maxTurns = 50) {
+  const obsEvents: ObservabilityEvent[] = [];
+  const agent = new Agent(client, tools, makeSkillRegistry(), undefined, undefined, maxTurns, {
+    model: "test-model",
+    onObservability: (e) => obsEvents.push(e),
+  });
+  return { agent, obsEvents };
+}
+
+async function drain(agent: Agent, input = "go"): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of agent.run(input)) {
+    // consume the stream
+  }
+}
+
+// ── Agent observability ───────────────────────────────────────────────────────
+
+describe("Agent observability — LLM call events", () => {
+  it("emits context_snapshot and llm_call_start before the LLM call", async () => {
+    const { agent, obsEvents } = makeAgent(
+      makeClient([{ type: "text", text: "hi" }, { type: "done" }]),
+      new ToolRegistry(),
+    );
+
+    await drain(agent);
+
+    const types = obsEvents.map((e) => e.type);
+    expect(types[0]).toBe("context_snapshot");
+    expect(types[1]).toBe("llm_call_start");
+  });
+
+  it("emits llm_call_start with correct model name", async () => {
+    const { agent, obsEvents } = makeAgent(makeClient([{ type: "done" }]), new ToolRegistry());
+
+    await drain(agent);
+
+    const start = obsEvents.find((e) => e.type === "llm_call_start");
+    expect(start).toBeDefined();
+    expect((start as Extract<ObservabilityEvent, { type: "llm_call_start" }>).model).toBe(
+      "test-model",
+    );
+  });
+
+  it("emits llm_call_end with model, latency, and token counts", async () => {
+    const { agent, obsEvents } = makeAgent(
+      makeClient([{ type: "usage", inputTokens: 42, outputTokens: 7 }, { type: "done" }]),
+      new ToolRegistry(),
+    );
+
+    await drain(agent);
+
+    const end = obsEvents.find((e) => e.type === "llm_call_end") as Extract<
+      ObservabilityEvent,
+      { type: "llm_call_end" }
+    >;
+    expect(end).toBeDefined();
+    expect(end.model).toBe("test-model");
+    expect(end.inputTokens).toBe(42);
+    expect(end.outputTokens).toBe(7);
+    expect(end.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("emits llm_call_end with zero tokens when no usage event", async () => {
+    const { agent, obsEvents } = makeAgent(
+      makeClient([{ type: "text", text: "ok" }, { type: "done" }]),
+      new ToolRegistry(),
+    );
+
+    await drain(agent);
+
+    const end = obsEvents.find((e) => e.type === "llm_call_end") as Extract<
+      ObservabilityEvent,
+      { type: "llm_call_end" }
+    >;
+    expect(end.inputTokens).toBe(0);
+    expect(end.outputTokens).toBe(0);
+  });
+
+  it("emits one llm_call pair per agentic turn", async () => {
+    let turnCount = 0;
+    const client: LLMClient = {
+      async *stream(_messages, _sys, _tools) {
+        turnCount++;
+        if (turnCount < 3) {
+          yield {
+            type: "function_call",
+            id: `c${turnCount}`,
+            name: "noop",
+            args: {},
+          } as StreamEvent;
+        }
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+
+    const { agent, obsEvents } = makeAgent(client, makeNoopRegistry());
+    await drain(agent);
+
+    const starts = obsEvents.filter((e) => e.type === "llm_call_start");
+    const ends = obsEvents.filter((e) => e.type === "llm_call_end");
+    expect(starts).toHaveLength(3);
+    expect(ends).toHaveLength(3);
+  });
+});
+
+describe("Agent observability — safety guards", () => {
+  it("emits guard_triggered with guard='max_turns' when max turns exceeded", async () => {
+    const { agent, obsEvents } = makeAgent(makeLoopingClient(), makeNoopRegistry(), 2);
+
+    await drain(agent);
+
+    const guard = obsEvents.find((e) => e.type === "guard_triggered") as Extract<
+      ObservabilityEvent,
+      { type: "guard_triggered" }
+    >;
+    expect(guard).toBeDefined();
+    expect(guard.guard).toBe("max_turns");
+  });
+
+  it("emits guard_triggered with guard='stuck_loop' when identical calls repeat", async () => {
+    const { agent, obsEvents } = makeAgent(makeLoopingClient(), makeNoopRegistry(), 50);
+
+    await drain(agent);
+
+    const guard = obsEvents.find((e) => e.type === "guard_triggered") as Extract<
+      ObservabilityEvent,
+      { type: "guard_triggered" }
+    >;
+    expect(guard).toBeDefined();
+    expect(guard.guard).toBe("stuck_loop");
+  });
+});
+
+// ── Executor observability ────────────────────────────────────────────────────
+
+describe("Executor observability — tool execution", () => {
+  it("emits tool_exec_start before and tool_exec_end after a successful tool call", async () => {
+    const obsEvents: ObservabilityEvent[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "read",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "content" }),
+    });
+
+    await executeCalls([makeToolCall("read")], {
+      tools: registry,
+      skills: makeSkillRegistry(),
+      context: new ContextManager(),
+      obs: (e) => obsEvents.push(e),
+    });
+
+    const start = obsEvents.find((e) => e.type === "tool_exec_start") as Extract<
+      ObservabilityEvent,
+      { type: "tool_exec_start" }
+    >;
+    const end = obsEvents.find((e) => e.type === "tool_exec_end") as Extract<
+      ObservabilityEvent,
+      { type: "tool_exec_end" }
+    >;
+
+    expect(start).toBeDefined();
+    expect(start.name).toBe("read");
+
+    expect(end).toBeDefined();
+    expect(end.name).toBe("read");
+    expect(end.success).toBe(true);
+    expect(end.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(end.outputBytes).toBeGreaterThan(0);
+  });
+
+  it("emits tool_exec_end with success=false on tool error", async () => {
+    const obsEvents: ObservabilityEvent[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "broken",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: false, output: "", error: "disk full" }),
+    });
+
+    await executeCalls([makeToolCall("broken")], {
+      tools: registry,
+      skills: makeSkillRegistry(),
+      context: new ContextManager(),
+      obs: (e) => obsEvents.push(e),
+    });
+
+    const end = obsEvents.find((e) => e.type === "tool_exec_end") as Extract<
+      ObservabilityEvent,
+      { type: "tool_exec_end" }
+    >;
+    expect(end.success).toBe(false);
+  });
+
+  it("emits tool_exec_start with the correct args", async () => {
+    const obsEvents: ObservabilityEvent[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "read",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "" }),
+    });
+
+    await executeCalls([makeToolCall("read", { file_path: "/tmp/f.txt" })], {
+      tools: registry,
+      skills: makeSkillRegistry(),
+      context: new ContextManager(),
+      obs: (e) => obsEvents.push(e),
+    });
+
+    const start = obsEvents.find((e) => e.type === "tool_exec_start") as Extract<
+      ObservabilityEvent,
+      { type: "tool_exec_start" }
+    >;
+    expect(start.args).toEqual({ file_path: "/tmp/f.txt" });
+  });
+});
+
+describe("Executor observability — tool_denied", () => {
+  it("emits tool_denied with reason='plan_mode' when readOnly blocks a write tool", async () => {
+    const obsEvents: ObservabilityEvent[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "write",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "" }),
+    });
+
+    await executeCalls([makeToolCall("write")], {
+      tools: registry,
+      skills: makeSkillRegistry(),
+      context: new ContextManager(),
+      readOnly: true,
+      obs: (e) => obsEvents.push(e),
+    });
+
+    const denied = obsEvents.find((e) => e.type === "tool_denied") as Extract<
+      ObservabilityEvent,
+      { type: "tool_denied" }
+    >;
+    expect(denied).toBeDefined();
+    expect(denied.name).toBe("write");
+    expect(denied.reason).toBe("plan_mode");
+  });
+
+  it("emits tool_denied with reason='non_interactive' when no confirmFn and confirmation required", async () => {
+    const obsEvents: ObservabilityEvent[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "risky",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "" }),
+      requiresConfirmation: () => true,
+    });
+
+    await executeCalls([makeToolCall("risky")], {
+      tools: registry,
+      skills: makeSkillRegistry(),
+      context: new ContextManager(),
+      obs: (e) => obsEvents.push(e),
+    });
+
+    const denied = obsEvents.find((e) => e.type === "tool_denied") as Extract<
+      ObservabilityEvent,
+      { type: "tool_denied" }
+    >;
+    expect(denied).toBeDefined();
+    expect(denied.reason).toBe("non_interactive");
+  });
+
+  it("emits tool_denied with reason='user_denied' when confirmFn returns deny", async () => {
+    const obsEvents: ObservabilityEvent[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "risky",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "" }),
+      requiresConfirmation: () => true,
+    });
+
+    await executeCalls([makeToolCall("risky")], {
+      tools: registry,
+      skills: makeSkillRegistry(),
+      context: new ContextManager(),
+      confirmFn: async () => "deny",
+      obs: (e) => obsEvents.push(e),
+    });
+
+    const denied = obsEvents.find((e) => e.type === "tool_denied") as Extract<
+      ObservabilityEvent,
+      { type: "tool_denied" }
+    >;
+    expect(denied).toBeDefined();
+    expect(denied.reason).toBe("user_denied");
+  });
+
+  it("does not emit tool_denied when confirmFn returns allow", async () => {
+    const obsEvents: ObservabilityEvent[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "risky",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "ran" }),
+      requiresConfirmation: () => true,
+    });
+
+    await executeCalls([makeToolCall("risky")], {
+      tools: registry,
+      skills: makeSkillRegistry(),
+      context: new ContextManager(),
+      confirmFn: async () => "allow",
+      obs: (e) => obsEvents.push(e),
+    });
+
+    expect(obsEvents.some((e) => e.type === "tool_denied")).toBe(false);
+    const end = obsEvents.find((e) => e.type === "tool_exec_end") as Extract<
+      ObservabilityEvent,
+      { type: "tool_exec_end" }
+    >;
+    expect(end.success).toBe(true);
+  });
+});

--- a/src/core/observability.ts
+++ b/src/core/observability.ts
@@ -1,0 +1,30 @@
+export type ObservabilityEvent =
+  /** Emitted before each LLM streaming call. */
+  | { type: "llm_call_start"; model: string; inputMessages: number }
+  /** Emitted after the LLM stream completes. inputTokens/outputTokens are 0 if the
+   *  provider did not return usage data for this call. */
+  | {
+      type: "llm_call_end";
+      model: string;
+      inputTokens: number;
+      outputTokens: number;
+      latencyMs: number;
+    }
+  /** Rough token estimate before each LLM call (chars / 4 — for pressure monitoring). */
+  | { type: "context_snapshot"; messageCount: number; estimatedTokens: number }
+  /** Emitted before a tool's execute() is called. */
+  | { type: "tool_exec_start"; name: string; args: Record<string, unknown> }
+  /** Emitted after a tool's execute() returns. */
+  | {
+      type: "tool_exec_end";
+      name: string;
+      latencyMs: number;
+      success: boolean;
+      outputBytes: number;
+    }
+  /** Emitted when a tool call is blocked without execution. */
+  | { type: "tool_denied"; name: string; reason: "plan_mode" | "user_denied" | "non_interactive" }
+  /** Emitted when a safety guard aborts the loop (max-turns, stuck-loop). */
+  | { type: "guard_triggered"; guard: string; reason: string };
+
+export type ObservabilityHandler = (event: ObservabilityEvent) => void;

--- a/src/core/observability.ts
+++ b/src/core/observability.ts
@@ -25,6 +25,6 @@ export type ObservabilityEvent =
   /** Emitted when a tool call is blocked without execution. */
   | { type: "tool_denied"; name: string; reason: "plan_mode" | "user_denied" | "non_interactive" }
   /** Emitted when a safety guard aborts the loop (max-turns, stuck-loop). */
-  | { type: "guard_triggered"; guard: string; reason: string };
+  | { type: "guard_triggered"; guard: "max_turns" | "stuck_loop"; reason: string };
 
 export type ObservabilityHandler = (event: ObservabilityEvent) => void;

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -37,9 +37,18 @@ export class AnthropicClient implements LLMClient {
         let currentToolId = "";
         let currentToolName = "";
         let currentToolInput = "";
+        let inputTokens = 0;
+        let outputTokens = 0;
 
         for await (const event of apiStream) {
-          if (event.type === "content_block_start" && event.content_block.type === "tool_use") {
+          if (event.type === "message_start") {
+            inputTokens = event.message.usage.input_tokens;
+          } else if (event.type === "message_delta") {
+            outputTokens = event.usage.output_tokens;
+          } else if (
+            event.type === "content_block_start" &&
+            event.content_block.type === "tool_use"
+          ) {
             currentToolId = event.content_block.id;
             currentToolName = event.content_block.name;
             currentToolInput = "";
@@ -60,6 +69,9 @@ export class AnthropicClient implements LLMClient {
           }
         }
 
+        if (inputTokens > 0 || outputTokens > 0) {
+          yield { type: "usage", inputTokens, outputTokens };
+        }
         yield { type: "done" };
         return;
       } catch (err) {

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -29,9 +29,13 @@ export function hasNativeThinking(model: string): boolean {
   return false;
 }
 
-export function createClient(model: string, apiKey: string): LLMClient {
+export function createClient(
+  model: string,
+  apiKey: string,
+  options?: { includeUsage?: boolean },
+): LLMClient {
   const provider = detectProvider(model);
   if (provider === "anthropic") return new AnthropicClient(apiKey, model);
-  if (provider === "openai") return new OpenAIClient(apiKey, model);
+  if (provider === "openai") return new OpenAIClient(apiKey, model, options);
   return new GeminiClient(apiKey, model);
 }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -35,26 +35,36 @@ export class GeminiClient implements LLMClient {
           },
         });
 
+        let usageInputTokens = 0;
+        let usageOutputTokens = 0;
+
         for await (const chunk of response) {
           const candidate = chunk.candidates?.[0];
-          if (!candidate?.content?.parts) continue;
-
-          for (const part of candidate.content.parts) {
-            if (part.text) {
-              yield { type: "text", text: part.text };
-            } else if (part.functionCall) {
-              yield {
-                type: "function_call",
-                id: part.functionCall.id ?? crypto.randomUUID(),
-                name: part.functionCall.name ?? "",
-                args: (part.functionCall.args ?? {}) as Record<string, unknown>,
-                thoughtSignature: (part as unknown as { thoughtSignature?: string })
-                  .thoughtSignature,
-              };
+          if (candidate?.content?.parts) {
+            for (const part of candidate.content.parts) {
+              if (part.text) {
+                yield { type: "text", text: part.text };
+              } else if (part.functionCall) {
+                yield {
+                  type: "function_call",
+                  id: part.functionCall.id ?? crypto.randomUUID(),
+                  name: part.functionCall.name ?? "",
+                  args: (part.functionCall.args ?? {}) as Record<string, unknown>,
+                  thoughtSignature: (part as unknown as { thoughtSignature?: string })
+                    .thoughtSignature,
+                };
+              }
             }
+          }
+          if (chunk.usageMetadata) {
+            usageInputTokens = chunk.usageMetadata.promptTokenCount ?? 0;
+            usageOutputTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
           }
         }
 
+        if (usageInputTokens > 0 || usageOutputTokens > 0) {
+          yield { type: "usage", inputTokens: usageInputTokens, outputTokens: usageOutputTokens };
+        }
         yield { type: "done" };
         return;
       } catch (err) {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -38,11 +38,19 @@ export class OpenAIClient implements LLMClient {
           messages: openaiMessages,
           tools: openaiTools.length > 0 ? openaiTools : undefined,
           stream: true,
+          stream_options: { include_usage: true },
         });
 
         const pendingCalls = new Map<number, { id: string; name: string; args: string }>();
+        let inputTokens = 0;
+        let outputTokens = 0;
 
         for await (const chunk of apiStream) {
+          if (chunk.usage) {
+            inputTokens = chunk.usage.prompt_tokens;
+            outputTokens = chunk.usage.completion_tokens;
+          }
+
           const choice = chunk.choices[0];
           if (!choice) continue;
 
@@ -80,6 +88,9 @@ export class OpenAIClient implements LLMClient {
           }
         }
 
+        if (inputTokens > 0 || outputTokens > 0) {
+          yield { type: "usage", inputTokens, outputTokens };
+        }
         yield { type: "done" };
         return;
       } catch (err) {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -14,10 +14,12 @@ function isReasoningModel(model: string): boolean {
 export class OpenAIClient implements LLMClient {
   private client: OpenAI;
   private model: string;
+  private includeUsage: boolean;
 
-  constructor(apiKey: string, model: string) {
+  constructor(apiKey: string, model: string, options?: { includeUsage?: boolean }) {
     this.client = new OpenAI({ apiKey });
     this.model = model;
+    this.includeUsage = options?.includeUsage ?? false;
   }
 
   async *stream(
@@ -38,7 +40,7 @@ export class OpenAIClient implements LLMClient {
           messages: openaiMessages,
           tools: openaiTools.length > 0 ? openaiTools : undefined,
           stream: true,
-          stream_options: { include_usage: true },
+          stream_options: this.includeUsage ? { include_usage: true } : undefined,
         });
 
         const pendingCalls = new Map<number, { id: string; name: string; args: string }>();

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -42,7 +42,7 @@ export interface ToolResult {
   error?: string;
 }
 
-// Normalized stream event types emitted by the Gemini client
+// Normalized stream event types emitted by all provider clients
 export type StreamEvent =
   | { type: "text"; text: string }
   | {
@@ -52,4 +52,5 @@ export type StreamEvent =
       args: Record<string, unknown>;
       thoughtSignature?: string;
     }
+  | { type: "usage"; inputTokens: number; outputTokens: number }
   | { type: "done" };


### PR DESCRIPTION
## Summary

- Adds `ObservabilityEvent` discriminated union and `ObservabilityHandler` callback type in `src/core/observability.ts`
- All three LLM provider clients (Gemini, Anthropic, OpenAI) now emit `usage` StreamEvents with input/output token counts
- `Agent` accepts an optional `{ model, onObservability }` options object (7th constructor arg, backward-compatible); emits `context_snapshot`, `llm_call_start`, `llm_call_end` (with latency + tokens), and `guard_triggered` events
- `Executor` emits `tool_denied` (with reason `plan_mode` / `user_denied` / `non_interactive`) and `tool_exec_start` / `tool_exec_end` (with latency, success, outputBytes) around every tool execution
- CLI: `--debug` flag on both `chat` and `run` commands writes JSON obs events to stderr
- 14 new tests covering every event type

## OTel / eval future-proofing

As discussed in #64, span IDs and turn IDs can be added later as additive fields on the existing event variants — no breaking changes required. See #64 for the full design notes.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 331/331 passed
- [ ] Manual smoke: `opencli run --debug "list files"` should emit JSON obs events to stderr

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)