### PR TITLE
fix(bash): unblock when backgrounded grandchildren hold stdio pipes

### DIFF
--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -221,7 +221,7 @@ After every code change:
 - One \`edit\` call per file per turn to avoid conflicts
 - **edit**: always \`read\` the file first; \`old_string\` must match exactly — whitespace and indentation included; if it fails with "not found", re-read and try again with the exact content
 - **bash**: if a command fails, read the full error output before retrying; never retry unchanged
-- **bash long-running servers**: use \`nohup CMD > log 2>&1 < /dev/null &\` to background dev servers and daemons. Never end an \`&&\` chain with a backgrounded long-running command (e.g. \`A && B && server &\`) — the backgrounded subshell inherits stdio pipes and the call will hang until timeout. After starting, verify with \`sleep 2 && curl -s localhost:PORT\` or \`tail log\`.
+- **bash long-running servers**: use \`nohup CMD > log 2>&1 < /dev/null &\` to background dev servers and daemons — all three FDs must be redirected so the shell can return immediately. Never end an \`&&\` chain with a backgrounded long-running command (e.g. \`A && B && server &\`) — the backgrounded subshell inherits stdio pipes and the call will hang until timeout. After starting, verify with \`sleep 2 && curl -s localhost:PORT\` or \`tail log\`.
 - **think**: use before starting any change that touches more than two files; reason through the approach and order of changes
 - **todo_write**: for tasks with more than three steps, write the steps first and check them off as you go
 

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -221,6 +221,7 @@ After every code change:
 - One \`edit\` call per file per turn to avoid conflicts
 - **edit**: always \`read\` the file first; \`old_string\` must match exactly — whitespace and indentation included; if it fails with "not found", re-read and try again with the exact content
 - **bash**: if a command fails, read the full error output before retrying; never retry unchanged
+- **bash long-running servers**: use \`nohup CMD > log 2>&1 < /dev/null &\` to background dev servers and daemons. Never end an \`&&\` chain with a backgrounded long-running command (e.g. \`A && B && server &\`) — the backgrounded subshell inherits stdio pipes and the call will hang until timeout. After starting, verify with \`sleep 2 && curl -s localhost:PORT\` or \`tail log\`.
 - **think**: use before starting any change that touches more than two files; reason through the approach and order of changes
 - **todo_write**: for tasks with more than three steps, write the steps first and check them off as you go
 

--- a/src/tools/exec/sandbox/bwrap.ts
+++ b/src/tools/exec/sandbox/bwrap.ts
@@ -134,6 +134,10 @@ export class BwrapRunner implements SandboxRunner {
         cwd: opts.cwd,
         env: opts.env ?? process.env,
         stdio: ["ignore", "pipe", "pipe"],
+        // bwrap becomes its own process group leader so spawnAndCollect
+        // can kill the whole group (including backgrounded grandchildren)
+        // on timeout via process.kill(-proc.pid, ...).
+        detached: true,
       },
     );
 

--- a/src/tools/exec/sandbox/passthrough.test.ts
+++ b/src/tools/exec/sandbox/passthrough.test.ts
@@ -25,12 +25,19 @@ describe("PassthroughRunner", () => {
     expect(result.exitCode).toBe(-1);
   });
 
-  it("unblocks within grace period when command backgrounds a process holding stdio", async () => {
+  it("unblocks promptly when command backgrounds a process holding stdio", async () => {
     // Issue #151 repro: a backgrounded grandchild that doesn't redirect
     // stdin/stdout/stderr keeps the spawn's pipe FDs open. Before the fix,
-    // the bash tool's Promise never resolved because `close` waited on those
-    // pipes. With detached spawn + process-group kill on timeout, the tool
-    // must unblock within (timeout + grace + force-resolve buffer).
+    // `close` couldn't fire and the bash tool's Promise hung forever.
+    //
+    // With `detached: true`, sleep stays in the shell's process group
+    // after the shell exits. The timer at `timeout` ms then sends SIGTERM
+    // to the process group via process.kill(-pid, ...). sleep dies, the
+    // pipes close, `close` fires with timedOut=true → exitCode -1.
+    //
+    // (Note: there's no SIGHUP cascade here because stdio is piped, not a
+    // controlling terminal — so session-leader-exit doesn't auto-signal
+    // the background job. The timer is what actually kills sleep.)
     const start = Date.now();
     const result = await runner.exec("sleep 30 & echo started", {
       cwd: process.cwd(),
@@ -38,14 +45,10 @@ describe("PassthroughRunner", () => {
     });
     const elapsed = Date.now() - start;
     // Must resolve well before the 30-second sleep finishes naturally.
-    // Budget: 300ms timeout + 2000ms SIGTERM→SIGKILL grace + 500ms force
-    // window + small slack.
-    expect(elapsed).toBeLessThan(5000);
-    // Either the shell exited cleanly after echo (the `close` event fired
-    // because nothing inherited the pipes that lap), OR the timeout fired
-    // and we forced detach. Both are acceptable — the test is about NOT
-    // hanging past the 30s sleep.
-    expect([0, -1]).toContain(result.exitCode);
+    // Expected: ~300-500ms (timeout + signal latency).
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.exitCode).toBe(-1);
+    expect(result.stdout).toContain("started");
   }, 10_000);
 
   it("exposes mode and null warning", () => {

--- a/src/tools/exec/sandbox/passthrough.test.ts
+++ b/src/tools/exec/sandbox/passthrough.test.ts
@@ -25,6 +25,29 @@ describe("PassthroughRunner", () => {
     expect(result.exitCode).toBe(-1);
   });
 
+  it("unblocks within grace period when command backgrounds a process holding stdio", async () => {
+    // Issue #151 repro: a backgrounded grandchild that doesn't redirect
+    // stdin/stdout/stderr keeps the spawn's pipe FDs open. Before the fix,
+    // the bash tool's Promise never resolved because `close` waited on those
+    // pipes. With detached spawn + process-group kill on timeout, the tool
+    // must unblock within (timeout + grace + force-resolve buffer).
+    const start = Date.now();
+    const result = await runner.exec("sleep 30 & echo started", {
+      cwd: process.cwd(),
+      timeout: 300,
+    });
+    const elapsed = Date.now() - start;
+    // Must resolve well before the 30-second sleep finishes naturally.
+    // Budget: 300ms timeout + 2000ms SIGTERM→SIGKILL grace + 500ms force
+    // window + small slack.
+    expect(elapsed).toBeLessThan(5000);
+    // Either the shell exited cleanly after echo (the `close` event fired
+    // because nothing inherited the pipes that lap), OR the timeout fired
+    // and we forced detach. Both are acceptable — the test is about NOT
+    // hanging past the 30s sleep.
+    expect([0, -1]).toContain(result.exitCode);
+  }, 10_000);
+
   it("exposes mode and null warning", () => {
     expect(runner.mode).toBe("off");
     expect(runner.warning).toBeNull();

--- a/src/tools/exec/sandbox/passthrough.ts
+++ b/src/tools/exec/sandbox/passthrough.ts
@@ -33,12 +33,15 @@ export async function spawnAndCollect(
     proc.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
     proc.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
 
+    let killTimer: NodeJS.Timeout | undefined;
+    let forceTimer: NodeJS.Timeout | undefined;
+
     const finish = (exitCode: number): void => {
       if (resolved) return;
       resolved = true;
       clearTimeout(timer);
-      clearTimeout(killTimer);
-      clearTimeout(forceTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (forceTimer) clearTimeout(forceTimer);
       // Detach stdio so a stuck grandchild can't keep this Promise alive
       // through the Node event loop after we've already given up.
       try {
@@ -59,7 +62,9 @@ export async function spawnAndCollect(
     };
 
     const killGroup = (signal: NodeJS.Signals): void => {
-      if (proc.pid === undefined) return;
+      // Guard against undefined (spawn failed) and 0/negative (would kill
+      // the calling process's group via process.kill(-0, ...) — catastrophic).
+      if (proc.pid === undefined || proc.pid <= 0) return;
       try {
         // Negative PID targets the process group — works only when the proc
         // was spawned with detached: true. Falls back to direct child kill.
@@ -72,11 +77,6 @@ export async function spawnAndCollect(
         }
       }
     };
-
-    let killTimer: NodeJS.Timeout = setTimeout(() => {}, 0);
-    let forceTimer: NodeJS.Timeout = setTimeout(() => {}, 0);
-    clearTimeout(killTimer);
-    clearTimeout(forceTimer);
 
     const timer = setTimeout(() => {
       timedOut = true;

--- a/src/tools/exec/sandbox/passthrough.ts
+++ b/src/tools/exec/sandbox/passthrough.ts
@@ -1,9 +1,24 @@
 import { spawn } from "node:child_process";
 import type { SandboxExecOptions, SandboxExecResult, SandboxMode, SandboxRunner } from "./types.js";
 
+// Grace period between SIGTERM and SIGKILL when a timeout fires.
+const KILL_GRACE_MS = 2_000;
+// Extra wait after SIGKILL before we give up on `close` and force-resolve.
+// Backgrounded grandchildren can keep stdio pipes open even after the
+// immediate child dies; without this, the Promise would never resolve.
+const FORCE_RESOLVE_MS = 500;
+
 /**
  * Collect stdout/stderr from a spawned process and resolve when it closes.
- * Sends SIGTERM after timeoutMs and resolves with exitCode -1.
+ *
+ * Timeout semantics:
+ *   - At timeoutMs, send SIGTERM to the process group (proc must be spawned
+ *     with detached: true so killing -proc.pid targets the group, not just
+ *     the immediate child).
+ *   - If the process hasn't closed after KILL_GRACE_MS, send SIGKILL.
+ *   - If `close` still hasn't fired after FORCE_RESOLVE_MS (typically
+ *     because a backgrounded grandchild is still holding stdio pipes open),
+ *     force-resolve the Promise with exitCode -1 so the bash tool unblocks.
  */
 export async function spawnAndCollect(
   proc: ReturnType<typeof spawn>,
@@ -12,23 +27,81 @@ export async function spawnAndCollect(
   return new Promise((resolve) => {
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
+    let resolved = false;
+    let timedOut = false;
 
     proc.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
     proc.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
 
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      proc.kill("SIGTERM");
-    }, timeoutMs);
-
-    proc.on("close", (code) => {
+    const finish = (exitCode: number): void => {
+      if (resolved) return;
+      resolved = true;
       clearTimeout(timer);
+      clearTimeout(killTimer);
+      clearTimeout(forceTimer);
+      // Detach stdio so a stuck grandchild can't keep this Promise alive
+      // through the Node event loop after we've already given up.
+      try {
+        proc.stdout?.destroy();
+      } catch {
+        // ignore
+      }
+      try {
+        proc.stderr?.destroy();
+      } catch {
+        // ignore
+      }
       resolve({
         stdout: Buffer.concat(stdout).toString("utf8").trimEnd(),
         stderr: Buffer.concat(stderr).toString("utf8").trimEnd(),
-        exitCode: timedOut ? -1 : (code ?? 1),
+        exitCode,
       });
+    };
+
+    const killGroup = (signal: NodeJS.Signals): void => {
+      if (proc.pid === undefined) return;
+      try {
+        // Negative PID targets the process group — works only when the proc
+        // was spawned with detached: true. Falls back to direct child kill.
+        process.kill(-proc.pid, signal);
+      } catch {
+        try {
+          proc.kill(signal);
+        } catch {
+          // already gone
+        }
+      }
+    };
+
+    let killTimer: NodeJS.Timeout = setTimeout(() => {}, 0);
+    let forceTimer: NodeJS.Timeout = setTimeout(() => {}, 0);
+    clearTimeout(killTimer);
+    clearTimeout(forceTimer);
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killGroup("SIGTERM");
+      killTimer = setTimeout(() => {
+        killGroup("SIGKILL");
+        forceTimer = setTimeout(() => {
+          if (!resolved) {
+            stderr.push(
+              Buffer.from(
+                "\n[opencli] command timed out; backgrounded child still holding stdio — forcing detach.\n",
+              ),
+            );
+            finish(-1);
+          }
+        }, FORCE_RESOLVE_MS);
+      }, KILL_GRACE_MS);
+    }, timeoutMs);
+
+    proc.on("close", (code) => {
+      finish(timedOut ? -1 : (code ?? 1));
+    });
+
+    proc.on("error", () => {
+      finish(-1);
     });
   });
 }
@@ -47,6 +120,9 @@ export class PassthroughRunner implements SandboxRunner {
       cwd: opts.cwd,
       env: opts.env ?? process.env,
       stdio: ["ignore", "pipe", "pipe"],
+      // detached: shell becomes its own process group leader so we can
+      // kill the whole group (including backgrounded grandchildren) on timeout.
+      detached: true,
     });
     return spawnAndCollect(proc, opts.timeout ?? 30_000);
   }

--- a/src/tools/exec/sandbox/sandbox-exec.ts
+++ b/src/tools/exec/sandbox/sandbox-exec.ts
@@ -118,6 +118,10 @@ export class SandboxExecRunner implements SandboxRunner {
       cwd: opts.cwd,
       env: opts.env ?? process.env,
       stdio: ["ignore", "pipe", "pipe"],
+      // sandbox-exec becomes its own process group leader so spawnAndCollect
+      // can kill the whole group (including any backgrounded grandchildren
+      // like `npm run dev &`) on timeout via process.kill(-proc.pid, ...).
+      detached: true,
     });
 
     return spawnAndCollect(proc, opts.timeout ?? 30_000);


### PR DESCRIPTION
## Summary

- Live session debugging revealed a hard bash-tool hang when the agent runs a backgrounded long-running process via an \`&&\` chain (e.g. \`kill -9 PID && rm -rf .next && npm run dev > log 2>&1 &\`). The backgrounded subshell holds inherited stdout/stderr pipe FDs forever; \`spawn.close\` never fires; the 30s SIGTERM misses the subshell because it targets only the immediate child PID. Result: the entire OpenCLI session is stuck until the user kills it manually.
- Fix in three parts:
  1. Each sandbox runner (\`passthrough\`, \`sandbox-exec\`, \`bwrap\`) spawns with \`detached: true\`, making the child its own process group leader.
  2. \`spawnAndCollect\` kills the process **group** on timeout (\`process.kill(-proc.pid, sig)\`), escalates SIGTERM → SIGKILL after a 2s grace, then force-resolves the Promise after a 500ms window if \`close\` still hasn't fired. \`proc.stdout/stderr.destroy()\` releases Node's hold on the pipes.
  3. System prompt now tells the agent to use \`nohup CMD > log 2>&1 < /dev/null &\` for long-running servers and to never end an \`&&\` chain with a backgrounded long-running command.

## Related issue

Closes #151

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm test\` — 550 tests pass
- [x] New regression test: \`PassthroughRunner > unblocks within grace period when command backgrounds a process holding stdio\` — runs \`sleep 30 & echo started\` with a 300ms timeout, asserts the call resolves in under 5s. Old behavior would hang ~30s.
- [x] Existing timeout test still passes (\`returns exitCode -1 on timeout\` — \`sleep 60\` with timeout=100ms)
- [ ] Manual verification: from a fresh REPL, ask the agent to run \`npm run dev > dev.log 2>&1 & sleep 2 && curl localhost:3000\` and confirm it returns promptly with the curl output

## Notes for reviewers

The three-stage timeout escalation (SIGTERM → grace → SIGKILL → grace → force-resolve) is overkill for most cases but handles the worst case: a backgrounded grandchild that ignores both signals because it's in a different process group AND has inherited pipe FDs. The two grace windows (2000ms + 500ms) are conservative; could be tightened later if telemetry shows shorter is sufficient.

\`detached: true\` is safe here because we still call \`spawn.on(\"close\", ...)\` — Node tracks the child until close fires. We don't \`unref()\` (which would let Node exit even if the child is still running). The only behavior change is signal targeting: signals sent via \`process.kill(-proc.pid, ...)\` now hit the whole group.

The system prompt addition is paired with the runtime fix because even with the runtime fix, the agent's command would now hit the 30s timeout (still slow). The prompt nudge teaches the agent to use \`nohup\` upfront, avoiding the 30s wait entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)