### PR TITLE
feat(cli): @file mention expansion + per-CWD input history (A4)

### DIFF
--- a/docs/design/a4-file-mentions-history.md
+++ b/docs/design/a4-file-mentions-history.md
@@ -1,6 +1,6 @@
 # Design: A4 — @file mention expansion + per-CWD input history
 
-_Status: Implemented — merged in <sha> (2026-05-10). Tracking issue: [#88](https://github.com/zjshen14/opencli/issues/88). Phase: [Roadmap A4](../roadmap.md)._
+_Status: Implemented — merged in 3ee9367 (2026-05-10). Tracking issue: [#88](https://github.com/zjshen14/opencli/issues/88). Phase: [Roadmap A4](../roadmap.md)._
 
 ---
 

--- a/docs/design/a4-file-mentions-history.md
+++ b/docs/design/a4-file-mentions-history.md
@@ -1,6 +1,6 @@
 # Design: A4 — @file mention expansion + per-CWD input history
 
-_Status: Ready for implementation. Tracking issue: [#88](https://github.com/zjshen14/opencli/issues/88). Phase: [Roadmap A4](../roadmap.md)._
+_Status: Implemented — merged in <sha> (2026-05-10). Tracking issue: [#88](https://github.com/zjshen14/opencli/issues/88). Phase: [Roadmap A4](../roadmap.md)._
 
 ---
 

--- a/src/cli/input.test.ts
+++ b/src/cli/input.test.ts
@@ -1,10 +1,26 @@
-import { describe, it, expect } from "vitest";
-import {
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import os from "node:os";
+
+// Isolate history writes from the real ~/.opencli
+const tmpHome = join(os.tmpdir(), `opencli-input-test-${Date.now()}`);
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, default: { ...actual, homedir: () => tmpHome }, homedir: () => tmpHome };
+});
+
+// Import after mock so AGENT_DIR resolves to tmpHome.
+// All input.ts exports use the dynamic import to avoid static-import hoisting
+// (which would trigger homedir() before tmpHome is initialized).
+const {
+  loadHistory,
+  saveHistory,
   insertAtCursor,
   deleteBeforeCursor,
   deleteWordBeforeCursor,
   renderSelectOptions,
-} from "./input.js";
+} = await import("./input.js");
 
 describe("insertAtCursor", () => {
   it("appends when cursor is at end", () => {
@@ -125,5 +141,40 @@ describe("renderSelectOptions", () => {
     const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
     expect(strip(first).split("\n")[0]).toContain("›");
     expect(strip(last).split("\n")[2]).toContain("›");
+  });
+});
+
+describe("per-CWD history", () => {
+  afterEach(async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it("loadHistory returns [] when no history file exists", async () => {
+    const history = await loadHistory("/some/new/project");
+    expect(history).toEqual([]);
+  });
+
+  it("saveHistory + loadHistory round-trips entries in the same CWD", async () => {
+    const cwd = "/project/alpha";
+    await saveHistory(["second", "first"], cwd);
+    const loaded = await loadHistory(cwd);
+    expect(loaded).toEqual(["second", "first"]);
+  });
+
+  it("histories for different CWDs are independent", async () => {
+    await saveHistory(["alpha-cmd"], "/project/alpha");
+    await saveHistory(["beta-cmd"], "/project/beta");
+    const alpha = await loadHistory("/project/alpha");
+    const beta = await loadHistory("/project/beta");
+    expect(alpha).toEqual(["alpha-cmd"]);
+    expect(beta).toEqual(["beta-cmd"]);
+  });
+
+  it("caps saved history at MAX_HISTORY (500) entries", async () => {
+    const cwd = "/project/cap";
+    const entries = Array.from({ length: 600 }, (_, i) => `cmd-${i}`);
+    await saveHistory(entries, cwd);
+    const loaded = await loadHistory(cwd);
+    expect(loaded.length).toBe(500);
   });
 });

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -28,12 +28,15 @@ export interface SlashCommand {
 
 // ── History persistence ───────────────────────────────────────────────────────
 
-const HISTORY_FILE = join(AGENT_DIR, "history");
 const MAX_HISTORY = 500;
 
-export async function loadHistory(): Promise<string[]> {
+function historyFile(cwd: string): string {
+  return join(AGENT_DIR, "history", Buffer.from(cwd).toString("base64url"));
+}
+
+export async function loadHistory(cwd: string): Promise<string[]> {
   try {
-    const raw = await readFile(HISTORY_FILE, "utf8");
+    const raw = await readFile(historyFile(cwd), "utf8");
     return raw
       .split("\n")
       .map((l) => l.trim())
@@ -44,12 +47,12 @@ export async function loadHistory(): Promise<string[]> {
   }
 }
 
-export async function saveHistory(history: string[]): Promise<void> {
+export async function saveHistory(history: string[], cwd: string): Promise<void> {
   try {
-    await mkdir(AGENT_DIR, { recursive: true });
+    await mkdir(join(AGENT_DIR, "history"), { recursive: true });
     // Write oldest-first, cap at MAX_HISTORY
     const lines = [...history].reverse().slice(-MAX_HISTORY).join("\n") + "\n";
-    await writeFile(HISTORY_FILE, lines, "utf8");
+    await writeFile(historyFile(cwd), lines, "utf8");
   } catch {
     // Non-fatal — history just won't persist
   }

--- a/src/cli/mentions.test.ts
+++ b/src/cli/mentions.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expandMentions } from "./mentions.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = join(tmpdir(), `mentions-test-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("expandMentions", () => {
+  it("input with no @tokens is returned unchanged with no warnings", async () => {
+    const result = await expandMentions("explain this code please", dir);
+    expect(result.expanded).toBe("explain this code please");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("single @file expands inline at token position", async () => {
+    await writeFile(join(dir, "hello.ts"), "const x = 1;\n");
+    const result = await expandMentions(`review @hello.ts please`, dir);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.expanded).toContain("--- @hello.ts ---");
+    expect(result.expanded).toContain("const x = 1;");
+    expect(result.expanded).toContain("--- end ---");
+    expect(result.expanded).toMatch(/^review .+ please$/s);
+  });
+
+  it("@nonexistent.ts leaves token unchanged and adds a warning", async () => {
+    const result = await expandMentions("check @nonexistent.ts", dir);
+    expect(result.expanded).toBe("check @nonexistent.ts");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/nonexistent\.ts.*(not found|ENOENT)/i);
+  });
+
+  it("@glob pattern expands to multiple file blocks", async () => {
+    await mkdir(join(dir, "src"), { recursive: true });
+    await writeFile(join(dir, "src", "a.ts"), "const a = 1;\n");
+    await writeFile(join(dir, "src", "b.ts"), "const b = 2;\n");
+    const result = await expandMentions(`review @src/*.ts`, dir);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.expanded).toContain("const a = 1;");
+    expect(result.expanded).toContain("const b = 2;");
+  });
+
+  it("@glob with no matches leaves token unchanged and warns", async () => {
+    const result = await expandMentions(`review @src/**/*.nonexistent`, dir);
+    expect(result.expanded).toBe(`review @src/**/*.nonexistent`);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/no files matched/i);
+  });
+
+  it("file exceeding 50 000-char cap is truncated with a note", async () => {
+    const big = "x".repeat(60_000);
+    await writeFile(join(dir, "big.ts"), big);
+    const result = await expandMentions(`@big.ts`, dir);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.expanded).toContain("truncated at 50000 chars");
+    expect(result.expanded.length).toBeLessThan(big.length);
+  });
+
+  it("glob hitting 20-file cap warns and returns partial result", async () => {
+    // Create 22 files
+    for (let i = 0; i < 22; i++) {
+      await writeFile(join(dir, `f${i}.ts`), `const f${i} = ${i};\n`);
+    }
+    const result = await expandMentions(`@*.ts`, dir);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/capped at 20 files/i);
+    // Should contain exactly 20 file blocks
+    const count = (result.expanded.match(/--- end ---/g) ?? []).length;
+    expect(count).toBe(20);
+  });
+
+  it("binary file is skipped with a warning", async () => {
+    // Write a file with a null byte
+    const buf = Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x00, 0x6f]);
+    await writeFile(join(dir, "binary.bin"), buf);
+    const result = await expandMentions(`@binary.bin`, dir);
+    expect(result.expanded).toBe(`@binary.bin`);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/binary file/i);
+  });
+
+  it("@token in the middle of a sentence expands inline", async () => {
+    await writeFile(join(dir, "util.ts"), "export function add() {}\n");
+    const result = await expandMentions(`please review @util.ts and fix it`, dir);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.expanded).toMatch(/^please review .+ and fix it$/s);
+    expect(result.expanded).toContain("export function add()");
+  });
+});

--- a/src/cli/mentions.ts
+++ b/src/cli/mentions.ts
@@ -1,0 +1,184 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join, relative, isAbsolute } from "node:path";
+
+const MAX_FILE_CHARS = 50_000;
+const MAX_GLOB_FILES = 20;
+const MAX_GLOB_CHARS = 200_000;
+
+export interface ExpandResult {
+  /** Input string with @tokens replaced by file content blocks. */
+  expanded: string;
+  /** Non-fatal warnings to print before the agent turn. */
+  warnings: string[];
+}
+
+/**
+ * Resolve @path and @glob tokens in `input` against `cwd`.
+ * Tokens that do not resolve to readable files are left unchanged and
+ * reported in `warnings`. Never throws.
+ */
+export async function expandMentions(input: string, cwd: string): Promise<ExpandResult> {
+  if (!input.includes("@")) return { expanded: input, warnings: [] };
+
+  const regex = /@(\S+)/g;
+  const matches = [...input.matchAll(regex)];
+  if (matches.length === 0) return { expanded: input, warnings: [] };
+
+  const warnings: string[] = [];
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
+
+  for (const match of matches) {
+    const token = match[1];
+    const start = match.index!;
+    const end = start + match[0].length;
+
+    const isGlob = /[*?{[]/.test(token);
+    const replacement = isGlob
+      ? await expandGlob(token, cwd, warnings)
+      : await expandFile(token, cwd, warnings);
+
+    if (replacement !== null) {
+      replacements.push({ start, end, text: replacement });
+    }
+  }
+
+  // Apply replacements in reverse so earlier offsets stay valid.
+  let expanded = input;
+  for (const r of replacements.reverse()) {
+    expanded = expanded.slice(0, r.start) + r.text + expanded.slice(r.end);
+  }
+
+  return { expanded, warnings };
+}
+
+async function expandFile(token: string, cwd: string, warnings: string[]): Promise<string | null> {
+  const filePath = isAbsolute(token) ? token : join(cwd, token);
+  let content: string;
+  try {
+    const buf = await readFile(filePath);
+    if (isBinary(buf)) {
+      warnings.push(`@${token}: skipped (binary file)`);
+      return null;
+    }
+    content = buf.toString("utf8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    const msg =
+      code === "ENOENT" ? "file not found" : err instanceof Error ? err.message : String(err);
+    warnings.push(`@${token}: ${msg}`);
+    return null;
+  }
+
+  let truncNote = "";
+  if (content.length > MAX_FILE_CHARS) {
+    content = content.slice(0, MAX_FILE_CHARS);
+    truncNote = ` (truncated at ${MAX_FILE_CHARS} chars)`;
+  }
+
+  return `--- @${token}${truncNote} ---\n${content}\n--- end ---`;
+}
+
+async function expandGlob(token: string, cwd: string, warnings: string[]): Promise<string | null> {
+  let allFiles: string[];
+  try {
+    allFiles = await walk(cwd);
+  } catch (err) {
+    warnings.push(`@${token}: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+
+  const matched = allFiles.filter((f) => matchGlob(token, relative(cwd, f)));
+  if (matched.length === 0) {
+    warnings.push(`@${token}: no files matched`);
+    return null;
+  }
+
+  const blocks: string[] = [];
+  let totalChars = 0;
+  let capped = false;
+
+  for (const filePath of matched) {
+    if (blocks.length >= MAX_GLOB_FILES) {
+      capped = true;
+      break;
+    }
+
+    let content: string;
+    try {
+      const buf = await readFile(filePath);
+      if (isBinary(buf)) {
+        warnings.push(`@${relative(cwd, filePath)}: skipped (binary file)`);
+        continue;
+      }
+      content = buf.toString("utf8");
+    } catch {
+      continue;
+    }
+
+    let truncNote = "";
+    if (content.length > MAX_FILE_CHARS) {
+      content = content.slice(0, MAX_FILE_CHARS);
+      truncNote = ` (truncated at ${MAX_FILE_CHARS} chars)`;
+    }
+
+    const rel = relative(cwd, filePath);
+    const block = `--- @${rel}${truncNote} ---\n${content}\n--- end ---`;
+
+    if (totalChars + block.length > MAX_GLOB_CHARS) {
+      capped = true;
+      break;
+    }
+
+    blocks.push(block);
+    totalChars += block.length;
+  }
+
+  if (capped) {
+    warnings.push(`@${token}: expansion capped at ${blocks.length} files`);
+  }
+
+  if (blocks.length === 0) {
+    warnings.push(`@${token}: no readable files matched`);
+    return null;
+  }
+
+  return blocks.join("\n\n");
+}
+
+function isBinary(buf: Buffer): boolean {
+  const limit = Math.min(buf.length, 8000);
+  for (let i = 0; i < limit; i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+}
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walk(full)));
+    } else {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function matchGlob(pattern: string, filePath: string): boolean {
+  const regex = new RegExp(
+    "^" +
+      pattern
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+        .replace(/\*\*/g, "§DSTAR§")
+        .replace(/\*/g, "[^/]*")
+        .replace(/\?/g, "[^/]")
+        .replace(/§DSTAR§\//g, "(?:.+/)?")
+        .replace(/§DSTAR§/g, ".*") +
+      "$",
+  );
+  return regex.test(filePath);
+}

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -4,6 +4,7 @@ import type { SkillRegistry } from "../skills/registry.js";
 import { loadSkillFile, processBody } from "../skills/loader.js";
 import { join } from "node:path";
 import { readLine, loadHistory, saveHistory, type SlashCommand } from "./input.js";
+import { expandMentions } from "./mentions.js";
 import { probeServer } from "./mcp-cmd.js";
 import { loadMcpConfig } from "../mcp/config.js";
 import { AGENT_DIR } from "../state/config.js";
@@ -44,7 +45,8 @@ export async function runRepl(
   }
   agent.setSessionTmpDir(session.tmpDir);
 
-  const history = await loadHistory();
+  const cwd = process.cwd();
+  const history = await loadHistory(cwd);
   const skillCommands: SlashCommand[] = skills
     .list()
     .map((s) => ({ name: s.name, description: s.description }));
@@ -56,14 +58,19 @@ export async function runRepl(
     // EOF (Ctrl+D)
     if (raw === null) break;
 
-    const input = raw.trim();
-    if (!input) continue;
+    const rawInput = raw.trim();
+    if (!rawInput) continue;
 
-    // Persist to history (skip duplicates at the top)
-    if (history[0] !== input) {
-      history.unshift(input);
+    // Persist original input to history (skip duplicates at the top)
+    if (history[0] !== rawInput) {
+      history.unshift(rawInput);
     }
-    void session.log({ type: "user", content: input });
+    void session.log({ type: "user", content: rawInput });
+
+    // Expand @file/@glob mentions before passing to agent or slash commands
+    const { expanded, warnings } = await expandMentions(rawInput, cwd);
+    for (const w of warnings) printInfo(w);
+    const input = expanded;
 
     // Built-in commands
     if (input === "/help") {
@@ -182,7 +189,7 @@ export async function runRepl(
     await runAgentTurn(agent, session, userMessage);
   }
 
-  await saveHistory(history);
+  await saveHistory(history, cwd);
   process.stdout.write(chalk.gray("Goodbye.\n"));
 }
 

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -65,12 +65,14 @@ export async function runRepl(
     if (history[0] !== rawInput) {
       history.unshift(rawInput);
     }
-    void session.log({ type: "user", content: rawInput });
 
     // Expand @file/@glob mentions before passing to agent or slash commands
     const { expanded, warnings } = await expandMentions(rawInput, cwd);
     for (const w of warnings) printInfo(w);
     const input = expanded;
+
+    // Log expanded content so resumed sessions restore the same context the agent saw
+    void session.log({ type: "user", content: input });
 
     // Built-in commands
     if (input === "/help") {


### PR DESCRIPTION
## Summary

- **`@file` / `@glob` expansion** — `@src/core/agent.ts` or `@src/**/*.ts` in a prompt is resolved and inlined before the message reaches the agent. Each file is wrapped in a fenced block (`--- @path ---` / `--- end ---`). Tokens that don't resolve are warned and left unchanged (so `@user`, `@TODO` etc. are not broken).
- **Per-CWD history** — input history is now stored at `~/.opencli/history/<base64url-encoded-cwd>` instead of a single global file. Histories across projects are fully independent. Old global history is left in place untouched.

Size caps: 50 000 chars/file, 20 files/glob, 200 000 chars total per glob. Binary files (null-byte heuristic) are skipped. Original unexpanded input is saved to history (not the expanded content).

## Test plan

- [x] 9 `src/cli/mentions.test.ts` tests: single file, missing file, glob, empty glob, size cap, file-count cap, binary skip, no-@ fast path, inline expansion
- [x] 4 new `src/cli/input.test.ts` tests: per-CWD isolation, round-trip, missing file → [], cap at 500
- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — 461 tests pass

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)