### PR TITLE
refactor: move read/write classification onto Tool interface, delete PLAN_MODE_TOOLS and WRITE_TOOLS

### DIFF
--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -78,11 +78,13 @@ describe("Agent plan mode", () => {
     };
 
     const registry = new ToolRegistry();
+    const readonlyNames = new Set(["read", "glob", "grep", "think"]);
     for (const name of ["read", "glob", "grep", "write", "edit", "bash", "think"]) {
       registry.register({
         name,
         description: "",
         parameters: { type: "object", properties: {} },
+        readonly: readonlyNames.has(name) ? true : undefined,
         execute: async () => ({ success: true, output: "" }),
       });
     }

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -22,22 +22,6 @@ const STUCK_THRESHOLD = 3;
 
 export type AgentRunMode = "react" | "plan";
 
-// Tools exposed in plan mode — exploration only, no writes.
-// Bash is excluded: read/glob/grep cover 95% of exploration, and reliably
-// validating bash as read-only is hard (subshells, redirects, find -exec).
-const PLAN_MODE_TOOLS = new Set([
-  "read",
-  "glob",
-  "grep",
-  "ls",
-  "web_fetch",
-  "todo_read",
-  "think",
-  "activate_skill",
-]);
-
-const PLAN_SYSTEM_SUFFIX = buildPlanSuffix(PLAN_MODE_TOOLS);
-
 export class Agent {
   private context: ContextManager;
   private confirmFn?: ConfirmFn;
@@ -84,12 +68,18 @@ export class Agent {
     });
 
     const allToolDefs = [...this.tools.all().map(toolToDefinition), activateSkillDefinition];
-    const toolDefinitions =
-      mode === "plan" ? allToolDefs.filter((t) => PLAN_MODE_TOOLS.has(t.name)) : allToolDefs;
 
-    const baseInstruction = this.context.getSystemInstruction(toolDefinitions);
-    const systemInstruction =
-      mode === "plan" ? baseInstruction + PLAN_SYSTEM_SUFFIX : baseInstruction;
+    let toolDefinitions = allToolDefs;
+    let systemInstruction: string;
+
+    if (mode === "plan") {
+      const readonlyTools = this.tools.all().filter((t) => t.readonly);
+      toolDefinitions = [...readonlyTools.map(toolToDefinition), activateSkillDefinition];
+      const planSuffix = buildPlanSuffix(new Set(readonlyTools.map((t) => t.name)));
+      systemInstruction = this.context.getSystemInstruction(toolDefinitions) + planSuffix;
+    } else {
+      systemInstruction = this.context.getSystemInstruction(allToolDefs);
+    }
 
     let turns = 0;
     let lastCallSig = "";

--- a/src/core/executor.test.ts
+++ b/src/core/executor.test.ts
@@ -57,6 +57,7 @@ describe("executeCalls", () => {
       name: "slow",
       description: "",
       parameters: { type: "object", properties: {} },
+      readonly: true,
       execute: async () => {
         await new Promise((r) => setTimeout(r, 20));
         order.push("slow");
@@ -67,6 +68,7 @@ describe("executeCalls", () => {
       name: "fast",
       description: "",
       parameters: { type: "object", properties: {} },
+      readonly: true,
       execute: async () => {
         order.push("fast");
         return { success: true, output: "fast result" };
@@ -350,7 +352,14 @@ describe("executeCalls", () => {
   });
 
   it("allows read/glob/grep when readOnly is set", async () => {
-    const registry = makeToolRegistry("read", "file contents");
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "read",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      readonly: true,
+      execute: async () => ({ success: true, output: "file contents" }),
+    });
     const { results } = await executeCalls([makeToolCall("read")], {
       tools: registry,
       skills: makeSkillRegistry({}),

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -14,10 +14,6 @@ const DEFAULT_MAX_OUTPUT = 20_000;
 const MAX_TOOL_OUTPUT =
   parseInt(process.env.OPENCLI_MAX_TOOL_OUTPUT ?? "", 10) || DEFAULT_MAX_OUTPUT;
 
-// Tools blocked when `readOnly` is set on ExecutorDeps (used by plan mode).
-// Defence-in-depth: even if the filtered tool list leaks, the executor refuses.
-const WRITE_TOOLS = new Set(["write", "edit", "bash", "todo_write"]);
-
 /** Called when a tool signals it requires confirmation. Returns "allow" or "deny". */
 export type ConfirmFn = (
   toolName: string,
@@ -68,7 +64,9 @@ async function executeOneCall(
   call: FunctionCallPart,
   deps: ExecutorDeps,
 ): Promise<FunctionResultPart> {
-  if (deps.readOnly && WRITE_TOOLS.has(call.name)) {
+  const tool = deps.tools.get(call.name);
+
+  if (deps.readOnly && !tool?.readonly) {
     deps.obs?.({ type: "tool_denied", name: call.name, reason: "plan_mode" });
     return {
       type: "function_result",
@@ -78,8 +76,6 @@ async function executeOneCall(
       thoughtSignature: call.thoughtSignature,
     };
   }
-
-  const tool = deps.tools.get(call.name);
   if (tool?.requiresConfirmation?.(call.args as Record<string, unknown>)) {
     const decision = deps.confirmFn
       ? await deps.confirmFn(call.name, call.args as Record<string, unknown>)
@@ -155,7 +151,7 @@ export async function executeCalls(
   // followed by a read that depends on it). Pure read batches still run in
   // parallel for speed.
   let results: FunctionResultPart[];
-  if (toolCalls.some((c) => WRITE_TOOLS.has(c.name))) {
+  if (toolCalls.some((c) => !deps.tools.get(c.name)?.readonly)) {
     results = [];
     for (const call of toolCalls) {
       results.push(await executeOneCall(call, deps));

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -148,7 +148,7 @@ export function buildPlanSuffix(allowedTools: ReadonlySet<string>): string {
 You are in **Plan Mode**. Your only task is to explore the codebase and produce a concrete numbered execution plan. You CANNOT and MUST NOT modify any files.
 
 Available tools: ${toolList}.
-Write tools (\`write\`, \`edit\`, \`bash\`, \`todo_write\`) are blocked at the executor level.
+All other tools are blocked at the executor level.
 
 ### Process
 

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -13,7 +13,8 @@ export interface Tool {
   name: string;
   description: string;
   parameters: JSONSchema;
+  /** true = safe in plan mode (read-only); false/undefined = write tool (blocked in plan mode) */
+  readonly?: boolean;
   execute: (params: Record<string, unknown>) => Promise<ToolResult>;
-  /** Return true if this call requires interactive user confirmation before execution. */
   requiresConfirmation?: (args: Record<string, unknown>) => boolean;
 }

--- a/src/tools/file/glob.ts
+++ b/src/tools/file/glob.ts
@@ -4,6 +4,7 @@ import type { Tool } from "../base.js";
 
 export const globTool: Tool = {
   name: "glob",
+  readonly: true,
   description:
     "Find files matching a glob pattern. Returns matching file paths sorted by modification time.",
   parameters: {

--- a/src/tools/file/grep.ts
+++ b/src/tools/file/grep.ts
@@ -4,6 +4,7 @@ import type { Tool } from "../base.js";
 
 export const grepTool: Tool = {
   name: "grep",
+  readonly: true,
   description:
     "Search for a regex pattern in file contents. Returns matching lines with file path and line number.",
   parameters: {

--- a/src/tools/file/ls.ts
+++ b/src/tools/file/ls.ts
@@ -4,6 +4,7 @@ import type { Tool } from "../base.js";
 
 export const lsTool: Tool = {
   name: "ls",
+  readonly: true,
   description:
     "List directory contents with file type and size. Use for directory exploration; use glob when you need pattern matching.",
   parameters: {

--- a/src/tools/file/read.ts
+++ b/src/tools/file/read.ts
@@ -4,6 +4,7 @@ import type { Tool } from "../base.js";
 
 export const readTool: Tool = {
   name: "read",
+  readonly: true,
   description:
     "Read the contents of a file. Optionally specify offset (line to start from, 1-based) and limit (number of lines to read).",
   parameters: {

--- a/src/tools/task/todo.ts
+++ b/src/tools/task/todo.ts
@@ -56,6 +56,7 @@ export const todoWriteTool: Tool = {
 
 export const todoReadTool: Tool = {
   name: "todo_read",
+  readonly: true,
   description:
     "Read the current session task list written by todo_write. Use to check progress before continuing a multi-step task.",
   parameters: {

--- a/src/tools/think.ts
+++ b/src/tools/think.ts
@@ -12,6 +12,7 @@ import type { Tool } from "./base.js";
  */
 export const thinkTool: Tool = {
   name: "think",
+  readonly: true,
   description:
     "Use this to reason privately before acting. The output is not shown to the user — " +
     "it is a scratchpad for working through a complex problem before committing to a tool call.",

--- a/src/tools/web/fetch.ts
+++ b/src/tools/web/fetch.ts
@@ -4,6 +4,7 @@ const MAX_OUTPUT = Number(process.env.OPENCLI_MAX_TOOL_OUTPUT ?? 20_000);
 
 export const webFetchTool: Tool = {
   name: "web_fetch",
+  readonly: true,
   description:
     "Fetch a URL and return its content as plain text. HTML is converted to readable text; JSON is returned as-is. Use for reading documentation, GitHub issues, API references, or any URL the user shares.",
   parameters: {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `readonly?: boolean` to the `Tool` interface in `src/tools/base.ts` — `true` means safe in plan mode, `undefined`/`false` means write tool
- Marks all read-only built-in tools (`read`, `glob`, `grep`, `ls`, `think`, `web_fetch`, `todo_read`) with `readonly: true`
- Removes `PLAN_MODE_TOOLS` from `src/core/agent.ts` and `WRITE_TOOLS` from `src/core/executor.ts`; both now derive the classification from `tool.readonly` at runtime
- Updates `buildPlanSuffix` to remove the hardcoded write-tool list from the plan-mode message
- Updates tests to set `readonly: true` on tools that should be allowed in plan mode / run in parallel

Adding a new tool no longer requires updating two separate hardcoded sets in two different files — the tool author simply sets `readonly: true` or omits the field.

## Test plan

- [ ] `npm run typecheck` — passes (pre-existing env errors unrelated to this change)
- [ ] `npm run lint` — passes
- [ ] `npm run format:check` — passes
- [ ] `npm test` — 355 tests pass, 6 skipped (smoke tests require a prior build)
- [ ] Plan mode still filters write tools from tool definitions
- [ ] Executor still blocks non-readonly tools when `readOnly` is set
- [ ] Parallel execution still used for batches of readonly-only tool calls

Closes #48

https://claude.ai/code/session_01ML8FpvQXjNPU2cHz9Pkqzq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ML8FpvQXjNPU2cHz9Pkqzq)_