### PR TITLE
fix: thread maxTokens from user config into all provider clients

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -178,7 +178,10 @@ async function createAgent(modelOverride?: string, maxTurns?: number, debug?: bo
 
   const provider = detectProvider(model);
   const apiKey = resolveApiKey(provider, config);
-  const client = createClient(model, apiKey, { includeUsage: !!debug });
+  const client = createClient(model, apiKey, {
+    includeUsage: !!debug,
+    maxTokens: config.maxTokens,
+  });
   const tools = createDefaultRegistry(model);
   const skills = new SkillRegistry();
   await skills.discover();

--- a/src/providers/anthropic.test.ts
+++ b/src/providers/anthropic.test.ts
@@ -125,4 +125,27 @@ describe("AnthropicClient error handling", () => {
     expect((err as Error).message).toContain("400");
     expect(mockStream).toHaveBeenCalledTimes(1);
   });
+
+  it("passes default maxTokens to the API call", async () => {
+    mockStream.mockImplementation(() => {
+      throw new Error("400 bad request");
+    });
+    await client
+      .stream([], "sys", [])
+      .next()
+      .catch(() => {});
+    expect(mockStream.mock.calls[0][0]).toMatchObject({ max_tokens: 8096 });
+  });
+
+  it("passes custom maxTokens to the API call", async () => {
+    const customClient = new AnthropicClient("fake-key", "claude-sonnet-4-6", 16384);
+    mockStream.mockImplementation(() => {
+      throw new Error("400 bad request");
+    });
+    await customClient
+      .stream([], "sys", [])
+      .next()
+      .catch(() => {});
+    expect(mockStream.mock.calls[0][0]).toMatchObject({ max_tokens: 16384 });
+  });
 });

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -9,10 +9,12 @@ const RETRY_BASE_MS = 1000;
 export class AnthropicClient implements LLMClient {
   private client: Anthropic;
   private model: string;
+  private maxTokens: number;
 
-  constructor(apiKey: string, model: string) {
+  constructor(apiKey: string, model: string, maxTokens = DEFAULT_MAX_TOKENS) {
     this.client = new Anthropic({ apiKey });
     this.model = model;
+    this.maxTokens = maxTokens;
   }
 
   async *stream(
@@ -28,7 +30,7 @@ export class AnthropicClient implements LLMClient {
       try {
         const apiStream = this.client.messages.stream({
           model: this.model,
-          max_tokens: DEFAULT_MAX_TOKENS,
+          max_tokens: this.maxTokens,
           system: systemInstruction,
           messages: anthropicMessages,
           tools: anthropicTools.length > 0 ? anthropicTools : undefined,

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -32,10 +32,10 @@ export function hasNativeThinking(model: string): boolean {
 export function createClient(
   model: string,
   apiKey: string,
-  options?: { includeUsage?: boolean },
+  options?: { includeUsage?: boolean; maxTokens?: number },
 ): LLMClient {
   const provider = detectProvider(model);
-  if (provider === "anthropic") return new AnthropicClient(apiKey, model);
+  if (provider === "anthropic") return new AnthropicClient(apiKey, model, options?.maxTokens);
   if (provider === "openai") return new OpenAIClient(apiKey, model, options);
-  return new GeminiClient(apiKey, model);
+  return new GeminiClient(apiKey, model, options?.maxTokens);
 }

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -110,4 +110,29 @@ describe("GeminiClient error handling", () => {
     expect((err as Error).message).toContain("400");
     expect(mockGenerateContentStream).toHaveBeenCalledTimes(1);
   });
+
+  it("passes undefined maxOutputTokens when not specified", async () => {
+    mockGenerateContentStream.mockImplementation(() => {
+      throw new Error("400 bad request");
+    });
+    await client
+      .stream([], "sys", [])
+      .next()
+      .catch(() => {});
+    expect(mockGenerateContentStream.mock.calls[0][0].config.maxOutputTokens).toBeUndefined();
+  });
+
+  it("passes custom maxOutputTokens to the API call", async () => {
+    const customClient = new GeminiClient("fake-key", undefined, 16384);
+    mockGenerateContentStream.mockImplementation(() => {
+      throw new Error("400 bad request");
+    });
+    await customClient
+      .stream([], "sys", [])
+      .next()
+      .catch(() => {});
+    expect(mockGenerateContentStream.mock.calls[0][0].config).toMatchObject({
+      maxOutputTokens: 16384,
+    });
+  });
 });

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -9,10 +9,12 @@ const RETRY_BASE_MS = 1000;
 export class GeminiClient implements LLMClient {
   private client: GoogleGenAI;
   private model: string;
+  private maxOutputTokens: number | undefined;
 
-  constructor(apiKey: string, model = DEFAULT_MODEL) {
+  constructor(apiKey: string, model = DEFAULT_MODEL, maxOutputTokens?: number) {
     this.client = new GoogleGenAI({ apiKey });
     this.model = model;
+    this.maxOutputTokens = maxOutputTokens;
   }
 
   async *stream(
@@ -32,6 +34,7 @@ export class GeminiClient implements LLMClient {
           config: {
             systemInstruction,
             tools: functionDeclarations.length > 0 ? [{ functionDeclarations }] : undefined,
+            maxOutputTokens: this.maxOutputTokens,
           },
         });
 

--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -121,6 +121,29 @@ describe("OpenAIClient message format", () => {
     client = new OpenAIClient("fake-key", "gpt-4o");
   });
 
+  it("passes default maxTokens to the API call", async () => {
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of client.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].max_tokens).toBe(8096);
+  });
+
+  it("passes custom maxTokens to the API call", async () => {
+    const customClient = new OpenAIClient("fake-key", "gpt-4o", { maxTokens: 16384 });
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of customClient.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].max_tokens).toBe(16384);
+  });
+
   it("injects system instruction as first message", async () => {
     mockCreate.mockResolvedValue(
       makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -15,11 +15,17 @@ export class OpenAIClient implements LLMClient {
   private client: OpenAI;
   private model: string;
   private includeUsage: boolean;
+  private maxTokens: number;
 
-  constructor(apiKey: string, model: string, options?: { includeUsage?: boolean }) {
+  constructor(
+    apiKey: string,
+    model: string,
+    options?: { includeUsage?: boolean; maxTokens?: number },
+  ) {
     this.client = new OpenAI({ apiKey });
     this.model = model;
     this.includeUsage = options?.includeUsage ?? false;
+    this.maxTokens = options?.maxTokens ?? DEFAULT_MAX_TOKENS;
   }
 
   async *stream(
@@ -36,7 +42,7 @@ export class OpenAIClient implements LLMClient {
       try {
         const apiStream = await this.client.chat.completions.create({
           model: this.model,
-          max_tokens: DEFAULT_MAX_TOKENS,
+          max_tokens: this.maxTokens,
           messages: openaiMessages,
           tools: openaiTools.length > 0 ? openaiTools : undefined,
           stream: true,


### PR DESCRIPTION
## Summary

- `AnthropicClient`, `GeminiClient`, and `OpenAIClient` all hardcoded their token limits (`DEFAULT_MAX_TOKENS = 8096`), silently ignoring the `maxTokens` field in the user's config
- Thread `maxTokens` from `Config` through `createClient()` options into each provider constructor
- Each client now uses the configured value; default falls back to the existing `DEFAULT_MAX_TOKENS` constant so no behaviour changes for existing users who haven't set `maxTokens`

## Test plan

- [ ] `AnthropicClient` test: verifies default `max_tokens` (8096) and custom value (16384) are passed to the SDK call
- [ ] `GeminiClient` test: verifies `maxOutputTokens` is `undefined` when not set, and the configured value when set
- [ ] `OpenAIClient` test: verifies default and custom `max_tokens` are passed to the SDK call
- [ ] All 352 existing tests continue to pass (`npm test`)

Closes #55

https://claude.ai/code/session_016PedqA6CLCgcDhTkUsb3Nn

---
_Generated by [Claude Code](https://claude.ai/code/session_016PedqA6CLCgcDhTkUsb3Nn)_