### PR TITLE
fix(agent): retry once when LLM returns empty response mid-task

### DIFF
--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -321,6 +321,123 @@ describe("Agent environmental error guard", () => {
   });
 });
 
+describe("Agent empty-response retry", () => {
+  it("retries once when the LLM returns no text and no function calls", async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        if (callCount === 1) {
+          yield { type: "done" } as StreamEvent; // empty — no text, no calls
+        } else {
+          yield { type: "text", text: "now I have something to say" } as StreamEvent;
+          yield { type: "done" } as StreamEvent;
+        }
+      },
+    };
+
+    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry());
+    const events = await collectEvents(agent, "hi");
+
+    expect(callCount).toBe(2);
+    const texts = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as { type: "text"; text: string }).text);
+    expect(texts.join("")).toBe("now I have something to say");
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+    expect(events.find((e) => e.type === "done")).toBeDefined();
+  });
+
+  it("terminates cleanly when the retry also returns empty", async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        yield { type: "done" } as StreamEvent; // always empty
+      },
+    };
+
+    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry());
+    const events = await collectEvents(agent, "hi");
+
+    expect(callCount).toBe(2);
+    expect(events.find((e) => e.type === "done")).toBeDefined();
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+
+  it("emits the empty_response_retry observability event on first empty response", async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        if (callCount === 1) {
+          yield { type: "done" } as StreamEvent;
+        } else {
+          yield { type: "text", text: "ok" } as StreamEvent;
+          yield { type: "done" } as StreamEvent;
+        }
+      },
+    };
+
+    const obsEvents: string[] = [];
+    const agent = new Agent(
+      client,
+      makeNoopRegistry(),
+      new SkillRegistry(),
+      undefined,
+      undefined,
+      50,
+      {
+        onObservability: (e) => obsEvents.push(e.type),
+      },
+    );
+    await collectEvents(agent, "hi");
+
+    expect(obsEvents).toContain("empty_response_retry");
+  });
+
+  it("does not retry when the response has text but no tool calls", async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        yield { type: "text", text: "I'm done" } as StreamEvent;
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+
+    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry());
+    await collectEvents(agent, "hi");
+
+    expect(callCount).toBe(1);
+  });
+
+  it("resets the retry flag between user turns", async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        if (callCount % 2 === 1) {
+          yield { type: "done" } as StreamEvent; // first call of each turn is empty
+        } else {
+          yield { type: "text", text: "response" } as StreamEvent;
+          yield { type: "done" } as StreamEvent;
+        }
+      },
+    };
+
+    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry());
+    // First turn: call 1 (empty) → retry → call 2 (text)
+    const events1 = await collectEvents(agent, "first");
+    expect(events1.find((e) => e.type === "done")).toBeDefined();
+
+    // Second turn: the retry flag should be reset — call 3 (empty) → retry → call 4 (text)
+    const events2 = await collectEvents(agent, "second");
+    expect(events2.find((e) => e.type === "done")).toBeDefined();
+    expect(callCount).toBe(4);
+  });
+});
+
 describe("Agent stuck-loop detection", () => {
   it("emits an error after 3 identical consecutive tool calls", async () => {
     const agent = new Agent(

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -114,6 +114,7 @@ export class Agent {
     let stuckCount = 0;
     let envErrorPattern = "";
     let envErrorCount = 0;
+    let emptyRetried = false;
     const firedReminders = new Set<string>();
 
     while (true) {
@@ -168,9 +169,19 @@ export class Agent {
       }
 
       if (pendingCalls.length === 0) {
+        if (responseText.trim() === "" && !emptyRetried) {
+          // Empty stream (no text, no tool calls) is likely a transient provider issue
+          // (safety filter, output truncation, parse failure). Retry once before
+          // treating as intentional done — nothing was added to context, so the
+          // retry sees the same conversation state.
+          emptyRetried = true;
+          this.obs?.({ type: "empty_response_retry" });
+          continue;
+        }
         yield { type: "done" };
         return;
       }
+      emptyRetried = false;
 
       // Max turns guard
       turns++;

--- a/src/core/observability.test.ts
+++ b/src/core/observability.test.ts
@@ -148,6 +148,10 @@ describe("Agent observability — LLM call events", () => {
             name: "noop",
             args: {},
           } as StreamEvent;
+        } else {
+          // Final turn: yield text so the agent exits cleanly without triggering
+          // the empty-response retry (which would add an extra LLM call).
+          yield { type: "text", text: "done" } as StreamEvent;
         }
         yield { type: "done" } as StreamEvent;
       },

--- a/src/core/observability.ts
+++ b/src/core/observability.ts
@@ -29,6 +29,8 @@ export type ObservabilityEvent =
       type: "guard_triggered";
       guard: "max_turns" | "stuck_loop" | "env_error_loop";
       reason: string;
-    };
+    }
+  /** Emitted when the agent retries after an empty LLM response (no text, no tool calls). */
+  | { type: "empty_response_retry" };
 
 export type ObservabilityHandler = (event: ObservabilityEvent) => void;


### PR DESCRIPTION
## Summary

- When a provider stream yields neither text nor function calls, the agent loop was silently treating it as "done" and terminating — even with work still pending. This was observed with Gemini Flash-Lite hitting safety filters, output truncation, or parse failures.
- Adds a one-shot empty-response retry: on the first empty stream the loop continues; on the second consecutive empty stream it exits cleanly. The empty turn is never written to context, so the retry sees the same conversation state.
- Adds a new `empty_response_retry` observability event so the retry is visible in `--debug` output.
- Fixes the existing `observability.test.ts` test whose final stub turn returned an empty stream (triggering the retry unexpectedly) by making it yield text instead.

## Related issue

Closes #128

## Test plan

- [ ] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (526 tests, 0 failures)
- [ ] New tests in `agent.test.ts` cover: retry on first empty → success, double-empty → clean exit, obs event emitted, text-only response not retried, retry flag resets between `run()` calls
- [ ] Manually: `opencli run "hi" --yes` with Gemini Flash-Lite still terminates normally (the text response bypasses the retry path)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NvG8SkmpkKTVwLA7Q1Um1y)_