### PR TITLE
fix: skip orphaned tool_result entries in reconstructMessages()

### DIFF
--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -258,6 +258,73 @@ describe("Session.log", () => {
   });
 });
 
+describe("Session.loadMessages — orphaned tool_result resilience", () => {
+  it("skips a tool_result that has no preceding tool_call", async () => {
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    const { AGENT_DIR } = await import("./config.js");
+    const { join } = await import("node:path");
+
+    const projectDir = join(AGENT_DIR, "projects", Buffer.from(CWD).toString("base64url"));
+    await mkdir(projectDir, { recursive: true });
+    const id = "2025-01-01T00-00-02";
+    const logPath = join(projectDir, `${id}.jsonl`);
+
+    const entry = (obj: object) => JSON.stringify({ ...obj, timestamp: "t" });
+    const lines = [
+      entry({ type: "session_start", cwd: CWD }),
+      entry({ type: "user", content: "Hello" }),
+      entry({ type: "tool_result", name: "bash", result: "orphaned" }), // no matching call
+      entry({ type: "assistant", content: "Hi there" }),
+    ].join("\n");
+
+    await writeFile(logPath, lines, "utf8");
+
+    const { messages } = await Session.loadMessages(id, CWD);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ role: "user", parts: [{ type: "text", text: "Hello" }] });
+    expect(messages[1]).toMatchObject({
+      role: "model",
+      parts: [{ type: "text", text: "Hi there" }],
+    });
+  });
+
+  it("skips extra tool_result entries when there are more results than calls", async () => {
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    const { AGENT_DIR } = await import("./config.js");
+    const { join } = await import("node:path");
+
+    const projectDir = join(AGENT_DIR, "projects", Buffer.from(CWD).toString("base64url"));
+    await mkdir(projectDir, { recursive: true });
+    const id = "2025-01-01T00-00-03";
+    const logPath = join(projectDir, `${id}.jsonl`);
+
+    const entry = (obj: object) => JSON.stringify({ ...obj, timestamp: "t" });
+    const lines = [
+      entry({ type: "session_start", cwd: CWD }),
+      entry({ type: "user", content: "Run" }),
+      entry({ type: "tool_call", name: "bash", args: { command: "ls" } }),
+      entry({ type: "tool_result", name: "bash", result: "file.txt" }), // matches the call
+      entry({ type: "tool_result", name: "bash", result: "extra" }), // orphaned — no second call
+      entry({ type: "assistant", content: "Done." }),
+    ].join("\n");
+
+    await writeFile(logPath, lines, "utf8");
+
+    const { messages } = await Session.loadMessages(id, CWD);
+    // user → model(1 call) → user(1 result) → model text  — extra result dropped
+    expect(messages).toHaveLength(4);
+    expect(messages[1].parts).toHaveLength(1); // one function_call
+    expect(messages[1].parts[0]).toMatchObject({ type: "function_call", name: "bash" });
+    expect(messages[2].parts).toHaveLength(1); // one function_result (not two)
+    expect(messages[2].parts[0]).toMatchObject({
+      type: "function_result",
+      name: "bash",
+      result: "file.txt",
+    });
+    expect(messages[3]).toMatchObject({ role: "model", parts: [{ type: "text", text: "Done." }] });
+  });
+});
+
 describe("Session.loadMessages — malformed JSONL resilience", () => {
   it("skips malformed lines and still returns valid messages", async () => {
     const { writeFile, mkdir } = await import("node:fs/promises");

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -156,7 +156,13 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
     } else if (entry.type === "tool_result") {
       // Results follow their calls — flush the pending call batch into a model message
       flushCalls();
-      const id = pendingCallIds.shift() ?? `resume-call-${++idCounter}`;
+      if (pendingCallIds.length === 0) {
+        process.stderr.write(
+          `[opencli] warn: orphaned tool_result for "${entry.name}" (no matching tool_call) — skipping\n`,
+        );
+        continue;
+      }
+      const id = pendingCallIds.shift()!;
       pendingResults.push({
         type: "function_result",
         id,


### PR DESCRIPTION
## Summary

- Replaces the silent fallback `?? \`resume-call-${++idCounter}\`` in `reconstructMessages()` with an explicit orphan check: when a `tool_result` entry has no matching `tool_call` (i.e. `pendingCallIds` is empty), emit a warning to stderr and skip the entry.
- Adds two new test cases in `session.test.ts` covering: (1) a `tool_result` with no preceding `tool_call`, and (2) more results than calls in the same round.

## Test plan

- [ ] `npm run typecheck` — passes
- [ ] `npm run lint` — passes
- [ ] `npm run format:check` — passes
- [ ] `npm test` — all 373 tests pass (26 in `session.test.ts`, including 2 new cases)

Closes #58

https://claude.ai/code/session_01X16kfxXppj3pzWBr3UX1cz

---
_Generated by [Claude Code](https://claude.ai/code/session_01X16kfxXppj3pzWBr3UX1cz)_