### PR TITLE
feat: MCP client integration (Phase A2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,53 @@ OPENCLI_SANDBOX=off opencli chat
 opencli config  # shows current config; edit sandbox field manually
 ```
 
+## MCP servers
+
+OpenCLI can connect to any [Model Context Protocol](https://modelcontextprotocol.io) server and expose its tools to the agent as `mcp__<server>__<tool>`.
+
+### Managing servers
+
+```bash
+opencli mcp add                            # interactive wizard
+opencli mcp add myserver npx -y @myco/mcp-server  # one-shot (stdio)
+opencli mcp add api --transport http --url http://localhost:3000/mcp  # HTTP
+opencli mcp list                           # list configured servers with live status
+opencli mcp test myserver                  # probe connection and list tools
+opencli mcp remove myserver                # remove a server
+```
+
+### Configuration format (`~/.opencli/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "callTimeout": 30000
+    },
+    "api": {
+      "transport": "http",
+      "url": "http://localhost:3000/mcp",
+      "headers": { "Authorization": "Bearer ${API_TOKEN}" }
+    }
+  }
+}
+```
+
+- **`${VAR}`** in `command`, `args`, `url`, and `headers` is expanded from environment variables at startup. Unset variables expand to `""` with a warning.
+- **`callTimeout`** (milliseconds, per-server) overrides the global default of 60 000 ms.
+- Tool names are prefixed as `mcp__<server>__<tool>`. Non-alphanumeric characters in server names (except `-`) are replaced with `_`.
+- All MCP tool calls require HITL confirmation. The confirmation dialog offers extra choices: allow this tool with any args (`t`), or allow all tools from this server (`s`).
+
+### In-session management
+
+```
+/mcp              # list configured servers
+/mcp test <name>  # probe a server inline
+```
+
 ## Architecture
 
 Five-layer design — see [`docs/architecture.md`](docs/architecture.md) for the full spec.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,6 +291,10 @@ src/tools/
     fetch.ts       web_fetch — HTTP GET with content extraction.
 ```
 
+#### `Tool.truncateOutput`
+
+Tools that can return arbitrarily large output (`bash`, `grep`, `glob`, MCP tools) set `truncateOutput: true`. The executor reads this flag and applies middle-truncation (capped at `OPENCLI_MAX_TOOL_OUTPUT`, default 20 000 chars) before feeding the result back to the LLM. Tools that must not truncate (e.g. `read`, `write`) leave the flag absent.
+
 #### Sandbox layer
 
 The sandbox layer wraps every `bash` execution with OS-level isolation. It is layered *after* the HITL confirmation gate — both layers must pass before a command runs.
@@ -422,7 +426,62 @@ Activated skill content is tagged `<skill_content name="...">` and prepended (ne
 
 ---
 
-### 6. State — `src/state/`
+### 6. MCP — `src/mcp/`
+
+The MCP layer connects OpenCLI to external tool servers via the [Model Context Protocol](https://modelcontextprotocol.io). It bridges external tools into the `ToolRegistry` as first-class `Tool` objects, transparent to the agent core.
+
+**Key files:**
+
+```
+src/mcp/
+  types.ts      McpStdioServer, McpHttpServer, McpServerConfig, McpConfig,
+                McpToolInfo — shared types; no SDK imports.
+  config.ts     loadMcpConfig(agentDir) — reads ~/.opencli/mcp.json; expands
+                ${VAR} (braced-only) in command/args/url/headers; defaults absent
+                transport to "stdio"; returns null on absent or malformed file.
+  client.ts     McpClient — wraps @modelcontextprotocol/sdk Client.
+                connect() uses StdioClientTransport or StreamableHTTPClientTransport.
+                callTool() enforces per-server callTimeout (default 60 000 ms) via
+                AbortController; catches AbortError and returns success:false.
+  adapter.ts    mcpToolToTool(client, sanitisedServerName, info) — bridges one MCP
+                tool into a Tool with name mcp__<server>__<tool>, truncateOutput:true,
+                requiresConfirmation:()=>true, readonly:false.
+  manager.ts    McpManager.create(config) — connects all configured servers in
+                parallel, detects post-sanitisation name collisions, logs failures
+                without blocking other servers. registerTools(registry) calls
+                listTools() per server (isolated failure) and registers adapters.
+                disconnectAll() closes all live clients.
+  index.ts      Re-exports all public types and classes.
+```
+
+#### Tool naming and sanitisation
+
+Server names are sanitised by replacing any character that is not `[a-zA-Z0-9_-]` with `_`. If two server names map to the same sanitised form, the second is skipped and a warning is emitted. Tool names become `mcp__<sanitisedServer>__<toolName>`.
+
+#### HITL confirmation for MCP tools
+
+All MCP tools require confirmation. The confirm dialog in the REPL shows two extra choices for MCP tools:
+- `t` — allow this specific tool (any args) for the rest of the project session
+- `s` — allow all tools from this server for the rest of the project session
+
+Both choices persist to `.opencli/settings.json` as a wildcard entry (`mcp__server__tool:*` or `mcp__server__*`).
+
+#### Layer constraints
+
+`src/mcp/` may import from `providers/types` (for shared types) but must never import from `cli/`, `state/`, `core/`, or `tools/`. API keys and the agent dir are passed in from the CLI layer.
+
+#### `opencli mcp` subcommands
+
+```bash
+opencli mcp add [name] [command [args...]]   # add/update a server
+opencli mcp list [--no-probe]                # list servers (probes by default)
+opencli mcp test <name>                      # probe one server
+opencli mcp remove <name> [-y]               # remove a server
+```
+
+---
+
+### 7. State — `src/state/`
 
 **Key files:**
 
@@ -550,6 +609,7 @@ User: /plan refactor auth module
 | `src/core/` | `providers/`, `tools/`, `skills/` | `cli/`, `state/` |
 | `src/providers/` | `providers/` only | `cli/`, `core/`, `tools/`, `skills/`, `state/` |
 | `src/tools/` | `providers/types` | `cli/`, `core/`, `providers/` (non-types), `state/` |
+| `src/mcp/` | `providers/types`, `@modelcontextprotocol/sdk` | `cli/`, `core/`, `tools/`, `state/` |
 | `src/skills/` | Node builtins | `cli/`, `core/`, `providers/`, `tools/`, `state/` |
 | `src/state/` | Node builtins, `providers/factory` (for Provider type) | `cli/`, `core/` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/sdk": "^0.91.1",
         "@clack/prompts": "^0.9.0",
         "@google/genai": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "boxen": "^8.0.1",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
@@ -771,6 +772,18 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -945,6 +958,69 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1489,6 +1565,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1823,12 +1900,26 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1871,6 +1962,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -1997,6 +2127,30 @@
         "node": "*"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boxen": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
@@ -2106,6 +2260,15 @@
         "esbuild": ">=0.18"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2114,6 +2277,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -2359,11 +2551,67 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2417,6 +2665,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -2424,6 +2681,20 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2442,6 +2713,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2453,6 +2730,15 @@
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -2466,12 +2752,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -2480,6 +2796,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2524,6 +2841,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2543,6 +2866,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2699,6 +3023,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2707,6 +3061,68 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -2719,7 +3135,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2735,6 +3150,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2788,6 +3219,27 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2869,6 +3321,24 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2882,6 +3352,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gaxios": {
@@ -2931,6 +3410,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -3040,6 +3556,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3047,6 +3575,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/highlight.js": {
@@ -3058,12 +3610,42 @@
         "node": "*"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -3094,6 +3676,22 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3112,6 +3710,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {
@@ -3158,6 +3780,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -3174,7 +3802,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3253,8 +3880,18 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -3309,6 +3946,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3499,6 +4142,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3525,6 +4169,61 @@
       },
       "peerDependencies": {
         "marked": ">=1 <16"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-function": {
@@ -3621,6 +4320,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -3681,6 +4389,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3856,6 +4597,15 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3870,7 +4620,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3891,6 +4640,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3922,6 +4681,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3937,6 +4697,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -3971,6 +4740,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4073,6 +4843,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4081,6 +4864,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/readdirp": {
@@ -4101,6 +4923,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4196,6 +5027,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4216,6 +5063,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -4229,11 +5082,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4246,10 +5149,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4315,6 +5289,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -4619,6 +5602,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4714,6 +5706,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4753,12 +5746,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4813,6 +5821,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4823,12 +5840,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4927,6 +5954,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -5007,7 +6035,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5164,6 +6191,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -5199,6 +6232,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -5247,6 +6281,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@anthropic-ai/sdk": "^0.91.1",
     "@clack/prompts": "^0.9.0",
     "@google/genai": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "boxen": "^8.0.1",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -185,8 +185,9 @@ async function startChat(
     process.exit(0);
   };
 
-  // SIGTERM from the OS (e.g. docker stop, systemd) also needs cleanup
+  // SIGTERM / SIGINT (signal-driven exit) also need graceful cleanup
   process.once("SIGTERM", () => void onExit());
+  process.once("SIGINT", () => void onExit());
 
   await runRepl(agent, skills, resumeSessionId, onExit);
   await cleanup(); // normal exit (Ctrl+D or /exit)
@@ -231,6 +232,14 @@ async function runSingle(
     return text;
   };
 
+  const sigCleanup = async () => {
+    await mcpManager.disconnectAll();
+    process.exit(0);
+  };
+  const sigHandler = () => void sigCleanup();
+  process.once("SIGINT", sigHandler);
+  process.once("SIGTERM", sigHandler);
+
   try {
     if (planMode) {
       const planText = await stream(prompt, "plan");
@@ -245,6 +254,8 @@ async function runSingle(
       await stream(prompt, "react");
     }
   } finally {
+    process.off("SIGINT", sigHandler);
+    process.off("SIGTERM", sigHandler);
     await mcpManager.disconnectAll();
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@ import { createClient, detectProvider } from "../providers/factory.js";
 import { Agent } from "../core/agent.js";
 import { createDefaultRegistry } from "../tools/index.js";
 import { SkillRegistry } from "../skills/registry.js";
-import { loadConfig, saveConfig } from "../state/config.js";
+import { loadConfig, saveConfig, AGENT_DIR } from "../state/config.js";
 import { Session } from "../state/session.js";
 import { loadSystemInstruction } from "../core/prompt.js";
 import { resolveApiKey } from "./keys.js";
@@ -13,6 +13,9 @@ import type { ObservabilityEvent } from "../core/observability.js";
 import { createSandboxRunner } from "../tools/exec/sandbox/index.js";
 import type { SandboxMode } from "../tools/exec/sandbox/types.js";
 import type { Config } from "../state/config.js";
+import { loadMcpConfig } from "../mcp/config.js";
+import { McpManager } from "../mcp/manager.js";
+import { registerMcpCommand } from "./mcp-cmd.js";
 
 const program = new Command();
 
@@ -147,6 +150,8 @@ program
     }
   });
 
+registerMcpCommand(program);
+
 program.parseAsync(process.argv).catch((err) => {
   printError(err instanceof Error ? err.message : String(err));
   process.exit(1);
@@ -161,7 +166,7 @@ async function startChat(
   providerOverride?: string,
   baseUrlOverride?: string,
 ): Promise<void> {
-  const { agent, skills } = await createAgent(
+  const { agent, skills, mcpManager } = await createAgent(
     modelOverride,
     maxTurns,
     debug,
@@ -169,7 +174,22 @@ async function startChat(
     providerOverride,
     baseUrlOverride,
   );
-  await runRepl(agent, skills, resumeSessionId);
+
+  const cleanup = async () => {
+    await mcpManager.disconnectAll();
+  };
+
+  // Ctrl+C in the REPL calls onExit for graceful MCP subprocess shutdown
+  const onExit = async () => {
+    await cleanup();
+    process.exit(0);
+  };
+
+  // SIGTERM from the OS (e.g. docker stop, systemd) also needs cleanup
+  process.once("SIGTERM", () => void onExit());
+
+  await runRepl(agent, skills, resumeSessionId, onExit);
+  await cleanup(); // normal exit (Ctrl+D or /exit)
 }
 
 async function runSingle(
@@ -183,7 +203,7 @@ async function runSingle(
   providerOverride?: string,
   baseUrlOverride?: string,
 ): Promise<void> {
-  const { agent } = await createAgent(
+  const { agent, mcpManager } = await createAgent(
     modelOverride,
     maxTurns,
     debug,
@@ -211,17 +231,21 @@ async function runSingle(
     return text;
   };
 
-  if (planMode) {
-    const planText = await stream(prompt, "plan");
-    if (planText.trim()) {
-      process.stderr.write("\nExecuting plan…\n");
-      await stream(
-        `I have approved the following plan. Execute it step by step:\n\n${planText}`,
-        "react",
-      );
+  try {
+    if (planMode) {
+      const planText = await stream(prompt, "plan");
+      if (planText.trim()) {
+        process.stderr.write("\nExecuting plan…\n");
+        await stream(
+          `I have approved the following plan. Execute it step by step:\n\n${planText}`,
+          "react",
+        );
+      }
+    } else {
+      await stream(prompt, "react");
     }
-  } else {
-    await stream(prompt, "react");
+  } finally {
+    await mcpManager.disconnectAll();
   }
 }
 
@@ -275,6 +299,15 @@ async function createAgent(
     baseUrl,
   });
   const tools = createDefaultRegistry(model, runner);
+
+  // Load and connect MCP servers, registering their tools into the registry
+  const mcpConfig = await loadMcpConfig(AGENT_DIR);
+  const mcpManager = await McpManager.create(mcpConfig ?? { mcpServers: {} });
+  if (mcpManager.connectedCount > 0) {
+    await mcpManager.registerTools(tools);
+    process.stderr.write(`[mcp] ${mcpManager.connectedCount} server(s) connected\n`);
+  }
+
   const skills = new SkillRegistry();
   await skills.discover();
 
@@ -283,5 +316,5 @@ async function createAgent(
     model,
     onObservability: debug ? makeDebugHandler() : undefined,
   });
-  return { agent, skills };
+  return { agent, skills, mcpManager };
 }

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -247,6 +247,11 @@ export async function selectKey(prompt: string, options: SelectOption[]): Promis
 
 // ── Main readLine ─────────────────────────────────────────────────────────────
 
+export interface ReadLineOpts {
+  /** Called instead of process.exit(0) when Ctrl+C is pressed. Useful for async cleanup. */
+  onExit?: () => Promise<void>;
+}
+
 /**
  * Read a line of input in raw mode.
  * Returns the submitted string, or null on EOF (Ctrl+D on empty line).
@@ -254,6 +259,7 @@ export async function selectKey(prompt: string, options: SelectOption[]): Promis
 export async function readLine(
   history: string[],
   commands: SlashCommand[],
+  opts?: ReadLineOpts,
 ): Promise<string | null> {
   emitKeypressEvents(stdin);
   stdin.ref(); // ensure the event loop stays alive while waiting for input
@@ -311,12 +317,18 @@ export async function readLine(
 
       const matches = input.startsWith("/") ? filterCommands(commands, input) : [];
 
-      // Ctrl+C → exit
+      // Ctrl+C → exit (via onExit callback for graceful async cleanup)
       if (key.ctrl && key.name === "c") {
         stdout.write("\n");
         if (stdin.isTTY) stdin.setRawMode(false);
         stdin.removeListener("keypress", onKey);
-        process.exit(0);
+        stdin.unref();
+        if (opts?.onExit) {
+          void opts.onExit();
+        } else {
+          process.exit(0);
+        }
+        return;
       }
 
       // Ctrl+D on empty input → EOF

--- a/src/cli/mcp-cmd.ts
+++ b/src/cli/mcp-cmd.ts
@@ -1,0 +1,336 @@
+import type { Command } from "commander";
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import chalk from "chalk";
+import * as clack from "@clack/prompts";
+import { AGENT_DIR } from "../state/config.js";
+import { McpClient } from "../mcp/client.js";
+import { loadMcpConfig } from "../mcp/config.js";
+import type { McpConfig, McpServerConfig } from "../mcp/types.js";
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+export interface ProbeResult {
+  ok: boolean;
+  tools?: string[];
+  error?: string;
+  latencyMs?: number;
+}
+
+export async function probeServer(name: string, config: McpServerConfig): Promise<ProbeResult> {
+  const client = new McpClient(name, config);
+  const start = Date.now();
+  try {
+    await client.connect();
+    const tools = await client.listTools();
+    await client.close();
+    return { ok: true, tools: tools.map((t) => t.name), latencyMs: Date.now() - start };
+  } catch (err) {
+    try {
+      await client.close();
+    } catch {
+      // ignore close errors
+    }
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function writeMcpConfig(updater: (current: McpConfig) => McpConfig): Promise<void> {
+  await mkdir(AGENT_DIR, { recursive: true });
+  const configPath = join(AGENT_DIR, "mcp.json");
+
+  let current: McpConfig = { mcpServers: {} };
+  try {
+    const raw = await readFile(configPath, "utf8");
+    current = JSON.parse(raw) as McpConfig;
+  } catch {
+    // file absent or unparseable — start fresh
+  }
+
+  const updated = updater(current);
+  const tmp = join(AGENT_DIR, `mcp.json.tmp-${randomUUID()}`);
+  await writeFile(tmp, JSON.stringify(updated, null, 2) + "\n", "utf8");
+  await rename(tmp, configPath);
+}
+
+// ── `opencli mcp add` ─────────────────────────────────────────────────────────
+
+async function mcpAdd(
+  nameArg: string | undefined,
+  rest: string[],
+  opts: {
+    transport?: string;
+    url?: string;
+    header?: string[];
+    force?: boolean;
+  },
+): Promise<void> {
+  const currentConfig = await loadMcpConfig(AGENT_DIR);
+  const currentServers = currentConfig?.mcpServers ?? {};
+
+  let name: string;
+  let serverConfig: McpServerConfig;
+
+  if (nameArg && rest.length > 0) {
+    // One-shot form: opencli mcp add <name> -- <command> [args...]
+    name = nameArg;
+    const transport = (opts.transport as "stdio" | "http" | undefined) ?? "stdio";
+    if (transport === "http") {
+      const url = opts.url ?? rest[0];
+      serverConfig = { transport: "http", url };
+    } else {
+      serverConfig = { transport: "stdio", command: rest[0], args: rest.slice(1) };
+    }
+  } else if (nameArg && opts.transport === "http" && opts.url) {
+    name = nameArg;
+    const headers: Record<string, string> = {};
+    for (const h of opts.header ?? []) {
+      const idx = h.indexOf(":");
+      if (idx !== -1) {
+        headers[h.slice(0, idx).trim()] = h.slice(idx + 1).trim();
+      }
+    }
+    serverConfig = {
+      transport: "http",
+      url: opts.url,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    };
+  } else {
+    // Interactive form
+    process.stdout.write("\n");
+    const _name = await clack.text({ message: "Server name", placeholder: "filesystem" });
+    if (clack.isCancel(_name)) {
+      process.stdout.write("Cancelled.\n");
+      return;
+    }
+    name = _name as string;
+
+    const _transport = await clack.select({
+      message: "Transport",
+      options: [
+        { value: "stdio", label: "stdio (subprocess)" },
+        { value: "http", label: "http (Streamable HTTP / SSE)" },
+      ],
+    });
+    if (clack.isCancel(_transport)) {
+      process.stdout.write("Cancelled.\n");
+      return;
+    }
+
+    if (_transport === "http") {
+      const _url = await clack.text({ message: "URL", placeholder: "http://localhost:3000/mcp" });
+      if (clack.isCancel(_url)) return;
+      serverConfig = { transport: "http", url: _url as string };
+    } else {
+      const _command = await clack.text({ message: "Command", placeholder: "npx" });
+      if (clack.isCancel(_command)) return;
+      const _argsRaw = await clack.text({
+        message: "Args (space-separated)",
+        placeholder: "-y @modelcontextprotocol/server-filesystem /tmp",
+        initialValue: "",
+      });
+      if (clack.isCancel(_argsRaw)) return;
+      const args = (_argsRaw as string).trim().split(/\s+/).filter(Boolean);
+      serverConfig = {
+        transport: "stdio",
+        command: _command as string,
+        args: args.length > 0 ? args : undefined,
+      };
+    }
+  }
+
+  // Validate name
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    process.stderr.write(
+      `Error: server name '${name}' contains invalid characters. Use [a-zA-Z0-9_-] only.\n`,
+    );
+    process.exit(1);
+  }
+
+  if (currentServers[name] && !opts.force) {
+    process.stderr.write(`Error: server '${name}' already exists. Use --force to overwrite.\n`);
+    process.exit(1);
+  }
+
+  process.stdout.write(`[mcp] connecting to ${name}...\n`);
+  const probe = await probeServer(name, serverConfig);
+  if (probe.ok) {
+    process.stdout.write(
+      chalk.green(`[mcp] ✓ connected — ${probe.tools!.length} tools: ${probe.tools!.join(", ")}\n`),
+    );
+  } else {
+    process.stdout.write(chalk.yellow(`[mcp] ✗ connection failed: ${probe.error}\n`));
+    const _saveAnyway = await clack.confirm({
+      message: "Save anyway?",
+      initialValue: false,
+    });
+    if (clack.isCancel(_saveAnyway) || !_saveAnyway) {
+      process.stdout.write("Aborted.\n");
+      return;
+    }
+  }
+
+  await writeMcpConfig((cfg) => ({
+    mcpServers: { ...cfg.mcpServers, [name]: serverConfig },
+  }));
+  process.stdout.write(`[mcp] saved to ${join(AGENT_DIR, "mcp.json")}\n`);
+}
+
+// ── `opencli mcp list` ────────────────────────────────────────────────────────
+
+async function mcpList(opts: { noProbe?: boolean }): Promise<void> {
+  const config = await loadMcpConfig(AGENT_DIR);
+  if (!config || Object.keys(config.mcpServers).length === 0) {
+    process.stdout.write("No MCP servers configured. Run `opencli mcp add` to add one.\n");
+    return;
+  }
+
+  const entries = Object.entries(config.mcpServers);
+
+  let probeResults: Map<string, ProbeResult> | null = null;
+  if (!opts.noProbe) {
+    const results = await Promise.allSettled(
+      entries.map(async ([name, cfg]) => ({ name, result: await probeServer(name, cfg) })),
+    );
+    probeResults = new Map(
+      results
+        .filter((r) => r.status === "fulfilled")
+        .map((r) => {
+          const { name, result } = (
+            r as PromiseFulfilledResult<{ name: string; result: ProbeResult }>
+          ).value;
+          return [name, result] as [string, ProbeResult];
+        }),
+    );
+  }
+
+  const nameW = 16,
+    transportW = 10,
+    statusW = 10;
+  const header =
+    "NAME".padEnd(nameW) + "TRANSPORT".padEnd(transportW) + "STATUS".padEnd(statusW) + "TOOLS";
+  process.stdout.write(chalk.bold(header) + "\n");
+  process.stdout.write("─".repeat(60) + "\n");
+
+  for (const [name, cfg] of entries) {
+    const transport = cfg.transport;
+    const probe = probeResults?.get(name);
+    let status: string;
+    let tools: string;
+
+    if (!probeResults) {
+      status = "—";
+      tools = "—";
+    } else if (probe?.ok) {
+      status = chalk.green("ok");
+      tools =
+        probe.tools!.length <= 3
+          ? probe.tools!.join(", ")
+          : `${probe.tools!.length} (${probe.tools!.slice(0, 3).join(", ")}, ...)`;
+    } else {
+      status = chalk.red("error");
+      tools = "—";
+    }
+
+    process.stdout.write(
+      name.padEnd(nameW) + transport.padEnd(transportW) + status.padEnd(statusW) + tools + "\n",
+    );
+  }
+}
+
+// ── `opencli mcp test` ────────────────────────────────────────────────────────
+
+async function mcpTest(name: string): Promise<void> {
+  const config = await loadMcpConfig(AGENT_DIR);
+  const serverConfig = config?.mcpServers[name];
+  if (!serverConfig) {
+    process.stderr.write(`Error: no server named '${name}' in mcp.json.\n`);
+    process.exit(1);
+  }
+
+  process.stdout.write(`[mcp] connecting to ${name}...\n`);
+  const probe = await probeServer(name, serverConfig);
+  if (probe.ok) {
+    process.stdout.write(
+      chalk.green(`[mcp] ✓ ok — ${probe.tools!.length} tools advertised in ${probe.latencyMs}ms\n`),
+    );
+    for (const t of probe.tools!) {
+      process.stdout.write(`       • ${t}\n`);
+    }
+    process.exit(0);
+  } else {
+    process.stderr.write(chalk.red(`[mcp] ✗ failed: ${probe.error}\n`));
+    process.exit(1);
+  }
+}
+
+// ── `opencli mcp remove` ─────────────────────────────────────────────────────
+
+async function mcpRemove(name: string, opts: { yes?: boolean }): Promise<void> {
+  const config = await loadMcpConfig(AGENT_DIR);
+  if (!config?.mcpServers[name]) {
+    process.stderr.write(`Error: no server named '${name}' in mcp.json.\n`);
+    process.exit(1);
+  }
+
+  if (!opts.yes) {
+    const confirm = await clack.confirm({
+      message: `Remove '${name}' from ${join(AGENT_DIR, "mcp.json")}?`,
+      initialValue: false,
+    });
+    if (clack.isCancel(confirm) || !confirm) {
+      process.stdout.write("Cancelled.\n");
+      return;
+    }
+  }
+
+  await writeMcpConfig((cfg) => ({
+    mcpServers: Object.fromEntries(Object.entries(cfg.mcpServers).filter(([k]) => k !== name)),
+  }));
+  process.stdout.write(`Removed '${name}'.\n`);
+}
+
+// ── Register subcommands on the commander instance ───────────────────────────
+
+export function registerMcpCommand(program: Command): void {
+  const mcp = program.command("mcp").description("Manage MCP server connections");
+
+  mcp
+    .command("add [name] [rest...]")
+    .description("Add an MCP server to ~/.opencli/mcp.json")
+    .option("--transport <transport>", "Transport type: stdio | http (default: stdio)")
+    .option("--url <url>", "Server URL (http transport)")
+    .option("--header <header...>", 'Header in "Key: Value" format (http transport)')
+    .option("--force", "Overwrite existing entry")
+    .action(async (name: string | undefined, rest: string[], opts) => {
+      await mcpAdd(
+        name,
+        rest,
+        opts as { transport?: string; url?: string; header?: string[]; force?: boolean },
+      );
+    });
+
+  mcp
+    .command("list")
+    .description("List configured MCP servers and their status")
+    .option("--no-probe", "Skip connection probe (faster, good for scripts)")
+    .action(async (opts) => {
+      await mcpList({ noProbe: !(opts as { probe: boolean }).probe });
+    });
+
+  mcp
+    .command("test <name>")
+    .description("Test connection to a configured MCP server")
+    .action(async (name: string) => {
+      await mcpTest(name);
+    });
+
+  mcp
+    .command("remove <name>")
+    .description("Remove an MCP server from ~/.opencli/mcp.json")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .action(async (name: string, opts) => {
+      await mcpRemove(name, opts as { yes?: boolean });
+    });
+}

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -7,6 +7,9 @@ import type { SkillRegistry } from "../skills/registry.js";
 import { loadSkillFile, processBody } from "../skills/loader.js";
 import { join } from "node:path";
 import { readLine, selectKey, loadHistory, saveHistory, type SlashCommand } from "./input.js";
+import { probeServer } from "./mcp-cmd.js";
+import { loadMcpConfig } from "../mcp/config.js";
+import { AGENT_DIR } from "../state/config.js";
 import type { ConfirmFn } from "../core/executor.js";
 import { loadConfig, saveConfig } from "../state/config.js";
 import { loadSettings, saveSettings } from "../state/settings.js";
@@ -41,8 +44,22 @@ export async function createConfirmFn(): Promise<ConfirmFn> {
   return async (toolName, args) => {
     if (!process.stdin.isTTY) return "deny";
 
-    const key = `${toolName}:${JSON.stringify(args)}`;
-    if (globalAllowSet.has(key) || projectAllowSet.has(key)) return "allow";
+    const exactKey = `${toolName}:${JSON.stringify(args)}`;
+    const toolWildcard = `${toolName}:*`;
+
+    // Derive MCP server wildcard from name like mcp__<server>__<tool>
+    const mcpMatch = toolName.match(/^mcp__([^_][^_]*)__/);
+    const serverWildcard = mcpMatch ? `mcp__${mcpMatch[1]}__*` : null;
+
+    const isAllowed = (key: string) => globalAllowSet.has(key) || projectAllowSet.has(key);
+
+    if (
+      isAllowed(exactKey) ||
+      isAllowed(toolWildcard) ||
+      (serverWildcard && isAllowed(serverWildcard))
+    ) {
+      return "allow";
+    }
 
     const detail =
       toolName === "bash"
@@ -54,22 +71,38 @@ export async function createConfirmFn(): Promise<ConfirmFn> {
     process.stderr.write(chalk.yellow(`\n  ⚠  ${toolName} requires confirmation\n`));
     process.stderr.write(chalk.dim(`     ${detail}\n`));
 
-    const choice = await selectKey(`Allow ${toolName}?`, [
+    const isMcp = toolName.startsWith("mcp__");
+    const options: Array<{ key: string; label: string }> = [
       { key: "y", label: "Yes, run once" },
       { key: "p", label: "Yes, always for this project  (.opencli/settings.json)" },
       { key: "g", label: "Yes, always globally          (~/.opencli/config.json)" },
-      { key: "n", label: "No, skip" },
-    ]);
+    ];
+    if (isMcp) {
+      options.push({ key: "t", label: `Yes, always for this tool, any args  (project)` });
+      options.push({
+        key: "s",
+        label: `Yes, always for any tool from '${mcpMatch![1]}'  (project)`,
+      });
+    }
+    options.push({ key: "n", label: "No, skip" });
+
+    const choice = await selectKey(`Allow ${toolName}?`, options);
 
     if (choice === null || choice === "n") return "deny";
 
     if (choice === "p") {
-      projectAllowSet.add(key);
+      projectAllowSet.add(exactKey);
       await saveSettings({ permissions: { allow: [...projectAllowSet] } });
     } else if (choice === "g") {
-      globalAllowSet.add(key);
+      globalAllowSet.add(exactKey);
       const cfg = await loadConfig();
       await saveConfig({ permissions: { ...cfg.permissions, allow: [...globalAllowSet] } });
+    } else if (choice === "t") {
+      projectAllowSet.add(toolWildcard);
+      await saveSettings({ permissions: { allow: [...projectAllowSet] } });
+    } else if (choice === "s" && serverWildcard) {
+      projectAllowSet.add(serverWildcard);
+      await saveSettings({ permissions: { allow: [...projectAllowSet] } });
     }
 
     return "allow";
@@ -80,6 +113,7 @@ export async function runRepl(
   agent: Agent,
   skills: SkillRegistry,
   resumeSessionId?: string,
+  onExit?: () => Promise<void>,
 ): Promise<void> {
   agent.setConfirmFn(await createConfirmFn());
   printInfo(`OpenCLI — type /help for commands, Ctrl+C to exit\n`);
@@ -103,7 +137,7 @@ export async function runRepl(
   const allCommands = [...BUILTIN_COMMANDS, ...skillCommands];
 
   while (true) {
-    const raw = await readLine(history, allCommands);
+    const raw = await readLine(history, allCommands, { onExit });
 
     // EOF (Ctrl+D)
     if (raw === null) break;
@@ -162,6 +196,44 @@ export async function runRepl(
         `I have approved the following plan. Execute it step by step, checking off each item as you complete it:\n\n${finalPlan}`,
         "react",
       );
+      continue;
+    }
+
+    // /mcp — quick MCP management from within the REPL
+    if (input === "/mcp" || input.startsWith("/mcp ")) {
+      const subArg = input.slice(4).trim();
+      if (!subArg || subArg === "list") {
+        const config = await loadMcpConfig(AGENT_DIR);
+        if (!config || Object.keys(config.mcpServers).length === 0) {
+          printInfo("No MCP servers configured. Run `opencli mcp add` to add one.\n");
+        } else {
+          for (const [name, cfg] of Object.entries(config.mcpServers)) {
+            process.stderr.write(chalk.bold(name) + chalk.dim(` [${cfg.transport}]`) + "\n");
+          }
+        }
+      } else if (subArg.startsWith("test ")) {
+        const serverName = subArg.slice(5).trim();
+        const config = await loadMcpConfig(AGENT_DIR);
+        const serverConfig = config?.mcpServers[serverName];
+        if (!serverConfig) {
+          printError(`No server named '${serverName}' in mcp.json.`);
+        } else {
+          process.stderr.write(`[mcp] connecting to ${serverName}...\n`);
+          const probe = await probeServer(serverName, serverConfig);
+          if (probe.ok) {
+            process.stderr.write(
+              chalk.green(`[mcp] ✓ ok — ${probe.tools!.length} tools in ${probe.latencyMs}ms\n`),
+            );
+            for (const t of probe.tools!) {
+              process.stderr.write(`       • ${t}\n`);
+            }
+          } else {
+            printError(`[mcp] ✗ ${probe.error}`);
+          }
+        }
+      } else {
+        printError(`Unknown /mcp subcommand. Use /mcp or /mcp test <name>.`);
+      }
       continue;
     }
 

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -48,7 +48,8 @@ export async function createConfirmFn(): Promise<ConfirmFn> {
     const toolWildcard = `${toolName}:*`;
 
     // Derive MCP server wildcard from name like mcp__<server>__<tool>
-    const mcpMatch = toolName.match(/^mcp__([^_][^_]*)__/);
+    // Use lazy .+? so server names containing _ (e.g. my_server) match correctly.
+    const mcpMatch = toolName.match(/^mcp__(.+?)__/);
     const serverWildcard = mcpMatch ? `mcp__${mcpMatch[1]}__*` : null;
 
     const isAllowed = (key: string) => globalAllowSet.has(key) || projectAllowSet.has(key);

--- a/src/core/executor.test.ts
+++ b/src/core/executor.test.ts
@@ -248,6 +248,7 @@ describe("executeCalls", () => {
       name: "bash",
       description: "",
       parameters: { type: "object", properties: {} },
+      truncateOutput: true,
       execute: async () => ({ success: true, output: big }),
     });
 

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -6,10 +6,9 @@ import type { SkillRegistry } from "../skills/registry.js";
 import type { ContextManager } from "./context.js";
 import type { ObservabilityHandler } from "./observability.js";
 
-// Tools whose output is truncated when it exceeds the limit.
+// Output truncation is controlled by Tool.truncateOutput.
 // read is excluded — it supports offset/limit pagination and agents rely on
 // exact line spans for follow-up edit calls.
-const TRUNCATE_TOOLS = new Set(["bash", "grep", "glob"]);
 const DEFAULT_MAX_OUTPUT = 20_000;
 const MAX_TOOL_OUTPUT =
   parseInt(process.env.OPENCLI_MAX_TOOL_OUTPUT ?? "", 10) || DEFAULT_MAX_OUTPUT;
@@ -108,7 +107,7 @@ async function executeOneCall(
   // the actual failure reason.
   const parts = [result.output, result.error && `Error: ${result.error}`].filter(Boolean);
   const raw = parts.join("\n") || "(no output)";
-  const output = TRUNCATE_TOOLS.has(call.name) ? truncateOutput(raw, call.id, deps.tmpDir) : raw;
+  const output = tool?.truncateOutput ? truncateOutput(raw, call.id, deps.tmpDir) : raw;
   deps.obs?.({
     type: "tool_exec_end",
     name: call.name,

--- a/src/mcp/adapter.test.ts
+++ b/src/mcp/adapter.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { mcpToolToTool } from "./adapter.js";
+import type { McpClient } from "./client.js";
+import type { McpToolInfo } from "./types.js";
+
+function makeClient(name: string): McpClient {
+  return { serverName: name, callTool: vi.fn() } as unknown as McpClient;
+}
+
+const info: McpToolInfo = {
+  name: "read_file",
+  description: "Read a file",
+  inputSchema: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+};
+
+describe("mcpToolToTool", () => {
+  const client = makeClient("filesystem");
+  const tool = mcpToolToTool(client, "filesystem", info);
+
+  it("generates name as mcp__server__tool", () => {
+    expect(tool.name).toBe("mcp__filesystem__read_file");
+  });
+
+  it("prefixes description with server name", () => {
+    expect(tool.description).toContain("[filesystem]");
+    expect(tool.description).toContain("Read a file");
+  });
+
+  it("sets readonly: false (blocked in plan mode)", () => {
+    expect(tool.readonly).toBe(false);
+  });
+
+  it("sets truncateOutput: true", () => {
+    expect(tool.truncateOutput).toBe(true);
+  });
+
+  it("requiresConfirmation always returns true", () => {
+    expect(tool.requiresConfirmation?.({})).toBe(true);
+  });
+
+  it("execute delegates to client.callTool with original tool name (not namespaced)", async () => {
+    const mockResult = { success: true, output: "contents" };
+    (client.callTool as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult);
+    const result = await tool.execute({ path: "/tmp/foo" });
+    expect(client.callTool).toHaveBeenCalledWith("read_file", { path: "/tmp/foo" });
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/mcp/adapter.ts
+++ b/src/mcp/adapter.ts
@@ -1,0 +1,32 @@
+import type { Tool } from "../tools/base.js";
+import type { McpClient } from "./client.js";
+import type { McpToolInfo } from "./types.js";
+
+/**
+ * Bridges one MCP tool into an OpenCLI Tool.
+ *
+ * Name format: mcp__<sanitisedServerName>__<toolName>
+ * (double-underscore, matching Claude Code's convention for compatibility)
+ *
+ * All MCP tools require HITL confirmation and are blocked in plan mode.
+ * truncateOutput is set so the executor caps oversized payloads identically
+ * to bash/grep/glob.
+ *
+ * The adapter receives the already-sanitised server name from the manager —
+ * it does not sanitise itself, to avoid one warning per tool from the same server.
+ */
+export function mcpToolToTool(
+  client: McpClient,
+  sanitisedServerName: string,
+  info: McpToolInfo,
+): Tool {
+  return {
+    name: `mcp__${sanitisedServerName}__${info.name}`,
+    description: `[${client.serverName}] ${info.description}`,
+    parameters: info.inputSchema as unknown as Tool["parameters"],
+    readonly: false,
+    truncateOutput: true,
+    requiresConfirmation: () => true,
+    execute: (params) => client.callTool(info.name, params),
+  };
+}

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { McpClient } from "./client.js";
+
+/**
+ * Build a paired (clientTransport, server) where the server advertises an
+ * "echo" tool that returns whatever text argument is passed.
+ */
+async function makeTestPair(overrides?: {
+  isError?: boolean;
+  includeImage?: boolean;
+}): Promise<{ clientTransport: InMemoryTransport; server: Server }> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = new Server({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: [
+      {
+        name: "echo",
+        description: "Echo input",
+        inputSchema: {
+          type: "object",
+          properties: { text: { type: "string" } },
+          required: ["text"],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, (req) => {
+    const text = (req.params.arguments as Record<string, string>)?.text ?? "";
+    const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [
+      { type: "text", text },
+    ];
+    if (overrides?.includeImage) {
+      content.push({ type: "image", data: "base64data", mimeType: "image/png" });
+    }
+    return { content, isError: overrides?.isError ?? false };
+  });
+
+  await server.connect(serverTransport);
+  return { clientTransport, server };
+}
+
+describe("McpClient", () => {
+  let client: McpClient;
+  let server: Server;
+
+  beforeEach(async () => {
+    const { clientTransport, server: s } = await makeTestPair();
+    server = s;
+    // Inject the in-memory transport by temporarily patching connect
+    client = new McpClient("test", { transport: "stdio", command: "unused" });
+    // Access the private sdkClient field via casting
+    const sdk = await import("@modelcontextprotocol/sdk/client/index.js");
+    (client as unknown as { sdkClient: InstanceType<typeof sdk.Client> }).sdkClient =
+      new sdk.Client({ name: "opencli", version: "0.1.0" });
+    await (client as unknown as { sdkClient: InstanceType<typeof sdk.Client> }).sdkClient.connect(
+      clientTransport,
+    );
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("listTools returns tool list", async () => {
+    const tools = await client.listTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("echo");
+    expect(tools[0].description).toBe("Echo input");
+  });
+
+  it("callTool returns success with text output", async () => {
+    const result = await client.callTool("echo", { text: "hello" });
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("hello");
+  });
+
+  it("callTool with isError:true returns success:false", async () => {
+    const { clientTransport, server: s } = await makeTestPair({ isError: true });
+    server = s;
+    const errorClient = new McpClient("test-err", { transport: "stdio", command: "unused" });
+    const sdk = await import("@modelcontextprotocol/sdk/client/index.js");
+    (errorClient as unknown as { sdkClient: InstanceType<typeof sdk.Client> }).sdkClient =
+      new sdk.Client({ name: "opencli", version: "0.1.0" });
+    await (
+      errorClient as unknown as { sdkClient: InstanceType<typeof sdk.Client> }
+    ).sdkClient.connect(clientTransport);
+    const result = await errorClient.callTool("echo", { text: "oops" });
+    expect(result.success).toBe(false);
+    await errorClient.close();
+  });
+
+  it("drops non-text content and appends omission note", async () => {
+    const { clientTransport, server: s } = await makeTestPair({ includeImage: true });
+    server = s;
+    const imgClient = new McpClient("test-img", { transport: "stdio", command: "unused" });
+    const sdk = await import("@modelcontextprotocol/sdk/client/index.js");
+    (imgClient as unknown as { sdkClient: InstanceType<typeof sdk.Client> }).sdkClient =
+      new sdk.Client({ name: "opencli", version: "0.1.0" });
+    await (
+      imgClient as unknown as { sdkClient: InstanceType<typeof sdk.Client> }
+    ).sdkClient.connect(clientTransport);
+    const result = await imgClient.callTool("echo", { text: "hi" });
+    expect(result.output).toContain("hi");
+    expect(result.output).toContain("non-text content block(s) omitted");
+    await imgClient.close();
+  });
+
+  it("returns success:false on timeout", async () => {
+    // Use a 1ms timeout to force a timeout error
+    const fastTimeoutClient = new McpClient("test-timeout", {
+      transport: "stdio",
+      command: "unused",
+      callTimeout: 1,
+    });
+    const sdk = await import("@modelcontextprotocol/sdk/client/index.js");
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const slowServer = new Server(
+      { name: "slow", version: "0.0.1" },
+      { capabilities: { tools: {} } },
+    );
+    slowServer.setRequestHandler(CallToolRequestSchema, () => new Promise(() => {})); // never resolves
+    await slowServer.connect(st);
+    (fastTimeoutClient as unknown as { sdkClient: InstanceType<typeof sdk.Client> }).sdkClient =
+      new sdk.Client({ name: "opencli", version: "0.1.0" });
+    await (
+      fastTimeoutClient as unknown as { sdkClient: InstanceType<typeof sdk.Client> }
+    ).sdkClient.connect(ct);
+    const result = await fastTimeoutClient.callTool("echo", {});
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/timeout/i);
+    await fastTimeoutClient.close();
+    await slowServer.close();
+  });
+
+  it("per-server callTimeout overrides global default", () => {
+    const c1 = new McpClient("srv", { transport: "stdio", command: "x", callTimeout: 5000 });
+    expect((c1 as unknown as { callTimeout: number }).callTimeout).toBe(5000);
+    const c2 = new McpClient("srv", { transport: "stdio", command: "x" }, { callTimeout: 9000 });
+    expect((c2 as unknown as { callTimeout: number }).callTimeout).toBe(9000);
+    const c3 = new McpClient(
+      "srv",
+      { transport: "stdio", command: "x", callTimeout: 3000 },
+      { callTimeout: 9000 },
+    );
+    // Per-server wins over global default
+    expect((c3 as unknown as { callTimeout: number }).callTimeout).toBe(3000);
+  });
+});

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,86 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { ToolResult } from "../providers/types.js";
+import type { McpServerConfig, McpToolInfo } from "./types.js";
+
+export interface McpClientOpts {
+  /** Per-call timeout in milliseconds. Default: 30_000. */
+  callTimeout?: number;
+}
+
+export class McpClient {
+  readonly serverName: string;
+  private config: McpServerConfig;
+  private callTimeout: number;
+  private sdkClient!: Client;
+
+  constructor(name: string, config: McpServerConfig, opts?: McpClientOpts) {
+    this.serverName = name;
+    this.config = config;
+    // Per-server callTimeout overrides the global default
+    this.callTimeout = config.callTimeout ?? opts?.callTimeout ?? 30_000;
+  }
+
+  async connect(): Promise<void> {
+    let transport;
+    if (this.config.transport === "http") {
+      transport = new StreamableHTTPClientTransport(new URL(this.config.url), {
+        requestInit: { headers: this.config.headers },
+      });
+    } else {
+      const childEnv: Record<string, string> = {
+        ...(process.env as Record<string, string>),
+        ...(this.config.env ?? {}),
+      };
+      transport = new StdioClientTransport({
+        command: this.config.command,
+        args: this.config.args,
+        env: childEnv,
+      });
+    }
+    this.sdkClient = new Client({ name: "opencli", version: "0.1.0" });
+    await this.sdkClient.connect(transport);
+  }
+
+  async listTools(): Promise<McpToolInfo[]> {
+    const response = await this.sdkClient.listTools();
+    return response.tools.map((t) => ({
+      name: t.name,
+      description: t.description ?? "",
+      inputSchema: (t.inputSchema as Record<string, unknown>) ?? { type: "object" },
+    }));
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<ToolResult> {
+    try {
+      const result = await this.sdkClient.callTool({ name: toolName, arguments: args }, undefined, {
+        signal: AbortSignal.timeout(this.callTimeout),
+      });
+      const content = result.content as Array<{ type: string; text?: string }>;
+      const textParts = content.filter((c) => c.type === "text").map((c) => c.text ?? "");
+      const droppedNonText = content.length - textParts.length;
+      let output = textParts.join("\n");
+      if (droppedNonText > 0) {
+        output += `\n[${droppedNonText} non-text content block(s) omitted]`;
+      }
+      return result.isError
+        ? { success: false, output, error: output || "MCP tool returned an error" }
+        : { success: true, output };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const isTimeout = err instanceof Error && err.name === "TimeoutError";
+      return {
+        success: false,
+        output: "",
+        error: isTimeout
+          ? `MCP tool '${toolName}' timed out after ${this.callTimeout}ms`
+          : `MCP tool '${toolName}' failed: ${message}`,
+      };
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.sdkClient?.close();
+  }
+}

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -40,7 +40,16 @@ export class McpClient {
       });
     }
     this.sdkClient = new Client({ name: "opencli", version: "0.1.0" });
-    await this.sdkClient.connect(transport);
+    try {
+      await this.sdkClient.connect(transport);
+    } catch (err) {
+      try {
+        await transport.close();
+      } catch {
+        // ignore close errors; the connect error is what matters
+      }
+      throw err;
+    }
   }
 
   async listTools(): Promise<McpToolInfo[]> {

--- a/src/mcp/config.test.ts
+++ b/src/mcp/config.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadMcpConfig } from "./config.js";
+
+describe("loadMcpConfig", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `mcp-config-test-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when mcp.json does not exist", async () => {
+    const result = await loadMcpConfig(dir);
+    expect(result).toBeNull();
+  });
+
+  it("returns null with a warning when mcp.json is malformed JSON", async () => {
+    await writeFile(join(dir, "mcp.json"), "{ bad json", "utf8");
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const result = await loadMcpConfig(dir);
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("parse error"));
+    spy.mockRestore();
+  });
+
+  it("parses a valid stdio server config", async () => {
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          filesystem: { transport: "stdio", command: "npx", args: ["-y", "some-server"] },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    expect(result).not.toBeNull();
+    expect(result!.mcpServers["filesystem"]).toMatchObject({
+      transport: "stdio",
+      command: "npx",
+    });
+  });
+
+  it("defaults absent transport to 'stdio' for Claude Desktop compat", async () => {
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({ mcpServers: { myserver: { command: "node", args: ["server.js"] } } }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    expect((result!.mcpServers["myserver"] as { transport: string }).transport).toBe("stdio");
+  });
+
+  it("expands ${VAR} in string values", async () => {
+    process.env["MCP_TEST_TOKEN"] = "secret123";
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          github: {
+            transport: "http",
+            url: "http://localhost:3000",
+            headers: { Authorization: "Bearer ${MCP_TEST_TOKEN}" },
+          },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    const headers = (result!.mcpServers["github"] as { headers: Record<string, string> }).headers;
+    expect(headers?.["Authorization"]).toBe("Bearer secret123");
+    delete process.env["MCP_TEST_TOKEN"];
+  });
+
+  it("leaves bare $VAR unexpanded", async () => {
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          srv: { transport: "http", url: "http://localhost", headers: { X: "$BARE_VAR" } },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    const headers = (result!.mcpServers["srv"] as { headers: Record<string, string> }).headers;
+    expect(headers?.["X"]).toBe("$BARE_VAR");
+  });
+
+  it("resolves $${ escape to literal ${", async () => {
+    process.env["NEVER_SET_XYZ"] = "should-not-expand";
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          srv: { transport: "http", url: "http://localhost", headers: { X: "$${LITERAL}" } },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    const headers = (result!.mcpServers["srv"] as { headers: Record<string, string> }).headers;
+    expect(headers?.["X"]).toBe("${LITERAL}");
+    delete process.env["NEVER_SET_XYZ"];
+  });
+
+  it("warns and substitutes empty string for unset ${VAR}", async () => {
+    delete process.env["DEFINITELY_UNSET_MCP_VAR"];
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          srv: {
+            transport: "http",
+            url: "http://localhost",
+            headers: { X: "${DEFINITELY_UNSET_MCP_VAR}" },
+          },
+        },
+      }),
+      "utf8",
+    );
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const result = await loadMcpConfig(dir);
+    const headers = (result!.mcpServers["srv"] as { headers: Record<string, string> }).headers;
+    expect(headers?.["X"]).toBe("");
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("DEFINITELY_UNSET_MCP_VAR"));
+    spy.mockRestore();
+  });
+
+  it("parses per-server callTimeout", async () => {
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: { fast: { transport: "stdio", command: "echo", callTimeout: 5000 } },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    expect(result!.mcpServers["fast"].callTimeout).toBe(5000);
+  });
+});

--- a/src/mcp/config.test.ts
+++ b/src/mcp/config.test.ts
@@ -145,4 +145,100 @@ describe("loadMcpConfig", () => {
     const result = await loadMcpConfig(dir);
     expect(result!.mcpServers["fast"].callTimeout).toBe(5000);
   });
+
+  it("expands ${VAR} in stdio command and args", async () => {
+    process.env["MCP_BIN"] = "/usr/local/bin/mcp";
+    process.env["MCP_FLAG"] = "--port=3000";
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          srv: {
+            transport: "stdio",
+            command: "${MCP_BIN}",
+            args: ["${MCP_FLAG}", "static"],
+          },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    const srv = result!.mcpServers["srv"] as { command: string; args: string[] };
+    expect(srv.command).toBe("/usr/local/bin/mcp");
+    expect(srv.args).toEqual(["--port=3000", "static"]);
+    delete process.env["MCP_BIN"];
+    delete process.env["MCP_FLAG"];
+  });
+
+  it("expands ${VAR} in http url", async () => {
+    process.env["MCP_API_BASE"] = "https://api.example.com";
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          api: { transport: "http", url: "${MCP_API_BASE}/mcp" },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    const api = result!.mcpServers["api"] as { url: string };
+    expect(api.url).toBe("https://api.example.com/mcp");
+    delete process.env["MCP_API_BASE"];
+  });
+
+  it("skips stdio server with missing command and warns", async () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          bad: { transport: "stdio" },
+          good: { transport: "stdio", command: "echo" },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    expect(result!.mcpServers["bad"]).toBeUndefined();
+    expect(result!.mcpServers["good"]).toBeDefined();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("missing required 'command'"));
+    spy.mockRestore();
+  });
+
+  it("skips http server with missing url and warns", async () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          bad: { transport: "http" },
+          good: { transport: "http", url: "http://localhost:3000" },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    expect(result!.mcpServers["bad"]).toBeUndefined();
+    expect(result!.mcpServers["good"]).toBeDefined();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("missing required 'url'"));
+    spy.mockRestore();
+  });
+
+  it("ignores non-numeric callTimeout and warns", async () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await writeFile(
+      join(dir, "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          srv: { transport: "stdio", command: "echo", callTimeout: "30000" },
+        },
+      }),
+      "utf8",
+    );
+    const result = await loadMcpConfig(dir);
+    expect(result!.mcpServers["srv"].callTimeout).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("callTimeout"));
+    spy.mockRestore();
+  });
 });

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { McpConfig, McpServerConfig } from "./types.js";
+
+const EXPAND_RE = /\$\$\{|\$\{([^}]+)\}/g;
+
+/**
+ * Expand ${VAR} references against process.env in a string value.
+ * - $${  → literal ${  (escape sequence)
+ * - ${VAR} → process.env.VAR (empty string + warning if unset)
+ * - bare $VAR is left as-is (not expanded)
+ */
+function expandEnvVars(value: string, context: string): string {
+  return value.replace(EXPAND_RE, (match, varName?: string) => {
+    if (match === "$${") return "${";
+    if (varName === undefined) return match;
+    const val = process.env[varName];
+    if (val === undefined) {
+      process.stderr.write(
+        `[mcp] warn: ${context}: env var '\${${varName}}' is not set — substituting empty string\n`,
+      );
+      return "";
+    }
+    return val;
+  });
+}
+
+function expandServerConfig(name: string, config: McpServerConfig): McpServerConfig {
+  if (config.transport === "http") {
+    const headers = config.headers
+      ? Object.fromEntries(
+          Object.entries(config.headers).map(([k, v]) => [k, expandEnvVars(v, name)]),
+        )
+      : undefined;
+    return { ...config, headers };
+  }
+  // stdio: expand env values
+  const env = config.env
+    ? Object.fromEntries(Object.entries(config.env).map(([k, v]) => [k, expandEnvVars(v, name)]))
+    : undefined;
+  return { ...config, env };
+}
+
+export async function loadMcpConfig(agentDir: string): Promise<McpConfig | null> {
+  const configPath = join(agentDir, "mcp.json");
+  let raw: string;
+  try {
+    raw = await readFile(configPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[mcp] warn: mcp.json parse error — ${msg}; skipping MCP\n`);
+    return null;
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as Record<string, unknown>).mcpServers !== "object"
+  ) {
+    process.stderr.write(`[mcp] warn: mcp.json missing 'mcpServers' object; skipping MCP\n`);
+    return null;
+  }
+
+  const raw_servers = (parsed as { mcpServers: Record<string, unknown> }).mcpServers;
+  const mcpServers: Record<string, McpServerConfig> = {};
+
+  for (const [name, serverRaw] of Object.entries(raw_servers)) {
+    if (typeof serverRaw !== "object" || serverRaw === null) continue;
+    const server = serverRaw as Record<string, unknown>;
+
+    // Default absent transport to "stdio" for Claude Desktop compat
+    const transport = (server.transport as string | undefined) ?? "stdio";
+
+    let config: McpServerConfig;
+    if (transport === "http") {
+      config = {
+        transport: "http",
+        url: server.url as string,
+        headers: server.headers as Record<string, string> | undefined,
+        callTimeout: server.callTimeout as number | undefined,
+      };
+    } else {
+      config = {
+        transport: "stdio",
+        command: server.command as string,
+        args: server.args as string[] | undefined,
+        env: server.env as Record<string, string> | undefined,
+        callTimeout: server.callTimeout as number | undefined,
+      };
+    }
+
+    mcpServers[name] = expandServerConfig(name, config);
+  }
+
+  return { mcpServers };
+}

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -27,18 +27,21 @@ function expandEnvVars(value: string, context: string): string {
 
 function expandServerConfig(name: string, config: McpServerConfig): McpServerConfig {
   if (config.transport === "http") {
+    const url = expandEnvVars(config.url, name);
     const headers = config.headers
       ? Object.fromEntries(
           Object.entries(config.headers).map(([k, v]) => [k, expandEnvVars(v, name)]),
         )
       : undefined;
-    return { ...config, headers };
+    return { ...config, url, headers };
   }
-  // stdio: expand env values
+  // stdio: expand command, args, and env values
+  const command = expandEnvVars(config.command, name);
+  const args = config.args?.map((a) => expandEnvVars(a, name));
   const env = config.env
     ? Object.fromEntries(Object.entries(config.env).map(([k, v]) => [k, expandEnvVars(v, name)]))
     : undefined;
-  return { ...config, env };
+  return { ...config, command, args, env };
 }
 
 export async function loadMcpConfig(agentDir: string): Promise<McpConfig | null> {
@@ -78,21 +81,37 @@ export async function loadMcpConfig(agentDir: string): Promise<McpConfig | null>
     // Default absent transport to "stdio" for Claude Desktop compat
     const transport = (server.transport as string | undefined) ?? "stdio";
 
+    if (server.callTimeout !== undefined && typeof server.callTimeout !== "number") {
+      process.stderr.write(
+        `[mcp] warn: server '${name}': 'callTimeout' must be a number; ignoring\n`,
+      );
+      server.callTimeout = undefined;
+    }
+    const callTimeout = server.callTimeout as number | undefined;
+
     let config: McpServerConfig;
     if (transport === "http") {
+      if (typeof server.url !== "string" || !server.url) {
+        process.stderr.write(`[mcp] warn: server '${name}' missing required 'url'; skipping\n`);
+        continue;
+      }
       config = {
         transport: "http",
-        url: server.url as string,
+        url: server.url,
         headers: server.headers as Record<string, string> | undefined,
-        callTimeout: server.callTimeout as number | undefined,
+        callTimeout,
       };
     } else {
+      if (typeof server.command !== "string" || !server.command) {
+        process.stderr.write(`[mcp] warn: server '${name}' missing required 'command'; skipping\n`);
+        continue;
+      }
       config = {
         transport: "stdio",
-        command: server.command as string,
+        command: server.command,
         args: server.args as string[] | undefined,
         env: server.env as Record<string, string> | undefined,
-        callTimeout: server.callTimeout as number | undefined,
+        callTimeout,
       };
     }
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,6 @@
+export { McpManager } from "./manager.js";
+export { McpClient } from "./client.js";
+export { mcpToolToTool } from "./adapter.js";
+export { loadMcpConfig } from "./config.js";
+export type { McpConfig, McpServerConfig, McpToolInfo } from "./types.js";
+export type { McpClientOpts } from "./client.js";

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpManager } from "./manager.js";
+import { McpClient } from "./client.js";
+import { ToolRegistry } from "../tools/registry.js";
+import type { McpConfig } from "./types.js";
+
+/** Wire a McpClient to an in-process Server via InMemoryTransport. */
+async function wireClient(client: McpClient, server: Server): Promise<void> {
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  await server.connect(st);
+  const sdkClient = new Client({ name: "opencli", version: "0.1.0" });
+  (client as unknown as { sdkClient: Client }).sdkClient = sdkClient;
+  await sdkClient.connect(ct);
+}
+
+function makeEchoServer(): Server {
+  const s = new Server({ name: "echo-srv", version: "0.0.1" }, { capabilities: { tools: {} } });
+  s.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: [
+      {
+        name: "echo",
+        description: "Echo",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      },
+    ],
+  }));
+  s.setRequestHandler(CallToolRequestSchema, () => ({
+    content: [{ type: "text", text: "ok" }],
+  }));
+  return s;
+}
+
+describe("McpManager", () => {
+  const servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(servers.map((s) => s.close()));
+    servers.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("registers tools from connected servers into the registry", async () => {
+    const s = makeEchoServer();
+    servers.push(s);
+    const config: McpConfig = {
+      mcpServers: { myserver: { transport: "stdio", command: "unused" } },
+    };
+
+    // Patch McpClient.connect to wire to in-memory server
+    vi.spyOn(McpClient.prototype, "connect").mockImplementation(async function (this: McpClient) {
+      await wireClient(this, s);
+    });
+
+    const manager = await McpManager.create(config);
+    const registry = new ToolRegistry();
+    await manager.registerTools(registry);
+
+    const tool = registry.get("mcp__myserver__echo");
+    expect(tool).toBeDefined();
+    expect(tool!.name).toBe("mcp__myserver__echo");
+  });
+
+  it("one server failing does not block others", async () => {
+    const good = makeEchoServer();
+    servers.push(good);
+
+    vi.spyOn(McpClient.prototype, "connect").mockImplementation(async function (this: McpClient) {
+      if (this.serverName === "bad") throw new Error("connection refused");
+      await wireClient(this, good);
+    });
+
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const config: McpConfig = {
+      mcpServers: {
+        bad: { transport: "stdio", command: "bad-cmd" },
+        good: { transport: "stdio", command: "good-cmd" },
+      },
+    };
+    const manager = await McpManager.create(config);
+    expect(manager.connectedCount).toBe(1);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("bad"));
+    spy.mockRestore();
+  });
+
+  it("sanitises server name and logs once per server (not per tool)", async () => {
+    const s = makeEchoServer();
+    servers.push(s);
+
+    vi.spyOn(McpClient.prototype, "connect").mockImplementation(async function (this: McpClient) {
+      await wireClient(this, s);
+    });
+
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const config: McpConfig = {
+      mcpServers: { "my-weird.server": { transport: "stdio", command: "x" } },
+    };
+    const manager = await McpManager.create(config);
+    const registry = new ToolRegistry();
+    await manager.registerTools(registry);
+
+    const sanitisationWarnings = (spy.mock.calls as [string][])
+      .map(([msg]) => msg)
+      .filter((m) => m.includes("sanitised"));
+    expect(sanitisationWarnings).toHaveLength(1);
+
+    const tool = registry.get("mcp__my-weird_server__echo");
+    expect(tool).toBeDefined();
+    spy.mockRestore();
+  });
+
+  it("skips second server whose name collides after sanitisation", async () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const collidingConfig: McpConfig = {
+      mcpServers: {
+        "srv a": { transport: "stdio", command: "x" },
+        "srv.a": { transport: "stdio", command: "y" },
+      },
+    };
+    vi.spyOn(McpClient.prototype, "connect").mockImplementation(async () => {});
+    const manager = await McpManager.create(collidingConfig);
+    expect(manager.connectedCount).toBe(1);
+    const collisionMsg = (spy.mock.calls as [string][])
+      .map(([msg]) => msg)
+      .find((m) => m.includes("collides"));
+    expect(collisionMsg).toBeDefined();
+    spy.mockRestore();
+  });
+
+  it("listTools failure on one server does not block others from registering", async () => {
+    const good = makeEchoServer();
+    servers.push(good);
+
+    vi.spyOn(McpClient.prototype, "connect").mockImplementation(async function (this: McpClient) {
+      if (this.serverName === "bad") return; // connects fine
+      await wireClient(this, good);
+    });
+    vi.spyOn(McpClient.prototype, "listTools").mockImplementation(async function (this: McpClient) {
+      if (this.serverName === "bad") throw new Error("listTools failed");
+      return [{ name: "echo", description: "Echo", inputSchema: { type: "object" } }];
+    });
+
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const config: McpConfig = {
+      mcpServers: {
+        bad: { transport: "stdio", command: "x" },
+        good: { transport: "stdio", command: "y" },
+      },
+    };
+    const manager = await McpManager.create(config);
+    const registry = new ToolRegistry();
+    await manager.registerTools(registry);
+
+    expect(registry.get("mcp__good__echo")).toBeDefined();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("listTools failed"));
+    spy.mockRestore();
+  });
+
+  it("disconnectAll closes all clients", async () => {
+    const closeSpy = vi.spyOn(McpClient.prototype, "close").mockResolvedValue(undefined);
+    vi.spyOn(McpClient.prototype, "connect").mockResolvedValue(undefined);
+    const config: McpConfig = {
+      mcpServers: {
+        a: { transport: "stdio", command: "x" },
+        b: { transport: "stdio", command: "y" },
+      },
+    };
+    const manager = await McpManager.create(config);
+    await manager.disconnectAll();
+    expect(closeSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -1,0 +1,104 @@
+import type { ToolRegistry } from "../tools/registry.js";
+import { McpClient, type McpClientOpts } from "./client.js";
+import { mcpToolToTool } from "./adapter.js";
+import type { McpConfig, McpToolInfo } from "./types.js";
+
+interface ConnectedServer {
+  client: McpClient;
+  rawName: string;
+  sanitisedName: string;
+}
+
+type ConnectAttempt =
+  | { ok: true; server: ConnectedServer }
+  | { ok: false; rawName: string; error: unknown };
+
+export class McpManager {
+  private constructor(private servers: ConnectedServer[]) {}
+
+  static async create(config: McpConfig, opts?: McpClientOpts): Promise<McpManager> {
+    const sanitise = (name: string): string => name.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+    // Build sanitised name table up front and detect cross-server collisions before
+    // attempting any connections — silent overwrite would route calls to the wrong server.
+    const sanitisedByRaw = new Map<string, string>();
+    const claimedSanitised = new Map<string, string>();
+    const skippedDueToCollision: string[] = [];
+
+    for (const rawName of Object.keys(config.mcpServers)) {
+      const sanitised = sanitise(rawName);
+      if (sanitised !== rawName) {
+        process.stderr.write(
+          `[mcp] '${rawName}': name sanitised to '${sanitised}' for tool naming\n`,
+        );
+      }
+      const previousClaimer = claimedSanitised.get(sanitised);
+      if (previousClaimer !== undefined) {
+        process.stderr.write(
+          `[mcp] '${rawName}': sanitised name '${sanitised}' collides with '${previousClaimer}' — skipping. Rename one in mcp.json.\n`,
+        );
+        skippedDueToCollision.push(rawName);
+        continue;
+      }
+      claimedSanitised.set(sanitised, rawName);
+      sanitisedByRaw.set(rawName, sanitised);
+    }
+
+    const attempts = await Promise.all(
+      Object.entries(config.mcpServers)
+        .filter(([rawName]) => !skippedDueToCollision.includes(rawName))
+        .map(async ([rawName, serverConfig]): Promise<ConnectAttempt> => {
+          try {
+            const client = new McpClient(rawName, serverConfig, opts);
+            await client.connect();
+            return {
+              ok: true,
+              server: { client, rawName, sanitisedName: sanitisedByRaw.get(rawName)! },
+            };
+          } catch (error) {
+            return { ok: false, rawName, error };
+          }
+        }),
+    );
+
+    const servers: ConnectedServer[] = [];
+    for (const attempt of attempts) {
+      if (attempt.ok) {
+        servers.push(attempt.server);
+      } else {
+        const msg = attempt.error instanceof Error ? attempt.error.message : String(attempt.error);
+        process.stderr.write(`[mcp] '${attempt.rawName}': failed to connect — ${msg}\n`);
+      }
+    }
+    return new McpManager(servers);
+  }
+
+  async registerTools(registry: ToolRegistry): Promise<void> {
+    for (const { client, sanitisedName } of this.servers) {
+      let tools: McpToolInfo[];
+      try {
+        tools = await client.listTools();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[mcp] '${client.serverName}': listTools failed — ${msg}\n`);
+        continue;
+      }
+      for (const info of tools) {
+        registry.register(mcpToolToTool(client, sanitisedName, info));
+      }
+    }
+  }
+
+  async disconnectAll(): Promise<void> {
+    await Promise.allSettled(this.servers.map(({ client }) => client.close()));
+  }
+
+  get connectedCount(): number {
+    return this.servers.length;
+  }
+
+  /** Names of all connected servers (sanitised). Used by mcp-cmd list. */
+  get serverNames(): Array<{ rawName: string; sanitisedName: string }> {
+    return this.servers.map(({ rawName, sanitisedName }) => ({ rawName, sanitisedName }));
+  }
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,33 @@
+/** Stdio-transport server: spawns a subprocess. */
+export interface McpStdioServer {
+  transport: "stdio";
+  command: string;
+  args?: string[];
+  /** Merged over process.env before spawning. */
+  env?: Record<string, string>;
+  /** Per-call timeout in ms; overrides global McpClientOpts.callTimeout. */
+  callTimeout?: number;
+}
+
+/** HTTP-transport server: connects to a running URL (SSE or Streamable HTTP). */
+export interface McpHttpServer {
+  transport: "http";
+  url: string;
+  headers?: Record<string, string>;
+  /** Per-call timeout in ms; overrides global McpClientOpts.callTimeout. */
+  callTimeout?: number;
+}
+
+export type McpServerConfig = McpStdioServer | McpHttpServer;
+
+export interface McpConfig {
+  /** Keyed by server name (e.g. "filesystem", "github"). Names must be [a-zA-Z0-9_-]. */
+  mcpServers: Record<string, McpServerConfig>;
+}
+
+/** Subset of MCP Tool schema used internally. */
+export interface McpToolInfo {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -19,4 +19,6 @@ export interface Tool {
   requiresConfirmation?: (args: Record<string, unknown>) => boolean;
   /** Return an error message string if params are invalid, or null if valid. */
   validate?: (params: Record<string, unknown>) => string | null;
+  /** When true, the executor middle-truncates output that exceeds MAX_TOOL_OUTPUT. */
+  truncateOutput?: boolean;
 }

--- a/src/tools/exec/bash.ts
+++ b/src/tools/exec/bash.ts
@@ -43,6 +43,7 @@ const SAFE_COMMANDS = [
 export function createBashTool(runner: SandboxRunner): Tool {
   return {
     name: "bash",
+    truncateOutput: true,
     description:
       "Execute a shell command and return its output. Avoid destructive operations. Commands timeout after 30 seconds.",
     parameters: {

--- a/src/tools/file/glob.ts
+++ b/src/tools/file/glob.ts
@@ -5,6 +5,7 @@ import type { Tool } from "../base.js";
 export const globTool: Tool = {
   name: "glob",
   readonly: true,
+  truncateOutput: true,
   description:
     "Find files matching a glob pattern. Returns matching file paths sorted by modification time.",
   parameters: {

--- a/src/tools/file/grep.ts
+++ b/src/tools/file/grep.ts
@@ -5,6 +5,7 @@ import type { Tool } from "../base.js";
 export const grepTool: Tool = {
   name: "grep",
   readonly: true,
+  truncateOutput: true,
   description:
     "Search for a regex pattern in file contents. Returns matching lines with file path and line number.",
   parameters: {


### PR DESCRIPTION
## Summary

- **`src/mcp/` layer**: `McpClient` (stdio + HTTP, per-server `callTimeout`), `McpManager` (parallel connect, post-sanitisation collision detection, isolated failure per server), `mcpToolToTool` adapter (`mcp__server__tool` naming), `loadMcpConfig` (`${VAR}` expansion), and a full test suite (38 tests).
- **`opencli mcp` subcommands**: `add` (interactive wizard + one-shot form), `list` (live probe table), `test`, `remove` — with atomic config writes via tmp-rename.
- **REPL commands**: `/mcp` (list) and `/mcp test <name>` for in-session management.
- **CLI wiring** (`index.ts`): `McpManager` created in `createAgent()`; `SIGTERM` + Ctrl+C `onExit` handler for graceful MCP subprocess shutdown.
- **HITL confirmation** (`repl.ts`): 3-pattern allow-list check (exact → tool-wildcard → server-wildcard); MCP tools get extra choices `t` (tool wildcard, project) and `s` (server wildcard, project).
- **`Tool.truncateOutput` refactor**: replaces the hardcoded `TRUNCATE_TOOLS` Set in `executor.ts`; `bash`, `grep`, `glob`, and all MCP tools set `truncateOutput: true`.
- **Docs**: README MCP section + `docs/architecture.md` section 6 with layer constraints.

## Test plan

- [ ] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (420 tests, 0 failures)
- [ ] `opencli mcp add <name> <command>` — adds entry to `~/.opencli/mcp.json`
- [ ] `opencli mcp list` — probes servers and shows status table
- [ ] `opencli mcp test <name>` — prints tool list and latency
- [ ] `opencli mcp remove <name>` — removes entry (with confirmation)
- [ ] Start REPL with configured MCP server — `[mcp] N server(s) connected` appears
- [ ] MCP tool call triggers HITL dialog with `t`/`s` options
- [ ] Ctrl+C exits cleanly, MCP subprocesses are terminated
- [ ] `${VAR}` in mcp.json expands from env; unset var emits warning

Closes #81

🤖 Generated with [Claude Code](https://claude.ai/claude-code)