### PR TITLE
feat(core): context compaction via LLM summarization (A5)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,6 +40,10 @@ program
   .option("--sandbox <mode>", "Sandbox mode for bash tool: auto | strict | off (default: auto)")
   .option("--provider <provider>", "Override provider detection: gemini | anthropic | openai")
   .option("--base-url <url>", "Custom base URL for proxy or local inference (e.g. LiteLLM)")
+  .option(
+    "--compaction",
+    "Enable context compaction: summarize old messages via LLM instead of dropping them",
+  )
   .action(async (opts) => {
     const sessionId = opts.session ?? (opts.resume ? "latest" : undefined);
     await startChat(
@@ -50,6 +54,7 @@ program
       opts.sandbox as string | undefined,
       opts.provider as string | undefined,
       opts.baseUrl as string | undefined,
+      opts.compaction as boolean | undefined,
     );
   });
 
@@ -167,6 +172,7 @@ async function startChat(
   sandboxFlag?: string,
   providerOverride?: string,
   baseUrlOverride?: string,
+  compaction?: boolean,
 ): Promise<void> {
   const { agent, skills, mcpManager, snapshotManager } = await createAgent(
     modelOverride,
@@ -175,6 +181,7 @@ async function startChat(
     sandboxFlag,
     providerOverride,
     baseUrlOverride,
+    compaction,
   );
 
   const cleanup = async () => {
@@ -292,6 +299,7 @@ async function createAgent(
   sandboxFlag?: string,
   providerOverride?: string,
   baseUrlOverride?: string,
+  compaction?: boolean,
 ) {
   const config = await loadConfig();
   const model = process.env.OPENCLI_MODEL ?? modelOverride ?? config.model;
@@ -331,6 +339,7 @@ async function createAgent(
     model,
     onObservability: debug ? makeDebugHandler() : undefined,
     snapshotManager,
+    compactionEnabled: compaction,
   });
   return { agent, skills, mcpManager, snapshotManager };
 }

--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -169,6 +169,66 @@ describe("Agent plan mode", () => {
   });
 });
 
+describe("Agent compaction", () => {
+  it("calls the LLM to summarize when compaction is triggered", async () => {
+    let compactionCallMessages: Message[] = [];
+
+    const client: LLMClient = {
+      async *stream(messages: Message[], sys: string, _tools: ToolDefinition[]) {
+        if (sys.includes("summarizer")) {
+          // This is the compaction call
+          compactionCallMessages = messages;
+          yield { type: "text", text: "Summary of work done." } as StreamEvent;
+          yield { type: "done" } as StreamEvent;
+        } else {
+          yield { type: "text", text: "done" } as StreamEvent;
+          yield { type: "done" } as StreamEvent;
+        }
+      },
+    };
+
+    // maxHistoryMessages=5, threshold=floor(5*0.8)=4 messages
+    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry(), undefined, 5, 10, {
+      compactionEnabled: true,
+    });
+
+    // Add 4 messages to the context manually by running 4 separate prompts
+    // Each run adds 1 user + 1 model message = 2 messages, so 2 runs → 4 messages
+    for (const prompt of ["task one", "task two"]) {
+      for await (const _e of agent.run(prompt)) void _e;
+    }
+
+    // On the 3rd run, the first thing the agent does is check needsCompaction()
+    // History now has 4 messages (2 user + 2 model), threshold is 4 → compaction fires
+    for await (const _e of agent.run("task three")) void _e;
+
+    expect(compactionCallMessages.length).toBeGreaterThan(0);
+  });
+
+  it("does not compact when compaction is disabled (default)", async () => {
+    let compactionCalled = false;
+
+    const client: LLMClient = {
+      async *stream(_messages: Message[], sys: string, _tools: ToolDefinition[]) {
+        if (sys.includes("summarizer")) {
+          compactionCalled = true;
+        }
+        yield { type: "text", text: "done" } as StreamEvent;
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+
+    // maxHistoryMessages=5, no compaction option
+    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry(), undefined, 5, 10);
+
+    for (const prompt of ["task one", "task two", "task three"]) {
+      for await (const _e of agent.run(prompt)) void _e;
+    }
+
+    expect(compactionCalled).toBe(false);
+  });
+});
+
 describe("Agent stuck-loop detection", () => {
   it("emits an error after 3 identical consecutive tool calls", async () => {
     const agent = new Agent(

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -23,6 +23,9 @@ const STUCK_THRESHOLD = 3;
 
 export type AgentRunMode = "react" | "plan";
 
+const COMPACTION_SYSTEM =
+  "You are a conversation summarizer. Summarize the key decisions, files changed, errors encountered, and current state from this conversation. Be concise — under 200 words. Preserve file paths and function names exactly.";
+
 export class Agent {
   private context: ContextManager;
   private confirmFn?: ConfirmFn;
@@ -41,9 +44,14 @@ export class Agent {
       model?: string;
       onObservability?: ObservabilityHandler;
       snapshotManager?: SnapshotManager;
+      compactionEnabled?: boolean;
     },
   ) {
-    this.context = new ContextManager(systemInstruction, maxHistoryMessages);
+    this.context = new ContextManager(
+      systemInstruction,
+      maxHistoryMessages,
+      options?.compactionEnabled ?? false,
+    );
     this.context.setSkillCatalog(skills.catalogSummary());
     this.model = options?.model ?? "";
     this.obs = options?.onObservability;
@@ -96,6 +104,10 @@ export class Agent {
     while (true) {
       const pendingCalls: FunctionCallPart[] = [];
       let responseText = "";
+
+      if (this.context.needsCompaction()) {
+        await this.compact();
+      }
 
       const messages = this.context.getMessages();
       const estimatedTokens = Math.round(
@@ -237,5 +249,25 @@ export class Agent {
 
   clearHistory(): void {
     this.context.clear();
+  }
+
+  private async compact(): Promise<void> {
+    const compactable = this.context.getCompactableMessages();
+    if (compactable.length === 0) return;
+
+    let summary = "";
+    for await (const event of this.client.stream(compactable, COMPACTION_SYSTEM, [])) {
+      if (event.type === "text") summary += event.text;
+    }
+    if (!summary.trim()) return;
+
+    const summaryMessage: Message = {
+      role: "user",
+      parts: [{ type: "text", text: `[Session summary — earlier context compacted]\n${summary}` }],
+    };
+    this.context.replaceWithSummary(summaryMessage);
+    process.stderr.write(
+      `[opencli] context compacted: ${compactable.length} messages → 1 summary\n`,
+    );
   }
 }

--- a/src/core/context.test.ts
+++ b/src/core/context.test.ts
@@ -303,6 +303,62 @@ describe("ContextManager", () => {
   });
 });
 
+describe("ContextManager compaction", () => {
+  it("needsCompaction() returns false by default (compaction disabled)", () => {
+    const ctx = new ContextManager(STUB, 10);
+    for (let i = 0; i < 9; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    expect(ctx.needsCompaction()).toBe(false);
+  });
+
+  it("needsCompaction() returns false below threshold when enabled", () => {
+    const ctx = new ContextManager(STUB, 10, true);
+    // threshold = floor(10 * 0.8) = 8; add 7 messages
+    for (let i = 0; i < 7; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    expect(ctx.needsCompaction()).toBe(false);
+  });
+
+  it("needsCompaction() returns true at threshold when enabled", () => {
+    const ctx = new ContextManager(STUB, 10, true);
+    // threshold = floor(10 * 0.8) = 8
+    for (let i = 0; i < 8; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    expect(ctx.needsCompaction()).toBe(true);
+  });
+
+  it("getCompactableMessages() returns older messages, keeping tail", () => {
+    const ctx = new ContextManager(STUB, 10, true);
+    // tailSize = max(1, floor(10 * 0.4)) = 4
+    for (let i = 0; i < 10; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    const compactable = ctx.getCompactableMessages();
+    // 10 total - 4 tail = 6 compactable
+    expect(compactable).toHaveLength(6);
+    expect((compactable[0].parts[0] as { type: string; text: string }).text).toBe("msg 0");
+    expect((compactable[5].parts[0] as { type: string; text: string }).text).toBe("msg 5");
+  });
+
+  it("replaceWithSummary() replaces old messages with summary + tail", () => {
+    const ctx = new ContextManager(STUB, 10, true);
+    // tailSize = max(1, floor(10 * 0.4)) = 4
+    for (let i = 0; i < 10; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    const summary = userMsg("[Session summary — earlier context compacted]\nDid some work.");
+    ctx.replaceWithSummary(summary);
+    const msgs = ctx.getMessages();
+    // summary + 4 tail messages = 5
+    expect(msgs).toHaveLength(5);
+    expect((msgs[0].parts[0] as { type: string; text: string }).text).toContain("compacted");
+    expect((msgs[1].parts[0] as { type: string; text: string }).text).toBe("msg 6");
+    expect((msgs[4].parts[0] as { type: string; text: string }).text).toBe("msg 9");
+  });
+
+  it("needsCompaction() returns false after replaceWithSummary reduces history", () => {
+    const ctx = new ContextManager(STUB, 10, true);
+    for (let i = 0; i < 8; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    expect(ctx.needsCompaction()).toBe(true);
+    ctx.replaceWithSummary(userMsg("[Session summary]\nDone."));
+    // After compaction: 1 summary + 4 tail = 5 messages — below threshold of 8
+    expect(ctx.needsCompaction()).toBe(false);
+  });
+});
+
 describe("DEFAULT_SYSTEM_INSTRUCTION", () => {
   it("contains all required placeholders", () => {
     expect(DEFAULT_SYSTEM_INSTRUCTION).toContain("{CWD}");

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,6 +1,11 @@
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { DEFAULT_SYSTEM_INSTRUCTION, getGitContext, renderSystemInstruction } from "./prompt.js";
 
+// Fraction of maxHistoryMessages at which compaction is triggered (80%)
+const COMPACTION_THRESHOLD = 0.8;
+// Fraction of maxHistoryMessages to retain as recent tail after compaction (40%)
+const COMPACTION_TAIL_FRACTION = 0.4;
+
 export class ContextManager {
   private history: Message[] = [];
   private skillContent: string[] = []; // activated skill bodies, never pruned
@@ -10,12 +15,15 @@ export class ContextManager {
   private cachedSystemInstruction: string | null = null;
   private cachedToolSignature: string | null = null;
   private skillCatalog = "";
+  private readonly compactionEnabled: boolean;
 
   constructor(
     private readonly systemInstructionTemplate = DEFAULT_SYSTEM_INSTRUCTION,
     maxHistoryMessages = 50,
+    compactionEnabled = false,
   ) {
     this.maxHistoryMessages = maxHistoryMessages;
+    this.compactionEnabled = compactionEnabled;
   }
 
   setSessionTmpDir(dir: string): void {
@@ -89,6 +97,28 @@ export class ContextManager {
     this.activatedSkills.clear();
     this.cachedSystemInstruction = null;
     this.cachedToolSignature = null;
+  }
+
+  /** Returns true when the history is at or past the soft compaction threshold. */
+  needsCompaction(): boolean {
+    if (!this.compactionEnabled) return false;
+    return this.history.length >= Math.floor(this.maxHistoryMessages * COMPACTION_THRESHOLD);
+  }
+
+  /**
+   * Returns the older "head" messages to be summarized.
+   * The most recent tail (40% of maxHistoryMessages) is kept verbatim.
+   */
+  getCompactableMessages(): Message[] {
+    const tailSize = Math.max(1, Math.floor(this.maxHistoryMessages * COMPACTION_TAIL_FRACTION));
+    return this.history.slice(0, Math.max(0, this.history.length - tailSize));
+  }
+
+  /** Replaces the compactable head with a single summary message, keeping the tail. */
+  replaceWithSummary(summaryMessage: Message): void {
+    const tailSize = Math.max(1, Math.floor(this.maxHistoryMessages * COMPACTION_TAIL_FRACTION));
+    const tail = this.history.slice(-tailSize);
+    this.history = [summaryMessage, ...tail];
   }
 
   private prune(): void {


### PR DESCRIPTION
## Summary

Closes #26.

Implements Phase A5 — context compaction via LLM summarization, replacing the hard-drop `slice(-N)` behaviour in `ContextManager.prune()` with a graceful summarization pass when history approaches the limit.

- **`ContextManager`** gains three new methods: `needsCompaction()` (returns true at 80% of `maxHistoryMessages`), `getCompactableMessages()` (the older head to summarize), and `replaceWithSummary(msg)` (swaps the head for a single summary message, keeping the 40% tail verbatim). The existing hard-cap `prune()` remains as a safety net.
- **`Agent`** checks `needsCompaction()` at the top of each iteration loop and calls a private `compact()` method that streams from the LLM with a dedicated summarization system prompt (no tools, no full system instruction). The resulting text is wrapped in a `[Session summary — earlier context compacted]` user message.
- **CLI flag**: `opencli chat --compaction` enables the feature. Off by default so existing behaviour is unchanged.

## Test plan

- [x] `ContextManager.needsCompaction()` returns false below 80% threshold and true at/above it
- [x] `ContextManager.getCompactableMessages()` returns the head (history minus 40% tail)
- [x] `ContextManager.replaceWithSummary()` collapses to summary + tail; subsequent `needsCompaction()` returns false
- [x] Agent calls the LLM summarizer when threshold is reached (verified with mock client)
- [x] Agent does NOT call summarizer when `compactionEnabled` is false (default)
- [x] All 464 existing tests continue to pass

https://claude.ai/code/session_01XMkecDE5XsrPgdosUzsDFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMkecDE5XsrPgdosUzsDFR)_