### PR TITLE
test: add regression test for failing-tool retry loop (closes #4)

### DIFF
--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -186,6 +186,42 @@ describe("Agent stuck-loop detection", () => {
     expect((error as { type: "error"; message: string }).message).toMatch(/identical tool calls/i);
   });
 
+  it("catches a model retrying a failing tool call with the same args (#4)", async () => {
+    // Scenario from issue #4: model tries to read a missing file, gets an
+    // error, and stubbornly retries the exact same call. The stuck-loop guard
+    // must abort after STUCK_THRESHOLD (3) identical consecutive calls.
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "read",
+      description: "read a file",
+      parameters: { type: "object", properties: { file_path: { type: "string" } } },
+      readonly: true,
+      execute: async () => ({
+        success: false,
+        output: "",
+        error: "ENOENT: no such file or directory, open '/missing.txt'",
+      }),
+    });
+
+    const agent = new Agent(
+      makeLoopingClient("read", { file_path: "/missing.txt" }),
+      registry,
+      new SkillRegistry(),
+      undefined,
+      undefined,
+      100, // high maxTurns so only stuck detection fires
+    );
+
+    const events = await collectEvents(agent, "read /missing.txt");
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeDefined();
+    expect((error as { type: "error"; message: string }).message).toMatch(/identical tool calls/i);
+
+    // Verify we stopped after exactly STUCK_THRESHOLD (3) tool call rounds
+    const toolCalls = events.filter((e) => e.type === "tool_call");
+    expect(toolCalls).toHaveLength(3);
+  });
+
   it("resets stuck counter when args change", async () => {
     let callCount = 0;
     // Alternate args every call so stuck detection never fires


### PR DESCRIPTION
## Summary

Issue #4 reported that the agent could enter an infinite loop when a model stubbornly retries a failing tool call (e.g. repeatedly trying to `read` a missing file).

This was already fixed by two guards in `agent.ts`:
1. **Stuck-loop detection** — aborts after 3 identical consecutive tool call signatures
2. **Max-turns guard** — hard cap at 50 iterations (configurable via `--max-turns`)

This PR adds an explicit regression test that reproduces the exact #4 scenario: a `read` tool that always returns `ENOENT`, with a client that retries identically. The test verifies the stuck-loop guard fires after exactly 3 iterations.

## What changed

- `src/core/agent.test.ts` — added `catches a model retrying a failing tool call with the same args (#4)` test case

## Verification

All 388 tests pass (15 skipped for platform-specific sandbox tests).

Closes #4

Co-authored-by: Antigravity <antigravity-bot@users.noreply.github.com>