### PR TITLE
feat(A5a): manual context compaction (/compact, /context)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { createClient, detectProvider } from "../providers/factory.js";
+import { createClient, createCompactionClient, detectProvider } from "../providers/factory.js";
 import { Agent } from "../core/agent.js";
 import { createDefaultRegistry } from "../tools/index.js";
 import { SkillRegistry } from "../skills/registry.js";
@@ -333,10 +333,12 @@ async function createAgent(
   const snapshotManager = new SnapshotManager();
 
   const systemInstruction = await loadSystemInstruction();
+  const compactionClient = createCompactionClient(model, apiKey);
   const agent = new Agent(client, tools, skills, systemInstruction, config.historySize, maxTurns, {
     model,
     onObservability: debug ? makeDebugHandler() : undefined,
     snapshotManager,
+    compactionClient,
   });
   return { agent, skills, mcpManager, snapshotManager };
 }

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -19,6 +19,8 @@ import type { SnapshotManager } from "../state/snapshot.js";
 const BUILTIN_COMMANDS: SlashCommand[] = [
   { name: "help", description: "list available skills and commands" },
   { name: "plan", description: "explore and draft a plan, then approve before executing" },
+  { name: "compact", description: "summarize older conversation history to free context" },
+  { name: "context", description: "show current token usage vs. context window" },
   { name: "rewind", description: "undo agent file changes since last snapshot" },
   { name: "clear", description: "clear conversation history" },
   { name: "exit", description: "exit the agent" },
@@ -96,6 +98,40 @@ export async function runRepl(
         continue;
       }
       await runPlanFlow(agent, session, planPrompt);
+      continue;
+    }
+
+    // /compact — summarize older conversation history to free context
+    if (input === "/compact") {
+      const stats = agent.getContextStats();
+      if (stats.messageCount < 4) {
+        printInfo("Nothing to compact — conversation is too short.");
+        continue;
+      }
+      printInfo("Compacting conversation history…");
+      try {
+        const result = await agent.compact();
+        if (result.messagesRemoved === 0) {
+          printInfo("Nothing to compact — recent messages fill the full window.");
+        } else {
+          printInfo(
+            `Compacted ${result.messagesRemoved} message(s) into a ${result.summaryLength}-char summary.`,
+          );
+        }
+      } catch (err) {
+        printError(`Compaction failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      continue;
+    }
+
+    // /context — show estimated token usage vs. context window
+    if (input === "/context") {
+      const { messageCount, estimatedTokens, contextWindow } = agent.getContextStats();
+      const pct = Math.round((estimatedTokens / contextWindow) * 100);
+      printInfo(
+        `Est. tokens:  ~${estimatedTokens.toLocaleString()} / ${contextWindow.toLocaleString()}  (${pct}%)`,
+      );
+      printInfo(`Messages:     ${messageCount}`);
       continue;
     }
 

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -9,6 +9,8 @@ import { buildReminder, buildPlanSuffix } from "./prompt.js";
 import type { FunctionCallPart, Message } from "../providers/types.js";
 import type { ObservabilityHandler } from "./observability.js";
 import type { SnapshotManager } from "../state/snapshot.js";
+import { compactHistory, contextWindowFor } from "./compact.js";
+import type { CompactResult } from "./compact.js";
 
 export type AgentEvent =
   | { type: "text"; text: string }
@@ -29,6 +31,7 @@ export class Agent {
   private model: string;
   private obs?: ObservabilityHandler;
   private snapshotManager?: SnapshotManager;
+  private compactionClient: LLMClient;
 
   constructor(
     private client: LLMClient,
@@ -41,6 +44,7 @@ export class Agent {
       model?: string;
       onObservability?: ObservabilityHandler;
       snapshotManager?: SnapshotManager;
+      compactionClient?: LLMClient;
     },
   ) {
     this.context = new ContextManager(systemInstruction, maxHistoryMessages);
@@ -48,6 +52,7 @@ export class Agent {
     this.model = options?.model ?? "";
     this.obs = options?.onObservability;
     this.snapshotManager = options?.snapshotManager;
+    this.compactionClient = options?.compactionClient ?? client;
   }
 
   setConfirmFn(fn: ConfirmFn): void {
@@ -233,6 +238,25 @@ export class Agent {
         });
       }
     }
+  }
+
+  async compact(): Promise<CompactResult> {
+    return compactHistory(this.context, this.compactionClient);
+  }
+
+  getContextStats(): {
+    messageCount: number;
+    estimatedTokens: number;
+    contextWindow: number;
+    maxHistoryMessages: number;
+  } {
+    const messages = this.context.getMessages();
+    return {
+      messageCount: this.context.messageCount,
+      estimatedTokens: Math.round(JSON.stringify(messages).length / 4),
+      contextWindow: contextWindowFor(this.model),
+      maxHistoryMessages: this.context.maxMessages,
+    };
   }
 
   clearHistory(): void {

--- a/src/core/compact.test.ts
+++ b/src/core/compact.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { compactHistory, contextWindowFor } from "./compact.js";
+import { ContextManager } from "./context.js";
+import type { LLMClient } from "../providers/client.js";
+import type { Message, StreamEvent } from "../providers/types.js";
+
+const FIXED_SUMMARY =
+  "## Task\nFix bug.\n\n## Progress\nEdited src/foo.ts.\n\n## Decisions\nUsed X.\n\n## Errors\nNone.\n\n## State\nDone.";
+
+function makeMockClient(summary: string): LLMClient {
+  return {
+    async *stream(): AsyncGenerator<StreamEvent> {
+      if (summary.length > 0) {
+        yield { type: "text", text: summary };
+      }
+      yield { type: "done" };
+    },
+  };
+}
+
+function userMsg(text: string): Message {
+  return { role: "user", parts: [{ type: "text", text }] };
+}
+
+function modelMsg(text: string): Message {
+  return { role: "model", parts: [{ type: "text", text }] };
+}
+
+function errorResultMsg(toolName: string, errorText: string): Message {
+  return {
+    role: "user",
+    parts: [{ type: "function_result", id: "r1", name: toolName, result: errorText }],
+  };
+}
+
+function makeMessages(count: number): Message[] {
+  return Array.from({ length: count }, (_, i) =>
+    i % 2 === 0 ? userMsg(`user turn ${i}`) : modelMsg(`model turn ${i}`),
+  );
+}
+
+describe("compactHistory", () => {
+  it("returns messagesRemoved: 0 when history is shorter than COMPACT_MIN_MESSAGES", async () => {
+    const ctx = new ContextManager();
+    ctx.addMessage(userMsg("a"));
+    ctx.addMessage(modelMsg("b"));
+    ctx.addMessage(userMsg("c"));
+    const result = await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    expect(result.messagesRemoved).toBe(0);
+    expect(result.summaryLength).toBe(0);
+    expect(ctx.messageCount).toBe(3);
+  });
+
+  it("returns messagesRemoved: 0 when all messages fit in KEEP_RECENT window", async () => {
+    const ctx = new ContextManager();
+    for (const msg of makeMessages(8)) ctx.addMessage(msg);
+    const result = await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    expect(result.messagesRemoved).toBe(0);
+    expect(ctx.messageCount).toBe(8);
+  });
+
+  it("compacts 20 messages to summary + last 10 verbatim", async () => {
+    const ctx = new ContextManager();
+    for (const msg of makeMessages(20)) ctx.addMessage(msg);
+    const result = await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    expect(result.messagesRemoved).toBe(10);
+    expect(ctx.messageCount).toBe(11); // 1 summary + 10 tail
+  });
+
+  it("summary message has role user and the compaction prefix", async () => {
+    const ctx = new ContextManager();
+    for (const msg of makeMessages(20)) ctx.addMessage(msg);
+    await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    const msgs = ctx.getMessages();
+    const summaryMsg = msgs[0];
+    expect(summaryMsg.role).toBe("user");
+    const text = (summaryMsg.parts[0] as { type: string; text: string }).text;
+    expect(text).toContain("[Session context compacted — earlier conversation summarized]");
+    expect(text).toContain(FIXED_SUMMARY);
+  });
+
+  it("messagesRemoved equals total minus KEEP_RECENT", async () => {
+    const ctx = new ContextManager();
+    for (const msg of makeMessages(25)) ctx.addMessage(msg);
+    const result = await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    expect(result.messagesRemoved).toBe(15);
+  });
+
+  it("mock client returning empty string produces summary message with empty body", async () => {
+    const ctx = new ContextManager();
+    for (const msg of makeMessages(20)) ctx.addMessage(msg);
+    await compactHistory(ctx, makeMockClient(""));
+    const msgs = ctx.getMessages();
+    const text = (msgs[0].parts[0] as { type: string; text: string }).text;
+    expect(text).toContain("[Session context compacted — earlier conversation summarized]");
+  });
+
+  it("summaryLength matches the LLM summary string length", async () => {
+    const ctx = new ContextManager();
+    for (const msg of makeMessages(20)) ctx.addMessage(msg);
+    const result = await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    expect(result.summaryLength).toBe(FIXED_SUMMARY.length);
+  });
+
+  it("error signals in head are quoted verbatim in the summary message", async () => {
+    const ctx = new ContextManager();
+    // Put the error message first so it ends up in the head (head = total - KEEP_RECENT messages).
+    // With 20 total messages, head = first 10, so the error at index 0 is always in the head.
+    ctx.addMessage(errorResultMsg("bash", "Error: command not found: foo"));
+    for (let i = 0; i < 19; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    const result = await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    expect(result.messagesRemoved).toBeGreaterThan(0);
+    const summaryText = (ctx.getMessages()[0].parts[0] as { type: string; text: string }).text;
+    expect(summaryText).toContain("Error: command not found: foo");
+    expect(summaryText).toContain("Verbatim error outputs preserved");
+  });
+
+  it("no error block when head has no function_result with Error:", async () => {
+    const ctx = new ContextManager();
+    for (const msg of makeMessages(20)) ctx.addMessage(msg);
+    await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
+    const summaryText = (ctx.getMessages()[0].parts[0] as { type: string; text: string }).text;
+    expect(summaryText).not.toContain("Verbatim error outputs preserved");
+  });
+});
+
+describe("contextWindowFor", () => {
+  it("returns 200_000 for claude- prefix", () => {
+    expect(contextWindowFor("claude-opus-4-7")).toBe(200_000);
+    expect(contextWindowFor("claude-haiku-4-5-20251001")).toBe(200_000);
+  });
+
+  it("returns 1_048_576 for gemini-2.5 prefix", () => {
+    expect(contextWindowFor("gemini-2.5-flash")).toBe(1_048_576);
+  });
+
+  it("returns 1_048_576 for gemini-2.0 prefix", () => {
+    expect(contextWindowFor("gemini-2.0-flash-lite")).toBe(1_048_576);
+  });
+
+  it("returns 128_000 for gpt-4o prefix", () => {
+    expect(contextWindowFor("gpt-4o-mini")).toBe(128_000);
+  });
+
+  it("returns 100_000 for unknown model", () => {
+    expect(contextWindowFor("unknown-model-xyz")).toBe(100_000);
+  });
+});

--- a/src/core/compact.ts
+++ b/src/core/compact.ts
@@ -1,0 +1,127 @@
+import type { LLMClient } from "../providers/client.js";
+import type { Message } from "../providers/types.js";
+import type { ContextManager } from "./context.js";
+
+export interface CompactResult {
+  messagesRemoved: number;
+  summaryLength: number;
+}
+
+const KEEP_RECENT = 10;
+const COMPACT_MIN_MESSAGES = 4;
+
+// Longest-prefix-first; order matters — more specific prefixes must come before shorter ones.
+const MODEL_CONTEXT_WINDOWS: [prefix: string, tokens: number][] = [
+  ["gemini-2.5", 1_048_576],
+  ["gemini-2.0", 1_048_576],
+  ["gemini-1.5", 1_048_576],
+  ["claude-", 200_000],
+  ["gpt-4o", 128_000],
+  ["o1", 200_000],
+  ["o3", 200_000],
+  ["o4", 200_000],
+];
+
+const DEFAULT_CONTEXT_WINDOW = 100_000;
+
+const SUMMARIZATION_PROMPT = `Summarize this coding session for context compaction.
+Respond with exactly these five sections using these headers — do not add or rename sections:
+
+## Task
+The original user request and overall goal. One or two sentences.
+
+## Progress
+What has been completed. List every file created or modified with its exact path.
+
+## Decisions
+Key technical choices made during the session and the reason for each.
+
+## Errors
+Any error messages or test failures encountered. Quote them exactly — do not paraphrase.
+If resolved, state the resolution. If unresolved, say so.
+
+## State
+Current state of work and the immediate next steps remaining.
+
+Rules:
+- Under 400 words total.
+- Copy file paths, error messages, function names, and version numbers exactly.
+- Do not narrate tool calls. Focus on outcomes and current state.`;
+
+export function contextWindowFor(model: string): number {
+  for (const [prefix, size] of MODEL_CONTEXT_WINDOWS) {
+    if (model.startsWith(prefix)) return size;
+  }
+  return DEFAULT_CONTEXT_WINDOW;
+}
+
+function extractErrorResults(messages: Message[]): string[] {
+  const errors: string[] = [];
+  for (const msg of messages) {
+    for (const part of msg.parts) {
+      if (part.type === "function_result" && part.result.includes("Error:")) {
+        errors.push(`[${part.name}] ${part.result}`);
+      }
+    }
+  }
+  return errors;
+}
+
+async function streamToText(
+  client: LLMClient,
+  messages: Message[],
+  prompt: string,
+): Promise<string> {
+  const chunks: string[] = [];
+  for await (const event of client.stream(messages, prompt, [])) {
+    if (event.type === "text") chunks.push(event.text);
+  }
+  return chunks.join("");
+}
+
+/**
+ * Replace old messages in `context` with a structured LLM-generated summary.
+ * Keeps the most recent KEEP_RECENT messages verbatim.
+ * Error signals from tool results are quoted verbatim in the summary.
+ * Returns { messagesRemoved: 0 } if history is too short to compact.
+ * Never throws — propagates LLM errors to the caller.
+ */
+export async function compactHistory(
+  context: ContextManager,
+  compactionClient: LLMClient,
+): Promise<CompactResult> {
+  if (context.messageCount < COMPACT_MIN_MESSAGES) {
+    return { messagesRemoved: 0, summaryLength: 0 };
+  }
+
+  const messages = context.getMessages();
+  const tail = messages.slice(-KEEP_RECENT);
+  const head = messages.slice(0, -KEEP_RECENT);
+
+  if (head.length === 0) {
+    return { messagesRemoved: 0, summaryLength: 0 };
+  }
+
+  const errors = extractErrorResults(head);
+  const summary = await streamToText(compactionClient, head, SUMMARIZATION_PROMPT);
+
+  const errorBlock =
+    errors.length > 0
+      ? `\n\n### Verbatim error outputs preserved from compacted history\n\n` +
+        errors.map((e) => "```\n" + e + "\n```").join("\n\n")
+      : "";
+
+  const summaryMessage: Message = {
+    role: "user",
+    parts: [
+      {
+        type: "text",
+        text: `[Session context compacted — earlier conversation summarized]\n\n${summary}${errorBlock}`,
+      },
+    ],
+  };
+
+  context.restoreMessages([summaryMessage, ...tail]);
+
+  return { messagesRemoved: head.length, summaryLength: summary.length };
+}

--- a/src/core/context.test.ts
+++ b/src/core/context.test.ts
@@ -303,6 +303,32 @@ describe("ContextManager", () => {
   });
 });
 
+describe("ContextManager — messageCount and maxMessages getters", () => {
+  it("messageCount is 0 initially", () => {
+    const ctx = new ContextManager(STUB);
+    expect(ctx.messageCount).toBe(0);
+  });
+
+  it("messageCount tracks addMessage calls", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("a"));
+    ctx.addMessage(modelMsg("b"));
+    expect(ctx.messageCount).toBe(2);
+  });
+
+  it("messageCount reflects restoreMessages", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("original"));
+    ctx.restoreMessages([userMsg("a"), modelMsg("b"), userMsg("c")]);
+    expect(ctx.messageCount).toBe(3);
+  });
+
+  it("maxMessages returns constructor value", () => {
+    const ctx = new ContextManager(STUB, 42);
+    expect(ctx.maxMessages).toBe(42);
+  });
+});
+
 describe("DEFAULT_SYSTEM_INSTRUCTION", () => {
   it("contains all required placeholders", () => {
     expect(DEFAULT_SYSTEM_INSTRUCTION).toContain("{CWD}");

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -83,6 +83,14 @@ export class ContextManager {
     this.history = messages;
   }
 
+  get messageCount(): number {
+    return this.history.length;
+  }
+
+  get maxMessages(): number {
+    return this.maxHistoryMessages;
+  }
+
   clear(): void {
     this.history = [];
     this.skillContent = [];

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -29,6 +29,18 @@ export function hasNativeThinking(model: string): boolean {
   return false;
 }
 
+const COMPACTION_MODELS: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  gemini: "gemini-2.0-flash-lite",
+  openai: "gpt-4.1-mini",
+};
+
+export function createCompactionClient(sessionModel: string, apiKey: string): LLMClient {
+  const provider = detectProvider(sessionModel);
+  const model = COMPACTION_MODELS[provider] ?? sessionModel;
+  return createClient(model, apiKey, { provider });
+}
+
 export function createClient(
   model: string,
   apiKey: string,


### PR DESCRIPTION
## Summary

- Adds `/compact` slash command — summarizes older conversation history using a cheap LLM model (Haiku for Anthropic, Flash-lite for Gemini), keeping the last 10 messages verbatim and quoting error signals exactly to prevent trajectory elongation.
- Adds `/context` slash command — displays estimated token usage vs. the model's context window size.
- New `src/core/compact.ts` with the shared algorithm: tail-keep + structured 5-section summary (Task/Progress/Decisions/Errors/State) + error signal extraction from `function_result` parts.
- `createCompactionClient()` in `factory.ts` picks the cheapest capable model per provider using the session API key.
- No auto-compact — that is A5b, which is blocked on real-session data collected after this ships.

Closes #112
Part of #26

## Test plan

- [ ] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (501 tests)
- [ ] `npm run dev` → `/context` shows `~0 tokens` on fresh session
- [ ] After a few exchanges → `/context` shows increasing token count and percentage
- [ ] `/compact` on a short session (< 4 messages) → "too short" message
- [ ] `/compact` on a longer session → reports messages removed and summary length
- [ ] `/context` after `/compact` → token count drops
- [ ] `/help` lists both `compact` and `context` in built-in commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)