### PR TITLE
fix: validate required tool params at registry boundary before execute

### DIFF
--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -17,4 +17,6 @@ export interface Tool {
   readonly?: boolean;
   execute: (params: Record<string, unknown>) => Promise<ToolResult>;
   requiresConfirmation?: (args: Record<string, unknown>) => boolean;
+  /** Return an error message string if params are invalid, or null if valid. */
+  validate?: (params: Record<string, unknown>) => string | null;
 }

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -56,4 +56,68 @@ describe("ToolRegistry", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/something went wrong/);
   });
+
+  it("rejects missing required parameters with a descriptive error", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "needs-cmd",
+      description: "Requires command",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+      execute: async () => ({ success: true, output: "ok" }),
+    });
+    const result = await registry.execute("needs-cmd", {});
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Missing required parameter: command/);
+  });
+
+  it("passes through when all required parameters are present", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "needs-cmd",
+      description: "Requires command",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+      execute: async ({ command }) => ({ success: true, output: command as string }),
+    });
+    const result = await registry.execute("needs-cmd", { command: "echo hi" });
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("echo hi");
+  });
+
+  it("calls validate() and returns its error message when validation fails", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "validated",
+      description: "Has custom validation",
+      parameters: { type: "object", properties: { value: { type: "number" } } },
+      validate: ({ value }) =>
+        typeof value === "number" && value > 0 ? null : "value must be a positive number",
+      execute: async () => ({ success: true, output: "ok" }),
+    });
+    const result = await registry.execute("validated", { value: -1 });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("value must be a positive number");
+  });
+
+  it("calls validate() and proceeds to execute when validation passes", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "validated",
+      description: "Has custom validation",
+      parameters: { type: "object", properties: { value: { type: "number" } } },
+      validate: ({ value }) =>
+        typeof value === "number" && value > 0 ? null : "value must be a positive number",
+      execute: async ({ value }) => ({ success: true, output: String(value) }),
+    });
+    const result = await registry.execute("validated", { value: 42 });
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("42");
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -25,6 +25,18 @@ export class ToolRegistry {
     if (!tool) {
       return { success: false, output: "", error: `Unknown tool: ${name}` };
     }
+
+    for (const field of tool.parameters.required ?? []) {
+      if (params[field] === undefined || params[field] === null) {
+        return { success: false, output: "", error: `Missing required parameter: ${field}` };
+      }
+    }
+
+    const validationError = tool.validate?.(params) ?? null;
+    if (validationError !== null) {
+      return { success: false, output: "", error: validationError };
+    }
+
     try {
       return await tool.execute(params);
     } catch (err) {


### PR DESCRIPTION
## Summary

- Add `validate?` hook to the `Tool` interface (`src/tools/base.ts`) for custom per-tool validation
- In `ToolRegistry.execute()`, check each field listed in `parameters.required` before calling `execute()` — missing fields now return a descriptive `"Missing required parameter: <field>"` error instead of silently producing `undefined` inside the tool
- Call `tool.validate?.(params)` as a second validation pass for any tool-specific logic beyond required-field checks
- Add 4 new tests in `registry.test.ts` covering: missing required param rejection, valid params passing through, `validate()` failing, and `validate()` passing

## Test plan

- [ ] `npm test` — all 365 tests pass (9 in registry.test.ts, including 4 new ones)
- [ ] `npm run lint` — no errors
- [ ] `npm run format:check` — no formatting issues
- [ ] Existing tool tests in `file.test.ts` and `bash.test.ts` unchanged and passing

Closes #51

https://claude.ai/code/session_01TaoZ4HmrdKruujhF632BZm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaoZ4HmrdKruujhF632BZm)_