### PR TITLE
fix(sandbox): kill process group on timeout to prevent pipe-hang deadlock

### DIFF
--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -221,6 +221,7 @@ After every code change:
 - One \`edit\` call per file per turn to avoid conflicts
 - **edit**: always \`read\` the file first; \`old_string\` must match exactly — whitespace and indentation included; if it fails with "not found", re-read and try again with the exact content
 - **bash**: if a command fails, read the full error output before retrying; never retry unchanged
+- **bash (background servers)**: use \`nohup CMD > log 2>&1 < /dev/null &\` to start long-running processes; never end an \`&&\` chain with a backgrounded server — the subshell inherits pipe file descriptors and the tool call will hang until the server exits
 - **think**: use before starting any change that touches more than two files; reason through the approach and order of changes
 - **todo_write**: for tasks with more than three steps, write the steps first and check them off as you go
 

--- a/src/tools/exec/sandbox/bwrap.ts
+++ b/src/tools/exec/sandbox/bwrap.ts
@@ -134,6 +134,7 @@ export class BwrapRunner implements SandboxRunner {
         cwd: opts.cwd,
         env: opts.env ?? process.env,
         stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
       },
     );
 

--- a/src/tools/exec/sandbox/passthrough.test.ts
+++ b/src/tools/exec/sandbox/passthrough.test.ts
@@ -25,6 +25,16 @@ describe("PassthroughRunner", () => {
     expect(result.exitCode).toBe(-1);
   });
 
+  it("resolves after timeout when a backgrounded child holds pipes open", async () => {
+    // Reproduces: bash runs `sleep 60 &` — shell exits immediately but sleep
+    // inherits the pipe FDs, so close() never fires without a group kill.
+    const start = Date.now();
+    const result = await runner.exec("sleep 60 &", { cwd: process.cwd(), timeout: 300 });
+    expect(result.exitCode).toBe(-1);
+    // Must resolve well within timeout + 2 s grace, not hang indefinitely.
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
   it("exposes mode and null warning", () => {
     expect(runner.mode).toBe("off");
     expect(runner.warning).toBeNull();

--- a/src/tools/exec/sandbox/passthrough.ts
+++ b/src/tools/exec/sandbox/passthrough.ts
@@ -1,10 +1,6 @@
 import { spawn } from "node:child_process";
 import type { SandboxExecOptions, SandboxExecResult, SandboxMode, SandboxRunner } from "./types.js";
 
-/**
- * Collect stdout/stderr from a spawned process and resolve when it closes.
- * Sends SIGTERM after timeoutMs and resolves with exitCode -1.
- */
 export async function spawnAndCollect(
   proc: ReturnType<typeof spawn>,
   timeoutMs: number,
@@ -17,18 +13,52 @@ export async function spawnAndCollect(
     proc.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
 
     let timedOut = false;
+    let settled = false;
+
+    const settle = (exitCode: number) => {
+      if (settled) return;
+      settled = true;
+      resolve({
+        stdout: Buffer.concat(stdout).toString("utf8").trimEnd(),
+        stderr: Buffer.concat(stderr).toString("utf8").trimEnd(),
+        exitCode,
+      });
+    };
+
+    // Kill the entire process group so backgrounded children (which inherit
+    // the pipe FDs) also receive the signal and release the pipes.
+    const killGroup = (sig: NodeJS.Signals) => {
+      if (proc.pid === undefined) return;
+      try {
+        process.kill(-proc.pid, sig);
+      } catch {
+        // group already gone; fall back to killing the individual process
+        try {
+          proc.kill(sig);
+        } catch {
+          // already dead
+        }
+      }
+    };
+
     const timer = setTimeout(() => {
       timedOut = true;
-      proc.kill("SIGTERM");
+      killGroup("SIGTERM");
+      // If close still hasn't fired after a grace period (backgrounded children
+      // may hold the pipe FDs open even after their parent shell exits), force-
+      // resolve and destroy the streams to release the event-loop references.
+      const killTimer = setTimeout(() => {
+        killGroup("SIGKILL");
+        proc.stdout?.destroy();
+        proc.stderr?.destroy();
+        settle(-1);
+      }, 2_000);
+      killTimer.unref();
     }, timeoutMs);
 
     proc.on("close", (code) => {
       clearTimeout(timer);
-      resolve({
-        stdout: Buffer.concat(stdout).toString("utf8").trimEnd(),
-        stderr: Buffer.concat(stderr).toString("utf8").trimEnd(),
-        exitCode: timedOut ? -1 : (code ?? 1),
-      });
+      settle(timedOut ? -1 : (code ?? 1));
     });
   });
 }
@@ -43,10 +73,13 @@ export class PassthroughRunner implements SandboxRunner {
   }
 
   async exec(command: string, opts: SandboxExecOptions): Promise<SandboxExecResult> {
+    // detached: true makes the child a process group leader so killGroup()
+    // can send signals to the entire group (including backgrounded children).
     const proc = spawn("bash", ["-c", command], {
       cwd: opts.cwd,
       env: opts.env ?? process.env,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
     });
     return spawnAndCollect(proc, opts.timeout ?? 30_000);
   }

--- a/src/tools/exec/sandbox/sandbox-exec.ts
+++ b/src/tools/exec/sandbox/sandbox-exec.ts
@@ -118,6 +118,7 @@ export class SandboxExecRunner implements SandboxRunner {
       cwd: opts.cwd,
       env: opts.env ?? process.env,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
     });
 
     return spawnAndCollect(proc, opts.timeout ?? 30_000);


### PR DESCRIPTION
## Summary

- **Root cause**: when an agent command backgrounds a long-running process via an `&&`-chain (e.g. `kill -9 PID && npm run dev > dev.log 2>&1 &`), bash runs the whole chain in a backgrounded subshell that **inherits Node's stdout/stderr pipe file descriptors**. The server never exits, never closes those FDs, so Node's `spawn('close')` event never fires and the Promise hangs forever — making the session unrecoverable.
- **Process-group kill**: all three runners (`PassthroughRunner`, `SandboxExecRunner`, `BwrapRunner`) now spawn with `detached: true` so the child shell becomes its own process group leader. `spawnAndCollect` now sends `SIGTERM` to the **entire group** (`process.kill(-proc.pid, "SIGTERM")`) on timeout, reaching backgrounded children that previously survived.
- **Force-resolve after grace period**: after SIGTERM, a 2-second grace timer fires `SIGKILL` on the group and then force-resolves the Promise (destroying the stdout/stderr streams to release pipe FD references) — so the agent loop recovers even if some process escapes the kill.
- **System-prompt guidance**: added a `bash (background servers)` bullet to `DEFAULT_SYSTEM_INSTRUCTION` directing the LLM to use `nohup CMD > log 2>&1 < /dev/null &` for long-running servers instead of ending an `&&`-chain with a backgrounded process.

Closes #151

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all 539 tests pass
- [x] New regression test `PassthroughRunner > resolves after timeout when a backgrounded child holds pipes open`: runs `bash -c "sleep 60 &"` with a 300 ms timeout; verifies `exitCode === -1` and completes in < 5 s (actual: ~303 ms — SIGTERM reaches the group and sleep exits cleanly)
- [x] Existing timeout test (`sleep 60` with 100 ms timeout) still passes unchanged

https://claude.ai/code/session_019Lo1p8X6xUnqCvR4AKa8DX

---
_Generated by [Claude Code](https://claude.ai/code/session_019Lo1p8X6xUnqCvR4AKa8DX)_