### PR TITLE
fix: parse OPENCLI_MAX_TOOL_OUTPUT once at module load, not per call

### DIFF
--- a/src/core/executor.test.ts
+++ b/src/core/executor.test.ts
@@ -236,7 +236,7 @@ describe("executeCalls", () => {
   });
 
   it("truncates bash output exceeding the limit (middle-truncation)", async () => {
-    const big = "A".repeat(5000) + "MIDDLE" + "B".repeat(5000);
+    const big = "A".repeat(12_000) + "MIDDLE" + "B".repeat(12_000);
     const registry = new ToolRegistry();
     registry.register({
       name: "bash",
@@ -245,14 +245,11 @@ describe("executeCalls", () => {
       execute: async () => ({ success: true, output: big }),
     });
 
-    const prev = process.env.OPENCLI_MAX_TOOL_OUTPUT;
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = "100";
     const { results } = await executeCalls([makeToolCall("bash")], {
       tools: registry,
       skills: makeSkillRegistry({}),
       context: new ContextManager(),
     });
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = prev;
 
     expect(results[0].result).toContain("[... ");
     expect(results[0].result).toContain("truncated");
@@ -269,14 +266,11 @@ describe("executeCalls", () => {
       execute: async () => ({ success: true, output: big }),
     });
 
-    const prev = process.env.OPENCLI_MAX_TOOL_OUTPUT;
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = "100";
     const { results } = await executeCalls([makeToolCall("read")], {
       tools: registry,
       skills: makeSkillRegistry({}),
       context: new ContextManager(),
     });
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = prev;
 
     expect(results[0].result).toBe(big);
   });
@@ -471,26 +465,20 @@ describe("executeCalls — confirmation", () => {
 
 describe("truncateOutput", () => {
   it("returns output unchanged when within limit", () => {
-    const prev = process.env.OPENCLI_MAX_TOOL_OUTPUT;
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = "100";
+    // "short".length = 5 which is well within the 20 000-char default
     expect(truncateOutput("short", "id1")).toBe("short");
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = prev;
   });
 
   it("middle-truncates output exceeding the limit", () => {
-    const prev = process.env.OPENCLI_MAX_TOOL_OUTPUT;
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = "100";
-    // head = 30, tail = 70; input = 50 A's + 500 M's + 50 B's (600 total)
-    const input = "A".repeat(50) + "M".repeat(500) + "B".repeat(50);
+    // head = floor(20000 * 0.3) = 6000, tail = 14000
+    // input: 5000 A's + 20000 M's + 5000 B's = 30000 total (exceeds 20000)
+    const input = "A".repeat(5_000) + "M".repeat(20_000) + "B".repeat(5_000);
     const result = truncateOutput(input, "id1");
-    // Head (first 30 chars) preserved
-    expect(result.startsWith("A".repeat(30))).toBe(true);
-    // Tail (last 50 B's fit within 70-char tail) preserved
-    expect(result.endsWith("B".repeat(50))).toBe(true);
-    // Truncation marker present
+    // First 6000 chars = all 5000 A's + 1000 M's
+    expect(result.startsWith("A".repeat(5_000))).toBe(true);
+    // Last 14000 chars include all 5000 B's at the end
+    expect(result.endsWith("B".repeat(5_000))).toBe(true);
     expect(result).toContain("truncated");
-    // Result is shorter than input
     expect(result.length).toBeLessThan(input.length);
-    process.env.OPENCLI_MAX_TOOL_OUTPUT = prev;
   });
 });

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -11,6 +11,8 @@ import type { ObservabilityHandler } from "./observability.js";
 // exact line spans for follow-up edit calls.
 const TRUNCATE_TOOLS = new Set(["bash", "grep", "glob"]);
 const DEFAULT_MAX_OUTPUT = 20_000;
+const MAX_TOOL_OUTPUT =
+  parseInt(process.env.OPENCLI_MAX_TOOL_OUTPUT ?? "", 10) || DEFAULT_MAX_OUTPUT;
 
 // Tools blocked when `readOnly` is set on ExecutorDeps (used by plan mode).
 // Defence-in-depth: even if the filtered tool list leaks, the executor refuses.
@@ -33,11 +35,10 @@ export interface ExecutorDeps {
 }
 
 export function truncateOutput(output: string, callId: string, tmpDir?: string): string {
-  const max = parseInt(process.env.OPENCLI_MAX_TOOL_OUTPUT ?? String(DEFAULT_MAX_OUTPUT));
-  if (output.length <= max) return output;
+  if (output.length <= MAX_TOOL_OUTPUT) return output;
 
-  const head = Math.floor(max * 0.3);
-  const tail = max - head;
+  const head = Math.floor(MAX_TOOL_OUTPUT * 0.3);
+  const tail = MAX_TOOL_OUTPUT - head;
 
   let savedNote = "";
   if (tmpDir) {
@@ -53,7 +54,7 @@ export function truncateOutput(output: string, callId: string, tmpDir?: string):
 
   return (
     output.slice(0, head) +
-    `\n\n[... ${output.length - max} chars truncated.${savedNote} ...]\n\n` +
+    `\n\n[... ${output.length - MAX_TOOL_OUTPUT} chars truncated.${savedNote} ...]\n\n` +
     output.slice(-tail)
   );
 }


### PR DESCRIPTION
## Summary

- Parse `OPENCLI_MAX_TOOL_OUTPUT` at module load into a `MAX_TOOL_OUTPUT` constant instead of calling `parseInt` on every `truncateOutput()` invocation
- Add radix `10` to `parseInt` and use `|| DEFAULT_MAX_OUTPUT` as fallback so malformed/hex values no longer silently produce `NaN` (which made every output appear to exceed the limit)
- Update executor tests to use input sizes relative to the 20 000-char default rather than overriding the env var at runtime (which stopped working with module-level caching)

## Test plan

- [ ] `npm run typecheck` — no new errors
- [ ] `npm run lint` — clean
- [ ] `npm run format:check` — clean
- [ ] `npm test` — all 342 tests pass

Closes #57

https://claude.ai/code/session_01CKNqw7XM5Py4J2E5nLyyz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKNqw7XM5Py4J2E5nLyyz2)_