### PR TITLE
fix(gemini): strip control tokens from text stream (Bug A, #125)

### DIFF
--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -299,3 +299,82 @@ describe("GeminiClient thoughtSignature handling", () => {
     expect(userMsg.parts[0]).not.toHaveProperty("thoughtSignature");
   });
 });
+
+describe("GeminiClient control token filtering", () => {
+  let mockGenerateContentStream: ReturnType<typeof vi.fn>;
+  let client: GeminiClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGenerateContentStream = vi.fn();
+    vi.mocked(GoogleGenAI).mockImplementation(
+      () =>
+        ({
+          models: { generateContentStream: mockGenerateContentStream },
+        }) as unknown as InstanceType<typeof GoogleGenAI>,
+    );
+    client = new GeminiClient("fake-key");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function* makeStream(parts: unknown[]) {
+    yield { candidates: [{ content: { parts } }] };
+  }
+
+  async function collectTextEvents(gen: AsyncGenerator<unknown>): Promise<string[]> {
+    const texts: string[] = [];
+    for await (const e of gen) {
+      if ((e as { type: string }).type === "text") texts.push((e as { text: string }).text);
+    }
+    return texts;
+  }
+
+  it("strips <end_of_turn> from a text-only chunk", async () => {
+    mockGenerateContentStream.mockReturnValue(makeStream([{ text: "<end_of_turn>" }]));
+    const texts = await collectTextEvents(client.stream([], "sys", []));
+    expect(texts).toHaveLength(0);
+  });
+
+  it("strips <end_of_turn> embedded in a larger text chunk", async () => {
+    mockGenerateContentStream.mockReturnValue(makeStream([{ text: "Hello<end_of_turn> world" }]));
+    const texts = await collectTextEvents(client.stream([], "sys", []));
+    expect(texts).toEqual(["Hello world"]);
+  });
+
+  it("strips <start_of_turn>model control token", async () => {
+    mockGenerateContentStream.mockReturnValue(
+      makeStream([{ text: "<start_of_turn>model\nSome response" }]),
+    );
+    const texts = await collectTextEvents(client.stream([], "sys", []));
+    expect(texts).toEqual(["\nSome response"]);
+  });
+
+  it("strips <start_of_turn>user control token", async () => {
+    mockGenerateContentStream.mockReturnValue(makeStream([{ text: "<start_of_turn>user\nHi" }]));
+    const texts = await collectTextEvents(client.stream([], "sys", []));
+    expect(texts).toEqual(["\nHi"]);
+  });
+
+  it("strips bare <start_of_turn> control token", async () => {
+    mockGenerateContentStream.mockReturnValue(makeStream([{ text: "<start_of_turn>answer" }]));
+    const texts = await collectTextEvents(client.stream([], "sys", []));
+    expect(texts).toEqual(["answer"]);
+  });
+
+  it("passes normal text through unchanged", async () => {
+    mockGenerateContentStream.mockReturnValue(makeStream([{ text: "Hello, world!" }]));
+    const texts = await collectTextEvents(client.stream([], "sys", []));
+    expect(texts).toEqual(["Hello, world!"]);
+  });
+
+  it("does not emit a text event when the filtered chunk is empty", async () => {
+    mockGenerateContentStream.mockReturnValue(
+      makeStream([{ text: "<end_of_turn><start_of_turn>model" }]),
+    );
+    const texts = await collectTextEvents(client.stream([], "sys", []));
+    expect(texts).toHaveLength(0);
+  });
+});

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -12,6 +12,13 @@ import { toFriendlyError } from "./errors.js";
 
 const DEFAULT_MODEL = "gemini-3-flash-preview";
 
+// Gemini thinking models occasionally emit these control tokens as plain text
+// when function calling falls back to text-mode output. Strip them defensively
+// so they never appear in user-visible streamed text.
+// <end_of_turn> is a standalone tag; <start_of_turn> is followed by the role
+// name as a separate text token (model or user), so both are stripped together.
+const GEMINI_CONTROL_RE = /<end_of_turn>|<start_of_turn>(?:model|user)?/g;
+
 export class GeminiClient implements LLMClient {
   private client: GoogleGenAI;
   private model: string;
@@ -76,7 +83,8 @@ export class GeminiClient implements LLMClient {
       if (candidate?.content?.parts) {
         for (const part of candidate.content.parts) {
           if (part.text) {
-            yield { type: "text", text: part.text };
+            const filtered = part.text.replace(GEMINI_CONTROL_RE, "");
+            if (filtered) yield { type: "text", text: filtered };
           } else if (part.functionCall) {
             const id = part.functionCall.id ?? crypto.randomUUID();
             const sig = (part as unknown as { thoughtSignature?: string }).thoughtSignature;


### PR DESCRIPTION
## Summary

- Adds a defensive regex filter (`GEMINI_CONTROL_RE`) in `src/providers/gemini.ts` that strips `<end_of_turn>` and `<start_of_turn>model/user` tokens from Gemini text stream chunks before they reach the renderer.
- Gemini thinking models (Flash Lite and similar) occasionally emit these tokenizer control tokens as plain text when the structured function-call channel falls back to text-mode output — they would otherwise appear verbatim in the user's terminal.
- Text chunks that are entirely control tokens are suppressed (no empty `text` event emitted).

Closes #125 (Bug A). Bug B was separately addressed in PR #135.

## Related issue

Part of #125 — "Plan mode: model control tokens leak to stdout"

## Test plan

- [ ] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (528 tests, 0 failures)
- [ ] 7 new unit tests in `src/providers/gemini.test.ts` covering: `<end_of_turn>` standalone, `<end_of_turn>` mid-chunk, `<start_of_turn>model`, `<start_of_turn>user`, bare `<start_of_turn>`, normal text passthrough, and all-token chunk producing no text event
- [ ] Bug A is intermittent by nature; the filter is always-on and defensive — it cannot produce false positives on normal text since the token strings (`<end_of_turn>`, `<start_of_turn>`) are not valid user-facing output

https://claude.ai/code/session_01L4bMne7CkGhu7RterFZWxs

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4bMne7CkGhu7RterFZWxs)_