### PR TITLE
docs: sync eval default Gemini model and add billing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,11 @@ npm run typecheck    # TypeScript type check
 npm run lint         # ESLint
 npm run lint:fix     # ESLint with auto-fix
 npm run format       # Prettier
-npm test             # Vitest
+npm test             # Vitest (offline unit tests)
+npm run eval         # Cross-provider eval matrix (requires npm run build first)
 ```
+
+`npm run eval` makes real API calls and costs money (~$1–5 per full run). It requires a **billing-enabled** API key — free-tier quotas are insufficient for preview models.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
 

--- a/docs/design/d1-eval-harness.md
+++ b/docs/design/d1-eval-harness.md
@@ -183,7 +183,7 @@ export function configuredProviders(): Provider[] {
   if (process.env.ANTHROPIC_API_KEY)
     providers.push({ label: "anthropic", model: process.env.EVAL_ANTHROPIC_MODEL ?? "claude-haiku-4-5-20251001" });
   if (process.env.GEMINI_API_KEY)
-    providers.push({ label: "gemini", model: process.env.EVAL_GEMINI_MODEL ?? "gemini-2.0-flash-lite" });
+    providers.push({ label: "gemini", model: process.env.EVAL_GEMINI_MODEL ?? "gemini-3.1-flash-lite-preview" });
   if (process.env.OPENAI_API_KEY)
     providers.push({ label: "openai", model: process.env.EVAL_OPENAI_MODEL ?? "gpt-4o-mini" });
 


### PR DESCRIPTION
## Summary

- Fixes stale `gemini-2.0-flash-lite` reference in `docs/design/d1-eval-harness.md`; the provider configuration snippet now matches the actual default in `src/eval/config.ts` (`gemini-3.1-flash-lite-preview`).
- Adds `npm run eval` to the README Development section with a note that eval requires a billing-enabled API key (preview models have no free-tier quota).

The other operational concerns from issue #126 are already handled:
- **429 backoff/retry**: covered by `withRetry` in `src/providers/gemini.ts` (retries on 429/500/502/503).
- **Serial-per-provider execution**: vitest runs all tests within a single file sequentially by default — no explicit `concurrent` flag needed.

Closes #126

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (521 tests)
- [x] `docs/design/d1-eval-harness.md` provider config snippet now shows `gemini-3.1-flash-lite-preview`
- [x] README Development table includes `npm run eval` with billing note

https://claude.ai/code/session_0195mYR4oqiUGvzQsei5hfPz

---
_Generated by [Claude Code](https://claude.ai/code/session_0195mYR4oqiUGvzQsei5hfPz)_