### PR TITLE
fix(plan): skip auto-execute when run --plan produces a direct answer

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,7 @@ import { McpManager } from "../mcp/manager.js";
 import { registerMcpCommand } from "./mcp-cmd.js";
 import { SnapshotManager } from "../state/snapshot.js";
 import pkg from "../../package.json";
+import { looksLikeActionablePlan } from "./plan.js";
 
 const program = new Command();
 
@@ -250,7 +251,7 @@ async function runSingle(
   try {
     if (planMode) {
       const planText = await stream(prompt, "plan");
-      if (planText.trim()) {
+      if (planText.trim() && looksLikeActionablePlan(planText)) {
         process.stderr.write("\nExecuting plan…\n");
         await stream(
           `I have approved the following plan. Execute it step by step:\n\n${planText}`,

--- a/src/cli/plan.test.ts
+++ b/src/cli/plan.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { looksLikeActionablePlan } from "./plan.js";
+
+describe("looksLikeActionablePlan", () => {
+  it("returns true for numbered steps", () => {
+    expect(looksLikeActionablePlan("1. Read the file\n2. Add the function\n3. Run tests")).toBe(
+      true,
+    );
+  });
+
+  it("returns true for indented numbered steps", () => {
+    expect(looksLikeActionablePlan("Here is the plan:\n  1. First step\n  2. Second step")).toBe(
+      true,
+    );
+  });
+
+  it("returns true for a ## Plan section header", () => {
+    expect(looksLikeActionablePlan("## Plan\nRead and modify the file.")).toBe(true);
+  });
+
+  it("returns true for a ## Steps section header", () => {
+    expect(looksLikeActionablePlan("## Steps\n- Do this\n- Do that")).toBe(true);
+  });
+
+  it("returns true for # Steps (single hash)", () => {
+    expect(looksLikeActionablePlan("# Steps\n1. Do something")).toBe(true);
+  });
+
+  it("returns true for Step N: heading", () => {
+    expect(looksLikeActionablePlan("Step 1: Read the file\nStep 2: Write the output")).toBe(true);
+  });
+
+  it("returns false for a plain informational answer", () => {
+    expect(
+      looksLikeActionablePlan(
+        "The src/ directory contains one file: math.ts.\nThe file src/math.ts has 11 lines.",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for a single-sentence answer", () => {
+    expect(looksLikeActionablePlan("The answer is 42.")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(looksLikeActionablePlan("")).toBe(false);
+  });
+
+  it("returns false for prose without step markers", () => {
+    expect(
+      looksLikeActionablePlan(
+        "I have read the file. It contains three functions: add, subtract, and multiply.",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -66,3 +66,11 @@ async function editPlanInEditor(plan: string): Promise<string | null> {
     await rm(tmpPath).catch(() => {});
   }
 }
+
+export function looksLikeActionablePlan(text: string): boolean {
+  // Numbered steps (1. ...) or plan/steps section headers indicate an executable plan.
+  // A direct informational answer — prose with no step structure — is already complete.
+  return (
+    /^\s*\d+\./m.test(text) || /^##?\s*(plan|steps)\b/im.test(text) || /^step\s+\d+/im.test(text)
+  );
+}


### PR DESCRIPTION
## Summary

- `opencli run --plan` was unconditionally replaying the plan text back into a react-mode agent pass, even when the plan-mode pass had already produced a complete informational answer (no steps to execute)
- Adds a `looksLikeActionablePlan` guard that checks for numbered steps (`1.`), step headings (`Step N:`), or plan/steps section headers (`## Plan`, `## Steps`) — only text matching these patterns triggers auto-execution
- Direct prose answers (e.g. "The file has 11 lines.") are treated as final responses and not re-executed, avoiding the confusing "I need a plan. Please provide the steps you'd like me to take." response

Closes #125

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (531 tests, 10 new)
- [x] New unit tests in `src/cli/plan.test.ts` cover: numbered steps → actionable, indented numbered steps → actionable, `## Plan` header → actionable, `## Steps` header → actionable, `# Steps` → actionable, `Step N:` heading → actionable, plain informational answer → not actionable, single-sentence answer → not actionable, empty string → not actionable, prose without step markers → not actionable
- [ ] Manual: `opencli run "List files in src/ and tell me how many lines src/math.ts has." --plan --yes` → plan answer printed, no "Executing plan…" follow-up
- [ ] Manual: `opencli run "Add a divide(a,b) function to src/math.ts" --plan --yes` → numbered plan printed, then "Executing plan…" and execution proceeds

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_011bpRBW14ePGDxvFEVngKd1)_