### PR TITLE
feat: allow explicit provider and base URL override

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,8 @@ program
   .option("--max-turns <n>", "Maximum agent iterations per prompt (default: 50)", parseInt)
   .option("--debug", "Emit structured observability events to stderr as JSON")
   .option("--sandbox <mode>", "Sandbox mode for bash tool: auto | strict | off (default: auto)")
+  .option("--provider <provider>", "Override provider detection: gemini | anthropic | openai")
+  .option("--base-url <url>", "Custom base URL for proxy or local inference (e.g. LiteLLM)")
   .action(async (opts) => {
     const sessionId = opts.session ?? (opts.resume ? "latest" : undefined);
     await startChat(
@@ -41,6 +43,8 @@ program
       opts.maxTurns,
       opts.debug as boolean | undefined,
       opts.sandbox as string | undefined,
+      opts.provider as string | undefined,
+      opts.baseUrl as string | undefined,
     );
   });
 
@@ -69,6 +73,8 @@ program
   .option("--yes", "Auto-approve all tool confirmations (skip interactive prompts)")
   .option("--debug", "Emit structured observability events to stderr as JSON")
   .option("--sandbox <mode>", "Sandbox mode for bash tool: auto | strict | off (default: auto)")
+  .option("--provider <provider>", "Override provider detection: gemini | anthropic | openai")
+  .option("--base-url <url>", "Custom base URL for proxy or local inference (e.g. LiteLLM)")
   .action(async (prompt: string, opts) => {
     await runSingle(
       prompt,
@@ -78,6 +84,8 @@ program
       opts.yes as boolean | undefined,
       opts.debug as boolean | undefined,
       opts.sandbox as string | undefined,
+      opts.provider as string | undefined,
+      opts.baseUrl as string | undefined,
     );
   });
 
@@ -88,6 +96,8 @@ program
   .option("--anthropic-api-key <key>", "Set your Anthropic API key")
   .option("--openai-api-key <key>", "Set your OpenAI API key")
   .option("--model <model>", "Set the default model")
+  .option("--provider <provider>", "Set the default provider: gemini | anthropic | openai")
+  .option("--base-url <url>", "Set a custom base URL for proxy or local inference")
   .action(async (opts) => {
     if (opts.geminiApiKey) {
       await saveConfig({ geminiApiKey: opts.geminiApiKey });
@@ -105,7 +115,22 @@ program
       await saveConfig({ model: opts.model });
       printInfo(`Default model set to ${opts.model}.`);
     }
-    if (!opts.geminiApiKey && !opts.anthropicApiKey && !opts.openaiApiKey && !opts.model) {
+    if (opts.provider) {
+      await saveConfig({ provider: opts.provider as Config["provider"] });
+      printInfo(`Default provider set to ${opts.provider}.`);
+    }
+    if (opts.baseUrl) {
+      await saveConfig({ baseUrl: opts.baseUrl });
+      printInfo(`Base URL set to ${opts.baseUrl}.`);
+    }
+    if (
+      !opts.geminiApiKey &&
+      !opts.anthropicApiKey &&
+      !opts.openaiApiKey &&
+      !opts.model &&
+      !opts.provider &&
+      !opts.baseUrl
+    ) {
       const config = await loadConfig();
       console.log(
         JSON.stringify(
@@ -133,8 +158,17 @@ async function startChat(
   maxTurns?: number,
   debug?: boolean,
   sandboxFlag?: string,
+  providerOverride?: string,
+  baseUrlOverride?: string,
 ): Promise<void> {
-  const { agent, skills } = await createAgent(modelOverride, maxTurns, debug, sandboxFlag);
+  const { agent, skills } = await createAgent(
+    modelOverride,
+    maxTurns,
+    debug,
+    sandboxFlag,
+    providerOverride,
+    baseUrlOverride,
+  );
   await runRepl(agent, skills, resumeSessionId);
 }
 
@@ -146,8 +180,17 @@ async function runSingle(
   autoApprove?: boolean,
   debug?: boolean,
   sandboxFlag?: string,
+  providerOverride?: string,
+  baseUrlOverride?: string,
 ): Promise<void> {
-  const { agent } = await createAgent(modelOverride, maxTurns, debug, sandboxFlag);
+  const { agent } = await createAgent(
+    modelOverride,
+    maxTurns,
+    debug,
+    sandboxFlag,
+    providerOverride,
+    baseUrlOverride,
+  );
   if (autoApprove) {
     agent.setConfirmFn(async () => "allow");
   } else if (process.stdin.isTTY) {
@@ -192,11 +235,26 @@ function resolveSandboxMode(flagValue: string | undefined, config: Config): Sand
   throw new Error(`Invalid --sandbox value '${raw}'. Valid values: auto, strict, off`);
 }
 
+function resolveProvider(
+  flag: string | undefined,
+  config: Config,
+  model: string,
+): "gemini" | "anthropic" | "openai" {
+  const raw = flag ?? config.provider;
+  if (raw !== undefined) {
+    if (raw === "gemini" || raw === "anthropic" || raw === "openai") return raw;
+    throw new Error(`Invalid --provider value '${raw}'. Valid values: gemini, anthropic, openai`);
+  }
+  return detectProvider(model);
+}
+
 async function createAgent(
   modelOverride?: string,
   maxTurns?: number,
   debug?: boolean,
   sandboxFlag?: string,
+  providerOverride?: string,
+  baseUrlOverride?: string,
 ) {
   const config = await loadConfig();
   const model = process.env.OPENCLI_MODEL ?? modelOverride ?? config.model;
@@ -207,11 +265,14 @@ async function createAgent(
     process.stderr.write(`[opencli] warn: ${runner.warning}\n`);
   }
 
-  const provider = detectProvider(model);
+  const provider = resolveProvider(providerOverride, config, model);
+  const baseUrl = baseUrlOverride ?? config.baseUrl;
   const apiKey = resolveApiKey(provider, config);
   const client = createClient(model, apiKey, {
     includeUsage: !!debug,
     maxTokens: config.maxTokens,
+    provider,
+    baseUrl,
   });
   const tools = createDefaultRegistry(model, runner);
   const skills = new SkillRegistry();

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -10,8 +10,8 @@ export class AnthropicClient implements LLMClient {
   private model: string;
   private maxTokens: number;
 
-  constructor(apiKey: string, model: string, maxTokens = DEFAULT_MAX_TOKENS) {
-    this.client = new Anthropic({ apiKey });
+  constructor(apiKey: string, model: string, maxTokens = DEFAULT_MAX_TOKENS, baseUrl?: string) {
+    this.client = new Anthropic({ apiKey, ...(baseUrl ? { baseURL: baseUrl } : {}) });
     this.model = model;
     this.maxTokens = maxTokens;
   }

--- a/src/providers/factory.test.ts
+++ b/src/providers/factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { detectProvider, hasNativeThinking } from "./factory.js";
+import { detectProvider, hasNativeThinking, createClient } from "./factory.js";
 
 describe("detectProvider", () => {
   it("detects anthropic for claude- prefix", () => {
@@ -53,5 +53,47 @@ describe("hasNativeThinking", () => {
   it("returns false for Claude models (use extended thinking via API config)", () => {
     expect(hasNativeThinking("claude-sonnet-4-6")).toBe(false);
     expect(hasNativeThinking("claude-opus-4-7")).toBe(false);
+  });
+});
+
+describe("createClient provider override", () => {
+  it("uses provider option instead of model-name detection", () => {
+    // "my-proxy" would normally detect as gemini, but explicit override routes to anthropic
+    const client = createClient("my-proxy", "key", { provider: "anthropic" });
+    expect(client.constructor.name).toBe("AnthropicClient");
+  });
+
+  it("uses provider option to route an aliased name to gemini", () => {
+    // "my-gemini-proxy" would normally detect as gemini anyway, but test explicit override
+    const client = createClient("custom-alias", "key", { provider: "gemini" });
+    expect(client.constructor.name).toBe("GeminiClient");
+  });
+
+  it("uses provider option to route an aliased name to openai", () => {
+    // A LiteLLM proxy model name that doesn't start with gpt- or o1
+    const client = createClient("ollama/llama3", "key", { provider: "openai" });
+    expect(client.constructor.name).toBe("OpenAIClient");
+  });
+
+  it("falls back to model-name detection when provider option is absent", () => {
+    expect(createClient("claude-sonnet-4-6", "key").constructor.name).toBe("AnthropicClient");
+    expect(createClient("gpt-4o", "key").constructor.name).toBe("OpenAIClient");
+    expect(createClient("gemini-3.1-flash", "key").constructor.name).toBe("GeminiClient");
+  });
+
+  it("passes baseUrl to the created client without throwing", () => {
+    // Constructors accept baseUrl — just verify no error is thrown
+    expect(() =>
+      createClient("my-proxy", "key", { provider: "anthropic", baseUrl: "http://localhost:4000" }),
+    ).not.toThrow();
+    expect(() =>
+      createClient("my-proxy", "key", { provider: "openai", baseUrl: "http://localhost:11434/v1" }),
+    ).not.toThrow();
+    expect(() =>
+      createClient("my-proxy", "key", {
+        provider: "gemini",
+        baseUrl: "http://localhost:8000",
+      }),
+    ).not.toThrow();
   });
 });

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -32,10 +32,12 @@ export function hasNativeThinking(model: string): boolean {
 export function createClient(
   model: string,
   apiKey: string,
-  options?: { includeUsage?: boolean; maxTokens?: number },
+  options?: { includeUsage?: boolean; maxTokens?: number; provider?: Provider; baseUrl?: string },
 ): LLMClient {
-  const provider = detectProvider(model);
-  if (provider === "anthropic") return new AnthropicClient(apiKey, model, options?.maxTokens);
-  if (provider === "openai") return new OpenAIClient(apiKey, model, options);
-  return new GeminiClient(apiKey, model, options?.maxTokens);
+  const provider = options?.provider ?? detectProvider(model);
+  const baseUrl = options?.baseUrl;
+  if (provider === "anthropic")
+    return new AnthropicClient(apiKey, model, options?.maxTokens, baseUrl);
+  if (provider === "openai") return new OpenAIClient(apiKey, model, { ...options, baseUrl });
+  return new GeminiClient(apiKey, model, options?.maxTokens, baseUrl);
 }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -19,8 +19,8 @@ export class GeminiClient implements LLMClient {
   // functionCall is received, echoed back in the corresponding functionResponse.
   private thoughtSignatures = new Map<string, string>();
 
-  constructor(apiKey: string, model = DEFAULT_MODEL, maxOutputTokens?: number) {
-    this.client = new GoogleGenAI({ apiKey });
+  constructor(apiKey: string, model = DEFAULT_MODEL, maxOutputTokens?: number, baseUrl?: string) {
+    this.client = new GoogleGenAI({ apiKey, ...(baseUrl ? { httpOptions: { baseUrl } } : {}) });
     this.model = model;
     this.maxOutputTokens = maxOutputTokens;
   }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -19,9 +19,9 @@ export class OpenAIClient implements LLMClient {
   constructor(
     apiKey: string,
     model: string,
-    options?: { includeUsage?: boolean; maxTokens?: number },
+    options?: { includeUsage?: boolean; maxTokens?: number; baseUrl?: string },
   ) {
-    this.client = new OpenAI({ apiKey });
+    this.client = new OpenAI({ apiKey, ...(options?.baseUrl ? { baseURL: options.baseUrl } : {}) });
     this.model = model;
     this.includeUsage = options?.includeUsage ?? false;
     this.maxTokens = options?.maxTokens ?? DEFAULT_MAX_TOKENS;

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -21,6 +21,10 @@ export interface Config {
   permissions?: Permissions;
   /** Sandbox mode for the bash tool. Absence is treated as "auto" by the CLI layer. */
   sandbox?: "auto" | "strict" | "off";
+  /** Explicit provider override — takes precedence over model-name detection. */
+  provider?: "gemini" | "anthropic" | "openai";
+  /** Custom base URL for proxy or local inference setups (e.g. LiteLLM, Ollama). */
+  baseUrl?: string;
 }
 
 const DEFAULTS: Config = {


### PR DESCRIPTION
## Summary

- Adds `provider?` and `baseUrl?` fields to `Config` so overrides persist across sessions
- `createClient()` now accepts a `provider` option that takes precedence over model-name prefix detection; also accepts `baseUrl` forwarded to each SDK constructor
- All three provider clients (Anthropic, OpenAI, Gemini) accept a custom `baseUrl` for proxy/local-inference setups
- CLI: `--provider <provider>` and `--base-url <url>` flags on `chat` and `run`; `--provider` and `--base-url` on `config` command to set persistent defaults
- `resolveProvider()` validates the flag value and falls back to `detectProvider(model)` when no override is present

## Test plan

- [ ] `npm run typecheck && npm run lint && npm run format:check && npm test` all pass (verified locally — 388 tests pass)
- [ ] `createClient("my-proxy", "key", { provider: "anthropic" })` returns `AnthropicClient` (new test in `factory.test.ts`)
- [ ] `createClient("ollama/llama3", "key", { provider: "openai" })` returns `OpenAIClient`
- [ ] `createClient("custom", "key", { provider: "gemini" })` returns `GeminiClient`
- [ ] Passing `baseUrl` to any client does not throw
- [ ] `opencli config --provider anthropic` persists and `opencli chat` uses it
- [ ] `opencli chat --provider openai --base-url http://localhost:11434/v1` routes correctly

Closes #54

https://claude.ai/code/session_0168yLHXAuP51he3GV4DTxWh

---
_Generated by [Claude Code](https://claude.ai/code/session_0168yLHXAuP51he3GV4DTxWh)_