### PR TITLE
fix(todo): nudge the agent to continue when pending items remain

### DIFF
--- a/src/tools/task/todo.test.ts
+++ b/src/tools/task/todo.test.ts
@@ -45,4 +45,42 @@ describe("todoWriteTool / todoReadTool", () => {
     expect(readResult.output).not.toContain("Old");
     expect(readResult.output).toContain("New");
   });
+
+  it("appends a pending-items footer when items remain pending", async () => {
+    const items = [
+      { id: "1", text: "Card detail page", status: "done" },
+      { id: "2", text: "Shopping cart", status: "done" },
+      { id: "3", text: "External API integration", status: "pending" },
+      { id: "4", text: "Authentication", status: "pending" },
+    ];
+    const result = await todoWriteTool.execute({ items });
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("2 pending item(s) remaining");
+    expect(result.output).toContain("- [3] External API integration");
+    expect(result.output).toContain("- [4] Authentication");
+    expect(result.output).toContain("Continue with the next pending item");
+  });
+
+  it("omits the pending footer when no items are pending", async () => {
+    const items = [
+      { id: "1", text: "First", status: "done" },
+      { id: "2", text: "Second", status: "done" },
+    ];
+    const result = await todoWriteTool.execute({ items });
+    expect(result.output).not.toContain("pending item(s) remaining");
+    expect(result.output).not.toContain("Continue with the next pending item");
+  });
+
+  it("counts in_progress items as still active (not pending) in the footer", async () => {
+    const items = [
+      { id: "1", text: "Currently working", status: "in_progress" },
+      { id: "2", text: "Up next", status: "pending" },
+    ];
+    const result = await todoWriteTool.execute({ items });
+    // Only "pending" status items count toward the footer reminder. in_progress
+    // items are visible in the main list; the model already knows it's working on them.
+    expect(result.output).toContain("1 pending item(s) remaining");
+    expect(result.output).toContain("- [2] Up next");
+    expect(result.output).not.toContain("- [1] Currently working");
+  });
 });

--- a/src/tools/task/todo.ts
+++ b/src/tools/task/todo.ts
@@ -43,16 +43,31 @@ export const todoWriteTool: Tool = {
     try {
       await mkdir(dirname(TODO_PATH), { recursive: true });
       await writeFile(TODO_PATH, JSON.stringify(items, null, 2), "utf8");
-      const list = (items as TodoItem[])
-        .map((it) => `[${statusIcon(it.status)}] ${it.id}. ${it.text}`)
-        .join("\n");
-      return { success: true, output: list || "(empty list)" };
+      const typed = items as TodoItem[];
+      const list = typed.map((it) => `[${statusIcon(it.status)}] ${it.id}. ${it.text}`).join("\n");
+      // Why: agents often emit a summary and stop after marking 1-2 items done,
+      // leaving the rest of a multi-step task incomplete. The pending footer is
+      // appended to the tool result so the model sees the unfinished work on
+      // its next turn and either continues or explicitly states why it's stopping.
+      const pending = typed.filter((it) => it.status === "pending");
+      const footer = pending.length > 0 ? pendingFooter(pending) : "";
+      return { success: true, output: (list || "(empty list)") + footer };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return { success: false, output: "", error: message };
     }
   },
 };
+
+function pendingFooter(pending: TodoItem[]): string {
+  const lines = pending.map((it) => `  - [${it.id}] ${it.text}`).join("\n");
+  return (
+    `\n\n${pending.length} pending item(s) remaining:\n${lines}\n\n` +
+    `Continue with the next pending item. Only stop if the user has redirected you, ` +
+    `a pending item is blocked on input you need, or all remaining items are out of scope — ` +
+    `and in those cases, say so explicitly before stopping.`
+  );
+}
 
 export const todoReadTool: Tool = {
   name: "todo_read",


### PR DESCRIPTION
## Summary

- Investigation of session [2026-05-17T22-00-06-184](https://github.com/zjshen14/opencli/issues) (card_trade) revealed the agent created a 6-item todo, completed items 1 and 2, then emitted a summary message with no tool calls and the agentic loop exited. Items 3–6 were never touched. The user had to manually prompt four separate times to get any progress.
- Root cause: the \`todo_write\` tool result just shows the list. Nothing in the result tells the model that pending work remains. LLMs treat \"completed a few items + summarized\" as a natural stopping point.
- Fix: append a pending-items footer to \`todo_write\`'s output. The footer enumerates the pending items and instructs the model to continue, or to explicitly state why it's stopping (user redirection, blocked on input, out of scope).

## Related issue

(No tracking issue — found via session forensics. This complements the recently-merged sandbox fix #148 / closes #127, which was the *other* reason the same session stalled.)

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm test\` — 549 tests pass (+3 new)
- [x] New unit tests cover: footer appears when pending items exist; footer omitted when all done; \`in_progress\` items don't count as pending
- [ ] Manual verification: re-run a multi-step task and confirm the agent works through the full todo list without prompting

## Notes for reviewers

The footer is intentionally directive (\"Continue with the next pending item. Only stop if…\") rather than passive. A passive reminder (\"You have N pending items\") wouldn't change the model's behavior — the model already knows that and chooses to stop anyway. The directive language is the lever.

\`in_progress\` items are deliberately excluded from the footer: the model is presumed to know it's working on them, and including them would make the reminder fire on every \`todo_write\` call even mid-task. Only \`pending\` items (work not yet started) trigger the nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)