### PR TITLE
fix(agent): abort loop on repeated environmental errors

### DIFF
--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -169,6 +169,137 @@ describe("Agent plan mode", () => {
   });
 });
 
+describe("Agent environmental error guard", () => {
+  // Client that makes a different call each turn (varying args) so stuck-loop
+  // detection never fires — mirrors the real scenario where the agent edits
+  // different files each turn but the underlying OS error persists.
+  function makeVaryingClient(toolName: string): { client: LLMClient; getCallCount: () => number } {
+    let n = 0;
+    const client: LLMClient = {
+      async *stream() {
+        n++;
+        yield { type: "function_call", id: `c${n}`, name: toolName, args: { n } } as StreamEvent;
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+    return { client, getCallCount: () => n };
+  }
+
+  it("aborts after 3 consecutive turns with the same EPERM error", async () => {
+    const { client } = makeVaryingClient("bash");
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "bash",
+      description: "",
+      parameters: { type: "object", properties: { n: { type: "number" } } },
+      execute: async () => ({
+        success: false,
+        output: "",
+        error: "Error: listen EPERM: operation not permitted 0.0.0.0",
+      }),
+    });
+
+    const agent = new Agent(client, registry, new SkillRegistry(), undefined, undefined, 100);
+    const events = await collectEvents(agent, "run tests");
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeDefined();
+    expect((error as { type: "error"; message: string }).message).toMatch(/EPERM/i);
+    expect((error as { type: "error"; message: string }).message).toMatch(/environment/i);
+    // Should stop after exactly 3 turns
+    const toolCalls = events.filter((e) => e.type === "tool_call");
+    expect(toolCalls).toHaveLength(3);
+  });
+
+  it("aborts on EACCES pattern", async () => {
+    const { client } = makeVaryingClient("bash");
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "bash",
+      description: "",
+      parameters: { type: "object", properties: { n: { type: "number" } } },
+      execute: async () => ({
+        success: false,
+        output: "",
+        error: "Error: EACCES: permission denied, open '/etc/shadow'",
+      }),
+    });
+
+    const agent = new Agent(client, registry, new SkillRegistry(), undefined, undefined, 100);
+    const events = await collectEvents(agent, "read shadow");
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeDefined();
+    expect((error as { type: "error"; message: string }).message).toMatch(/EACCES/i);
+  });
+
+  it("resets env error counter when a turn produces no matching error", async () => {
+    // Two EPERM turns, then one clean turn, then two more EPERM turns.
+    // Counter resets at the clean turn so it never reaches ENV_ERROR_THRESHOLD (3).
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        // Varying args so stuck-loop never fires
+        yield {
+          type: "function_call",
+          id: `c${callCount}`,
+          name: "bash",
+          args: { n: callCount },
+        } as StreamEvent;
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "bash",
+      description: "",
+      parameters: { type: "object", properties: { n: { type: "number" } } },
+      execute: async () => {
+        // turns 1+2 → EPERM, turn 3 → clean, turns 4+5 → EPERM again
+        if (callCount === 3) return { success: true, output: "ok" };
+        return { success: false, output: "", error: "EPERM: not permitted" };
+      },
+    });
+
+    const agent = new Agent(client, registry, new SkillRegistry(), undefined, undefined, 5);
+    const events = await collectEvents(agent, "go");
+    const error = events.find((e) => e.type === "error");
+    // Counter reset at turn 3, so env guard never fires — should hit maxTurns (5)
+    expect((error as { type: "error"; message: string }).message).toMatch(/maximum iterations/i);
+  });
+
+  it("does not trigger on a single isolated env error", async () => {
+    // Model calls tool once (returns EPERM), then stops. Count is 1 — below threshold.
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        if (callCount === 1) {
+          yield {
+            type: "function_call",
+            id: "c1",
+            name: "bash",
+            args: { command: "x" },
+          } as StreamEvent;
+        }
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "bash",
+      description: "",
+      parameters: { type: "object", properties: { command: { type: "string" } } },
+      execute: async () => ({ success: false, output: "", error: "EPERM: not permitted" }),
+    });
+
+    const agent = new Agent(client, registry, new SkillRegistry(), undefined, undefined, 10);
+    const events = await collectEvents(agent, "go");
+    const error = events.find((e) => e.type === "error");
+    // No error — model stopped voluntarily after 1 turn
+    expect(error).toBeUndefined();
+  });
+});
+
 describe("Agent stuck-loop detection", () => {
   it("emits an error after 3 identical consecutive tool calls", async () => {
     const agent = new Agent(
@@ -222,7 +353,7 @@ describe("Agent stuck-loop detection", () => {
     expect(toolCalls).toHaveLength(3);
   });
 
-  it("resets stuck counter when args change", async () => {
+  it("resets stuck counter when tool args change between turns", async () => {
     let callCount = 0;
     // Alternate args every call so stuck detection never fires
     const client: LLMClient = {

--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -298,6 +298,27 @@ describe("Agent environmental error guard", () => {
     // No error — model stopped voluntarily after 1 turn
     expect(error).toBeUndefined();
   });
+
+  it("fires the env_error_loop guard_triggered observability event", async () => {
+    const { client } = makeVaryingClient("bash");
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "bash",
+      description: "",
+      parameters: { type: "object", properties: { n: { type: "number" } } },
+      execute: async () => ({ success: false, output: "", error: "EPERM: not permitted" }),
+    });
+
+    const guardEvents: string[] = [];
+    const agent = new Agent(client, registry, new SkillRegistry(), undefined, undefined, 100, {
+      onObservability: (e) => {
+        if (e.type === "guard_triggered") guardEvents.push(e.guard);
+      },
+    });
+
+    await collectEvents(agent, "go");
+    expect(guardEvents).toContain("env_error_loop");
+  });
 });
 
 describe("Agent stuck-loop detection", () => {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -29,9 +29,14 @@ const ENV_ERROR_THRESHOLD = 3;
 const ENV_ERROR_PATTERNS = [
   "EPERM",
   "EACCES",
+  "ENOSPC",
+  "EMFILE",
+  "ENOMEM",
   "permission denied",
   "operation not permitted",
   "access is denied",
+  "no space left on device",
+  "too many open files",
 ];
 
 export type AgentRunMode = "react" | "plan";

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -22,6 +22,17 @@ export type AgentEvent =
 
 const DEFAULT_MAX_TURNS = 50;
 const STUCK_THRESHOLD = 3;
+const ENV_ERROR_THRESHOLD = 3;
+
+// OS-level errors that code changes cannot fix. If the same pattern appears in
+// tool results across ENV_ERROR_THRESHOLD consecutive turns, the loop aborts.
+const ENV_ERROR_PATTERNS = [
+  "EPERM",
+  "EACCES",
+  "permission denied",
+  "operation not permitted",
+  "access is denied",
+];
 
 export type AgentRunMode = "react" | "plan";
 
@@ -96,6 +107,8 @@ export class Agent {
     let turns = 0;
     let lastCallSig = "";
     let stuckCount = 0;
+    let envErrorPattern = "";
+    let envErrorCount = 0;
     const firedReminders = new Set<string>();
 
     while (true) {
@@ -207,6 +220,37 @@ export class Agent {
       const snapshotWarning = this.snapshotManager?.drainWarning();
       if (snapshotWarning) {
         yield { type: "error", message: `[snapshot] ${snapshotWarning}` };
+      }
+
+      // Environmental error guard: OS-level errors (EPERM, EACCES, etc.) cannot
+      // be fixed by editing code. If the same pattern recurs across consecutive
+      // turns, stop and surface a diagnosis instead of burning more turns.
+      const combinedResults = results.map((r) => r.result).join("\n");
+      const matchedPattern = ENV_ERROR_PATTERNS.find((p) =>
+        combinedResults.toLowerCase().includes(p.toLowerCase()),
+      );
+      if (matchedPattern) {
+        if (matchedPattern === envErrorPattern) {
+          envErrorCount++;
+        } else {
+          envErrorPattern = matchedPattern;
+          envErrorCount = 1;
+        }
+        if (envErrorCount >= ENV_ERROR_THRESHOLD) {
+          this.obs?.({
+            type: "guard_triggered",
+            guard: "env_error_loop",
+            reason: `"${matchedPattern}" in ${ENV_ERROR_THRESHOLD} consecutive turns`,
+          });
+          yield {
+            type: "error",
+            message: `Detected "${matchedPattern}" in ${ENV_ERROR_THRESHOLD} consecutive turns. This looks like an OS or environment restriction that code changes cannot fix — check permissions, network settings, or sandbox configuration.`,
+          };
+          return;
+        }
+      } else {
+        envErrorPattern = "";
+        envErrorCount = 0;
       }
 
       // Append an event-driven reminder to the last tool result based on what

--- a/src/core/observability.ts
+++ b/src/core/observability.ts
@@ -24,7 +24,11 @@ export type ObservabilityEvent =
     }
   /** Emitted when a tool call is blocked without execution. */
   | { type: "tool_denied"; name: string; reason: "plan_mode" | "user_denied" | "non_interactive" }
-  /** Emitted when a safety guard aborts the loop (max-turns, stuck-loop). */
-  | { type: "guard_triggered"; guard: "max_turns" | "stuck_loop"; reason: string };
+  /** Emitted when a safety guard aborts the loop (max-turns, stuck-loop, env-error). */
+  | {
+      type: "guard_triggered";
+      guard: "max_turns" | "stuck_loop" | "env_error_loop";
+      reason: string;
+    };
 
 export type ObservabilityHandler = (event: ObservabilityEvent) => void;


### PR DESCRIPTION
## Summary

- Adds a second stuck-loop signal to the agentic loop for OS-level errors that code changes cannot fix. If the same error pattern (`EPERM`, `EACCES`, `permission denied`, `operation not permitted`, `access is denied`) appears in tool results across 3 consecutive turns, the loop stops and yields a clear diagnostic error message.
- The existing stuck-loop guard catches *identical* call signatures — this new guard catches varied-but-futile edit attempts where the agent modifies different files each turn but keeps hitting the same OS restriction.
- Counter resets when a turn produces no matching error, so brief transient failures don't trigger it.
- Adds `env_error_loop` to the `guard_triggered` observability event union.

**Real trigger:** `listen EPERM: operation not permitted 0.0.0.0` — a macOS network binding restriction that caused 5+ edit/test cycles before the session crashed.

Closes #121

## Test plan

- [ ] `npm run typecheck && npm run lint && npm run format:check && npm test` — 507 tests pass
- [ ] EPERM aborts after 3 turns with diagnostic message
- [ ] EACCES aborts after 3 turns
- [ ] Counter resets on a clean turn — no false abort
- [ ] Single isolated env error → loop completes normally, no abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)