### PR TITLE
refactor: contain thoughtSignature inside GeminiClient (closes #49)

### DIFF
--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -231,7 +231,6 @@ export async function runAgentTurn(
             type: "tool_call",
             name: event.name,
             args: event.args,
-            thoughtSignature: event.thoughtSignature,
           });
           if (COMPACT_TOOLS.has(event.name)) {
             printToolCallCompact(event.name, event.args);

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -11,7 +11,7 @@ import type { ObservabilityHandler } from "./observability.js";
 
 export type AgentEvent =
   | { type: "text"; text: string }
-  | { type: "tool_call"; name: string; args: Record<string, unknown>; thoughtSignature?: string }
+  | { type: "tool_call"; name: string; args: Record<string, unknown> }
   | { type: "tool_result"; name: string; result: string }
   | { type: "skill_activated"; name: string }
   | { type: "error"; message: string }
@@ -110,13 +110,11 @@ export class Agent {
             id: event.id,
             name: event.name,
             args: event.args,
-            thoughtSignature: event.thoughtSignature,
           });
           yield {
             type: "tool_call",
             name: event.name,
             args: event.args,
-            thoughtSignature: event.thoughtSignature,
           };
         } else if (event.type === "usage") {
           usageInputTokens = event.inputTokens;

--- a/src/core/executor.test.ts
+++ b/src/core/executor.test.ts
@@ -241,25 +241,6 @@ describe("executeCalls", () => {
     expect(skillRegistry.load).not.toHaveBeenCalled();
   });
 
-  it("propagates thoughtSignature from call to result", async () => {
-    const registry = makeToolRegistry("read", "content");
-    const call: FunctionCallPart = {
-      type: "function_call",
-      id: "c1",
-      name: "read",
-      args: {},
-      thoughtSignature: "sig-abc",
-    };
-
-    const { results } = await executeCalls([call], {
-      tools: registry,
-      skills: makeSkillRegistry({}),
-      context: new ContextManager(),
-    });
-
-    expect(results[0].thoughtSignature).toBe("sig-abc");
-  });
-
   it("truncates bash output exceeding the limit (middle-truncation)", async () => {
     const big = "A".repeat(12_000) + "MIDDLE" + "B".repeat(12_000);
     const registry = new ToolRegistry();

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -73,7 +73,6 @@ async function executeOneCall(
       id: call.id,
       name: call.name,
       result: `Error: '${call.name}' is blocked in plan mode. Use read, glob, or grep to explore the codebase.`,
-      thoughtSignature: call.thoughtSignature,
     };
   }
   if (tool?.requiresConfirmation?.(call.args as Record<string, unknown>)) {
@@ -93,7 +92,6 @@ async function executeOneCall(
         result: deps.confirmFn
           ? `Blocked: user denied '${call.name}' tool call.`
           : `Blocked: '${call.name}' requires confirmation but is running non-interactively. Pass --yes to auto-approve.`,
-        thoughtSignature: call.thoughtSignature,
       };
     }
   }
@@ -123,7 +121,6 @@ async function executeOneCall(
     id: call.id,
     name: call.name,
     result: output,
-    thoughtSignature: call.thoughtSignature,
   };
 }
 

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -170,3 +170,132 @@ describe("GeminiClient error handling", () => {
     });
   });
 });
+
+describe("GeminiClient thoughtSignature handling", () => {
+  let mockGenerateContentStream: ReturnType<typeof vi.fn>;
+  let client: GeminiClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGenerateContentStream = vi.fn();
+    vi.mocked(GoogleGenAI).mockImplementation(
+      () =>
+        ({
+          models: { generateContentStream: mockGenerateContentStream },
+        }) as unknown as InstanceType<typeof GoogleGenAI>,
+    );
+    client = new GeminiClient("fake-key");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function* makeStream(parts: unknown[]) {
+    yield {
+      candidates: [{ content: { parts } }],
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+    };
+  }
+
+  it("does not include thoughtSignature in yielded StreamEvent", async () => {
+    mockGenerateContentStream.mockReturnValue(
+      makeStream([
+        {
+          functionCall: { id: "call-1", name: "bash", args: { command: "ls" } },
+          thoughtSignature: "sig-abc",
+        },
+      ]),
+    );
+
+    const events = [];
+    for await (const event of client.stream([], "sys", [])) {
+      events.push(event);
+    }
+
+    const callEvent = events.find((e) => e.type === "function_call");
+    expect(callEvent).toBeDefined();
+    expect(callEvent).not.toHaveProperty("thoughtSignature");
+  });
+
+  it("echoes thoughtSignature on functionResponse when the call ID is known", async () => {
+    // First stream: receive a function_call with a thoughtSignature
+    mockGenerateContentStream.mockReturnValueOnce(
+      makeStream([
+        {
+          functionCall: { id: "call-1", name: "bash", args: { command: "ls" } },
+          thoughtSignature: "sig-abc",
+        },
+      ]),
+    );
+
+    for await (const event of client.stream([], "sys", [])) void event;
+
+    // Second stream: send back the result; verify thoughtSignature is echoed
+    mockGenerateContentStream.mockReturnValueOnce(makeStream([{ text: "done" }]));
+
+    const messagesWithResult = [
+      {
+        role: "model" as const,
+        parts: [
+          { type: "function_call" as const, id: "call-1", name: "bash", args: { command: "ls" } },
+        ],
+      },
+      {
+        role: "user" as const,
+        parts: [
+          { type: "function_result" as const, id: "call-1", name: "bash", result: "file.txt" },
+        ],
+      },
+    ];
+
+    for await (const event of client.stream(messagesWithResult, "sys", [])) void event;
+
+    const secondCallContents = mockGenerateContentStream.mock.calls[1][0].contents;
+    const modelMsg = secondCallContents[0];
+    const userMsg = secondCallContents[1];
+
+    expect(modelMsg.parts[0].thoughtSignature).toBe("sig-abc");
+    expect(userMsg.parts[0].thoughtSignature).toBe("sig-abc");
+  });
+
+  it("omits thoughtSignature on functionResponse when no signature was captured", async () => {
+    // Stream a function_call without a thoughtSignature (non-thinking model)
+    mockGenerateContentStream.mockReturnValueOnce(
+      makeStream([{ functionCall: { id: "call-2", name: "read", args: { file_path: "f.ts" } } }]),
+    );
+
+    for await (const event of client.stream([], "sys", [])) void event;
+
+    mockGenerateContentStream.mockReturnValueOnce(makeStream([{ text: "ok" }]));
+
+    const messagesWithResult = [
+      {
+        role: "model" as const,
+        parts: [
+          {
+            type: "function_call" as const,
+            id: "call-2",
+            name: "read",
+            args: { file_path: "f.ts" },
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        parts: [
+          { type: "function_result" as const, id: "call-2", name: "read", result: "content" },
+        ],
+      },
+    ];
+
+    for await (const event of client.stream(messagesWithResult, "sys", [])) void event;
+
+    const secondCallContents = mockGenerateContentStream.mock.calls[1][0].contents;
+    const modelMsg = secondCallContents[0];
+    const userMsg = secondCallContents[1];
+
+    expect(modelMsg.parts[0]).not.toHaveProperty("thoughtSignature");
+    expect(userMsg.parts[0]).not.toHaveProperty("thoughtSignature");
+  });
+});

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -15,6 +15,9 @@ export class GeminiClient implements LLMClient {
   private client: GoogleGenAI;
   private model: string;
   private maxOutputTokens: number | undefined;
+  // Stores thoughtSignature keyed by function call ID; populated when a thinking-model
+  // functionCall is received, echoed back in the corresponding functionResponse.
+  private thoughtSignatures = new Map<string, string>();
 
   constructor(apiKey: string, model = DEFAULT_MODEL, maxOutputTokens?: number) {
     this.client = new GoogleGenAI({ apiKey });
@@ -27,7 +30,7 @@ export class GeminiClient implements LLMClient {
     systemInstruction: string,
     tools: ToolDefinition[],
   ): AsyncGenerator<StreamEvent> {
-    const contents = messagesToContents(messages);
+    const contents = this.messagesToContents(messages);
     const functionDeclarations = tools.map(definitionToFunctionDeclaration);
 
     yield* withRetry(
@@ -61,12 +64,14 @@ export class GeminiClient implements LLMClient {
           if (part.text) {
             yield { type: "text", text: part.text };
           } else if (part.functionCall) {
+            const id = part.functionCall.id ?? crypto.randomUUID();
+            const sig = (part as unknown as { thoughtSignature?: string }).thoughtSignature;
+            if (sig) this.thoughtSignatures.set(id, sig);
             yield {
               type: "function_call",
-              id: part.functionCall.id ?? crypto.randomUUID(),
+              id,
               name: part.functionCall.name ?? "",
               args: (part.functionCall.args ?? {}) as Record<string, unknown>,
-              thoughtSignature: (part as unknown as { thoughtSignature?: string }).thoughtSignature,
             };
           }
         }
@@ -82,32 +87,33 @@ export class GeminiClient implements LLMClient {
     }
     yield { type: "done" };
   }
-}
-
-function messagesToContents(messages: Message[]): Content[] {
-  return messages.map((msg) => ({
-    role: msg.role,
-    parts: msg.parts.map((part) => {
-      if (part.type === "text") {
-        return { text: part.text };
-      }
-      if (part.type === "function_call") {
+  private messagesToContents(messages: Message[]): Content[] {
+    return messages.map((msg) => ({
+      role: msg.role,
+      parts: msg.parts.map((part) => {
+        if (part.type === "text") {
+          return { text: part.text };
+        }
+        if (part.type === "function_call") {
+          const sig = this.thoughtSignatures.get(part.id);
+          return {
+            functionCall: { id: part.id, name: part.name, args: part.args },
+            ...(sig ? { thoughtSignature: sig } : {}),
+          };
+        }
+        // function_result — echo thoughtSignature back as required by Gemini thinking models
+        const sig = this.thoughtSignatures.get(part.id);
         return {
-          functionCall: { id: part.id, name: part.name, args: part.args },
-          ...(part.thoughtSignature ? { thoughtSignature: part.thoughtSignature } : {}),
+          functionResponse: {
+            id: part.id,
+            name: part.name,
+            response: { output: part.result },
+          },
+          ...(sig ? { thoughtSignature: sig } : {}),
         };
-      }
-      // function_result — echo thoughtSignature back as required by Gemini thinking models
-      return {
-        functionResponse: {
-          id: part.id,
-          name: part.name,
-          response: { output: part.result },
-        },
-        ...(part.thoughtSignature ? { thoughtSignature: part.thoughtSignature } : {}),
-      };
-    }),
-  }));
+      }),
+    }));
+  }
 }
 
 function definitionToFunctionDeclaration(def: ToolDefinition): FunctionDeclaration {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -18,7 +18,6 @@ export interface FunctionCallPart {
   id: string;
   name: string;
   args: Record<string, unknown>;
-  thoughtSignature?: string; // required by Gemini thinking models
 }
 
 export interface FunctionResultPart {
@@ -26,7 +25,6 @@ export interface FunctionResultPart {
   id: string;
   name: string;
   result: string;
-  thoughtSignature?: string; // echoed back from the original function call
 }
 
 export type MessagePart = TextPart | FunctionCallPart | FunctionResultPart;
@@ -45,12 +43,6 @@ export interface ToolResult {
 // Normalized stream event types emitted by all provider clients
 export type StreamEvent =
   | { type: "text"; text: string }
-  | {
-      type: "function_call";
-      id: string;
-      name: string;
-      args: Record<string, unknown>;
-      thoughtSignature?: string;
-    }
+  | { type: "function_call"; id: string; name: string; args: Record<string, unknown> }
   | { type: "usage"; inputTokens: number; outputTokens: number }
   | { type: "done" };

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -220,72 +220,23 @@ describe("Session.loadMessages", () => {
     expect(calls[0].id).not.toBe(calls[1].id);
   });
 
-  it("preserves thoughtSignature from tool_call through function_call and function_result parts", async () => {
+  it("reconstructed function_call parts have no thoughtSignature (handled by GeminiClient internally)", async () => {
     const session = await Session.create(CWD);
-    await session.log({ type: "user", content: "Use a thinking model tool" });
-    await session.log({
-      type: "tool_call",
-      name: "bash",
-      args: { command: "ls" },
-      thoughtSignature: "sig-abc123",
-    });
+    await session.log({ type: "user", content: "Tool call" });
+    await session.log({ type: "tool_call", name: "bash", args: { command: "ls" } });
     await session.log({ type: "tool_result", name: "bash", result: "file.txt" });
     await session.log({ type: "assistant", content: "Done." });
 
     const { messages } = await Session.loadMessages(session.id, CWD);
     expect(messages).toHaveLength(4);
 
-    const callPart = messages[1].parts[0] as { type: string; thoughtSignature?: string };
+    const callPart = messages[1].parts[0] as unknown as Record<string, unknown>;
     expect(callPart.type).toBe("function_call");
-    expect(callPart.thoughtSignature).toBe("sig-abc123");
+    expect(Object.prototype.hasOwnProperty.call(callPart, "thoughtSignature")).toBe(false);
 
-    const resultPart = messages[2].parts[0] as { type: string; thoughtSignature?: string };
+    const resultPart = messages[2].parts[0] as unknown as Record<string, unknown>;
     expect(resultPart.type).toBe("function_result");
-    expect(resultPart.thoughtSignature).toBe("sig-abc123");
-  });
-
-  it("handles missing thoughtSignature gracefully (non-thinking models)", async () => {
-    const session = await Session.create(CWD);
-    await session.log({ type: "user", content: "Normal tool call" });
-    await session.log({ type: "tool_call", name: "bash", args: { command: "echo hi" } });
-    await session.log({ type: "tool_result", name: "bash", result: "hi" });
-    await session.log({ type: "assistant", content: "Done." });
-
-    const { messages } = await Session.loadMessages(session.id, CWD);
-    const callPart = messages[1].parts[0] as { type: string; thoughtSignature?: string };
-    expect(callPart.thoughtSignature).toBeUndefined();
-    const resultPart = messages[2].parts[0] as { type: string; thoughtSignature?: string };
-    expect(resultPart.thoughtSignature).toBeUndefined();
-  });
-
-  it("preserves thoughtSignature across parallel multi-call rounds", async () => {
-    const session = await Session.create(CWD);
-    await session.log({ type: "user", content: "Parallel calls" });
-    await session.log({
-      type: "tool_call",
-      name: "glob",
-      args: { pattern: "*.ts" },
-      thoughtSignature: "sig-1",
-    });
-    await session.log({
-      type: "tool_call",
-      name: "grep",
-      args: { pattern: "foo" },
-      thoughtSignature: "sig-2",
-    });
-    await session.log({ type: "tool_result", name: "glob", result: "a.ts" });
-    await session.log({ type: "tool_result", name: "grep", result: "a.ts:1" });
-    await session.log({ type: "assistant", content: "Done." });
-
-    const { messages } = await Session.loadMessages(session.id, CWD);
-    // messages[1] = model(2 calls), messages[2] = user(2 results)
-    const calls = messages[1].parts as Array<{ type: string; thoughtSignature?: string }>;
-    const results = messages[2].parts as Array<{ type: string; thoughtSignature?: string }>;
-
-    expect(calls[0].thoughtSignature).toBe("sig-1");
-    expect(calls[1].thoughtSignature).toBe("sig-2");
-    expect(results[0].thoughtSignature).toBe("sig-1");
-    expect(results[1].thoughtSignature).toBe("sig-2");
+    expect(Object.prototype.hasOwnProperty.call(resultPart, "thoughtSignature")).toBe(false);
   });
 
   it("ignores session_start and unknown entries", async () => {

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -118,11 +118,9 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
   // Pending batches accumulate until we know where they belong
   let pendingCalls: FunctionCallPart[] = [];
   let pendingResults: FunctionResultPart[] = [];
-  // Queue of call IDs (and their thoughtSignatures) waiting for their matching results;
-  // ensures each function_result references the same ID as its function_call (required by
-  // the Anthropic API) and echoes back thoughtSignature (required by Gemini thinking models).
+  // Queue of call IDs waiting for their matching results; ensures each
+  // function_result references the same ID as its function_call (required by the Anthropic API).
   let pendingCallIds: string[] = [];
-  let pendingCallSignatures: (string | undefined)[] = [];
 
   function flushCalls(): void {
     if (pendingCalls.length === 0) return;
@@ -136,7 +134,6 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
     messages.push({ role: "user", parts: pendingResults });
     pendingResults = [];
     pendingCallIds = [];
-    pendingCallSignatures = [];
   }
 
   for (const entry of entries) {
@@ -150,25 +147,21 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
       flushResults();
       const id = `resume-call-${++idCounter}`;
       pendingCallIds.push(id);
-      pendingCallSignatures.push(entry.thoughtSignature);
       pendingCalls.push({
         type: "function_call",
         id,
         name: entry.name,
         args: entry.args,
-        thoughtSignature: entry.thoughtSignature,
       });
     } else if (entry.type === "tool_result") {
       // Results follow their calls — flush the pending call batch into a model message
       flushCalls();
       const id = pendingCallIds.shift() ?? `resume-call-${++idCounter}`;
-      const resultSignature = pendingCallSignatures.shift();
       pendingResults.push({
         type: "function_result",
         id,
         name: entry.name,
         result: entry.result,
-        thoughtSignature: resultSignature,
       });
     } else if (entry.type === "assistant" && entry.content) {
       flushCalls();
@@ -189,13 +182,7 @@ export type SessionEntry =
   | { type: "session_start"; timestamp: string; cwd: string }
   | { type: "user"; timestamp: string; content: string }
   | { type: "assistant"; timestamp: string; content: string }
-  | {
-      type: "tool_call";
-      timestamp: string;
-      name: string;
-      args: Record<string, unknown>;
-      thoughtSignature?: string;
-    }
+  | { type: "tool_call"; timestamp: string; name: string; args: Record<string, unknown> }
   | { type: "tool_result"; timestamp: string; name: string; result: string };
 
 type WithoutTimestamp<T> = T extends unknown ? Omit<T, "timestamp"> : never;


### PR DESCRIPTION
## Summary

- `thoughtSignature` is a Gemini thinking-model API detail that had leaked into universal types (`FunctionCallPart`, `FunctionResultPart`, `StreamEvent`), `AgentEvent`, session JSONL logs, and `reconstructMessages()` in `session.ts`.
- This PR implements **Option B** from issue #49: keep a `Map<callId, thoughtSignature>` inside `GeminiClient`. The map is populated when a thinking-model `functionCall` arrives; the signature is looked up when building `functionCall` and `functionResponse` Content parts on the next request. Nothing outside `gemini.ts` ever sees the field.

### Files changed

| File | Change |
|---|---|
| `src/providers/types.ts` | Remove `thoughtSignature` from `FunctionCallPart`, `FunctionResultPart`, `StreamEvent` |
| `src/providers/gemini.ts` | Add `thoughtSignatures: Map`; convert `messagesToContents` to private instance method |
| `src/core/agent.ts` | Remove from `AgentEvent.tool_call` and `FunctionCallPart` construction |
| `src/core/executor.ts` | Remove from all three `FunctionResultPart` return sites |
| `src/cli/repl.ts` | Remove from `session.log` tool_call entry |
| `src/state/session.ts` | Remove from `SessionEntry`; drop `pendingCallSignatures` array from `reconstructMessages` |
| `src/providers/gemini.test.ts` | Add 3 tests: signature not in StreamEvent, echoed on next request, omitted when absent |
| `src/state/session.test.ts` | Replace 3 "preserves thoughtSignature" tests with 1 "no thoughtSignature in reconstructed parts" test |
| `src/core/executor.test.ts` | Remove "propagates thoughtSignature from call to result" test |

### Tradeoff

Session replay will not preserve thought signatures — this is acceptable since Gemini does not validate them on replay (as noted in the issue).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 365 tests pass, 6 skipped (smoke tests that need a built binary)
- [x] New `GeminiClient thoughtSignature handling` suite verifies: (1) signature is not in yielded `StreamEvent`, (2) it is echoed in the `functionCall` and `functionResponse` Content parts on the next API call, (3) no signature fields when the model didn't provide one

Closes #49

https://claude.ai/code/session_01MN7VmWxNUv7RqgTRtu5oEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN7VmWxNUv7RqgTRtu5oEX)_