### PR TITLE
validate --max-turns and --temperature flags to prevent silent NaN

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { createClient, createCompactionClient, detectProvider } from "../providers/factory.js";
 import { Agent } from "../core/agent.js";
 import { createDefaultRegistry } from "../tools/index.js";
@@ -19,6 +19,20 @@ import { McpManager } from "../mcp/manager.js";
 import { registerMcpCommand } from "./mcp-cmd.js";
 import { SnapshotManager } from "../state/snapshot.js";
 
+function parseTurns(raw: string): number {
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1)
+    throw new InvalidArgumentError("--max-turns must be a positive integer");
+  return n;
+}
+
+function parseTemperature(raw: string): number {
+  const n = parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 2)
+    throw new InvalidArgumentError("--temperature must be between 0 and 2");
+  return n;
+}
+
 const program = new Command();
 
 program
@@ -35,7 +49,7 @@ program
   )
   .option("-r, --resume", "Resume the most recent session")
   .option("-s, --session <id>", "Resume a specific session by ID")
-  .option("--max-turns <n>", "Maximum agent iterations per prompt (default: 50)", parseInt)
+  .option("--max-turns <n>", "Maximum agent iterations per prompt (default: 50)", parseTurns)
   .option("--debug", "Emit structured observability events to stderr as JSON")
   .option("--sandbox <mode>", "Sandbox mode for bash tool: auto | strict | off (default: auto)")
   .option("--provider <provider>", "Override provider detection: gemini | anthropic | openai")
@@ -73,14 +87,14 @@ program
   .command("run <prompt>")
   .description("Run a single prompt and exit")
   .option("-m, --model <model>", "Model to use")
-  .option("--max-turns <n>", "Maximum agent iterations (default: 50)", parseInt)
+  .option("--max-turns <n>", "Maximum agent iterations (default: 50)", parseTurns)
   .option("--plan", "Run a read-only planning pass first, then auto-execute the plan")
   .option("--yes", "Auto-approve all tool confirmations (skip interactive prompts)")
   .option("--debug", "Emit structured observability events to stderr as JSON")
   .option("--sandbox <mode>", "Sandbox mode for bash tool: auto | strict | off (default: auto)")
   .option("--provider <provider>", "Override provider detection: gemini | anthropic | openai")
   .option("--base-url <url>", "Custom base URL for proxy or local inference (e.g. LiteLLM)")
-  .option("--temperature <float>", "LLM temperature (use 0 for determinism)", parseFloat)
+  .option("--temperature <float>", "LLM temperature (use 0 for determinism)", parseTemperature)
   .action(async (prompt: string, opts) => {
     await runSingle(
       prompt,

--- a/src/cli/run.smoke.test.ts
+++ b/src/cli/run.smoke.test.ts
@@ -78,6 +78,46 @@ describe.skipIf(!CLI_BUILT)("CLI subprocess smoke (requires npm run build)", () 
     });
   });
 
+  it("run --max-turns with non-numeric value exits 1 with a clear error", async () => {
+    await expect(
+      execFileAsync("node", [DIST_ENTRY, "run", "--max-turns", "abc", "echo hi"], {
+        timeout: 10_000,
+      }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("--max-turns must be a positive integer"),
+    });
+  });
+
+  it("run --max-turns with zero exits 1 with a clear error", async () => {
+    await expect(
+      execFileAsync("node", [DIST_ENTRY, "run", "--max-turns", "0", "echo hi"], {
+        timeout: 10_000,
+      }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("--max-turns must be a positive integer"),
+    });
+  });
+
+  it("run --temperature with non-numeric value exits 1 with a clear error", async () => {
+    await expect(
+      execFileAsync("node", [DIST_ENTRY, "run", "--temperature", "notanumber", "echo hi"], {
+        timeout: 10_000,
+      }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("--temperature must be between 0 and 2"),
+    });
+  });
+
+  it("run --temperature with out-of-range value exits 1 with a clear error", async () => {
+    await expect(
+      execFileAsync("node", [DIST_ENTRY, "run", "--temperature", "-1", "echo hi"], {
+        timeout: 10_000,
+      }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("--temperature must be between 0 and 2"),
+    });
+  });
+
   it("OPENCLI_SANDBOX with invalid value exits 1 with a clear error", async () => {
     await expect(
       execFileAsync("node", [DIST_ENTRY, "run", "echo hi"], {


### PR DESCRIPTION
## Summary

- Replaces bare `parseInt`/`parseFloat` coercers on `--max-turns` and `--temperature` with validator functions that throw `InvalidArgumentError` on bad input
- `--max-turns abc` or `--max-turns 0` now exits 1 with `"--max-turns must be a positive integer"` instead of silently passing `NaN` (which disabled the safety guard in `agent.ts`)
- `--temperature notanumber` or out-of-range values now exits 1 with `"--temperature must be between 0 and 2"` instead of forwarding `NaN` to the provider
- Pattern matches existing `--sandbox` / `--provider` validation already in the codebase

Closes #116

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass
- [x] New smoke tests cover: non-numeric `--max-turns`, zero `--max-turns`, non-numeric `--temperature`, out-of-range `--temperature` (all run against the built dist via `npm run build`)
- [x] Valid values (`--max-turns 5`, `--temperature 0.7`) still pass through unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLp3cPtmy4GeAVwDTSqipY)_