### PR TITLE
fix(resume): unblock Gemini thinking-model sessions + prune-anchor hardening

### DIFF
--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -73,8 +73,11 @@ export async function runRepl(
     for (const w of warnings) printInfo(w);
     const input = expanded;
 
-    // Log expanded content so resumed sessions restore the same context the agent saw
-    void session.log({ type: "user", content: input });
+    // NOTE: user messages are logged at the point they actually reach the agent
+    // (just before runPlanFlow / runAgentTurn below). Logging here would persist
+    // REPL-only commands like /exit, /help, /clear as user content — resumed
+    // sessions would then replay them as consecutive user messages and the
+    // provider would reject with INVALID_ARGUMENT (role alternation violated).
 
     // Built-in commands
     if (input === "/help") {
@@ -97,6 +100,7 @@ export async function runRepl(
         printError("Usage: /plan <task description>");
         continue;
       }
+      void session.log({ type: "user", content: planPrompt });
       await runPlanFlow(agent, session, planPrompt);
       continue;
     }
@@ -224,6 +228,7 @@ export async function runRepl(
       userMessage = args || `Please follow the ${entry.name} skill instructions.`;
     }
 
+    void session.log({ type: "user", content: userMessage });
     await runAgentTurn(agent, session, userMessage);
   }
 

--- a/src/core/compact.test.ts
+++ b/src/core/compact.test.ts
@@ -119,7 +119,8 @@ describe("compactHistory", () => {
     // Put the error message first so it ends up in the head (head = total - KEEP_RECENT messages).
     // With 20 total messages, head = first 10, so the error at index 0 is always in the head.
     ctx.addMessage(errorResultMsg("bash", "Error: command not found: foo"));
-    for (let i = 0; i < 19; i++) ctx.addMessage(userMsg(`msg ${i}`));
+    for (let i = 0; i < 19; i++)
+      ctx.addMessage(i % 2 === 0 ? userMsg(`msg ${i}`) : modelMsg(`msg ${i}`));
     const result = await compactHistory(ctx, makeMockClient(FIXED_SUMMARY));
     expect(result.messagesRemoved).toBeGreaterThan(0);
     const summaryText = (ctx.getMessages()[0].parts[0] as { type: string; text: string }).text;
@@ -150,7 +151,8 @@ describe("compactHistory — tool message flattening", () => {
       parts: [{ type: "function_result", id: "c1", name: "bash", result: "file.ts\n" }],
     });
     // Pad to 20 so head is non-empty
-    for (let i = 0; i < 17; i++) ctx.addMessage(userMsg(`pad ${i}`));
+    for (let i = 0; i < 17; i++)
+      ctx.addMessage(i % 2 === 0 ? userMsg(`pad ${i}`) : modelMsg(`pad ${i}`));
 
     const { client, captured } = makeCapturingClient(FIXED_SUMMARY);
     await compactHistory(ctx, client);
@@ -175,7 +177,8 @@ describe("compactHistory — tool message flattening", () => {
       role: "user",
       parts: [{ type: "function_result", id: "c1", name: "bash", result: "hi\n" }],
     });
-    for (let i = 0; i < 17; i++) ctx.addMessage(userMsg(`pad ${i}`));
+    for (let i = 0; i < 17; i++)
+      ctx.addMessage(i % 2 === 0 ? userMsg(`pad ${i}`) : modelMsg(`pad ${i}`));
 
     const { client, captured } = makeCapturingClient(FIXED_SUMMARY);
     await compactHistory(ctx, client);
@@ -197,7 +200,8 @@ describe("compactHistory — tool message flattening", () => {
       role: "user",
       parts: [{ type: "function_result", id: "c1", name: "bash", result: longOutput }],
     });
-    for (let i = 0; i < 17; i++) ctx.addMessage(userMsg(`pad ${i}`));
+    for (let i = 0; i < 17; i++)
+      ctx.addMessage(i % 2 === 0 ? userMsg(`pad ${i}`) : modelMsg(`pad ${i}`));
 
     const { client, captured } = makeCapturingClient(FIXED_SUMMARY);
     await compactHistory(ctx, client);
@@ -227,7 +231,8 @@ describe("compactHistory — tool message flattening", () => {
       role: "user",
       parts: [{ type: "function_result", id: "c1", name: "write", result: "ok" }],
     });
-    for (let i = 0; i < 17; i++) ctx.addMessage(userMsg(`pad ${i}`));
+    for (let i = 0; i < 17; i++)
+      ctx.addMessage(i % 2 === 0 ? userMsg(`pad ${i}`) : modelMsg(`pad ${i}`));
 
     const { client, captured } = makeCapturingClient(FIXED_SUMMARY);
     await compactHistory(ctx, client);
@@ -247,7 +252,8 @@ describe("compactHistory — tool message flattening", () => {
     // messages and risking role-alternation errors on strict providers.
     ctx.addMessage({ role: "model", parts: [{ type: "text", text: "   " }] });
     ctx.addMessage(userMsg("continue"));
-    for (let i = 0; i < 17; i++) ctx.addMessage(userMsg(`pad ${i}`));
+    for (let i = 0; i < 17; i++)
+      ctx.addMessage(i % 2 === 0 ? userMsg(`pad ${i}`) : modelMsg(`pad ${i}`));
 
     const { client, captured } = makeCapturingClient(FIXED_SUMMARY);
     await compactHistory(ctx, client);

--- a/src/core/context.test.ts
+++ b/src/core/context.test.ts
@@ -110,6 +110,33 @@ describe("ContextManager", () => {
     expect(msgs[1].role).toBe("model");
   });
 
+  it("merges consecutive user-text messages so providers never see two user turns in a row", () => {
+    const ctx = new ContextManager(STUB);
+    // Simulates restoring a session that ended on a user message (agent crashed),
+    // then the user typing again. Without merge, Gemini returns 400 INVALID_ARGUMENT.
+    ctx.addMessage(userMsg("first"));
+    ctx.addMessage(userMsg("continue"));
+    const msgs = ctx.getMessages();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "first\n\ncontinue" }],
+    });
+  });
+
+  it("does not merge a function_result user message into a preceding text user message", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("run ls"));
+    ctx.addMessage({
+      role: "user",
+      parts: [{ type: "function_result", id: "c1", name: "bash", result: "ok" }],
+    });
+    const msgs = ctx.getMessages();
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].parts[0]).toMatchObject({ type: "text" });
+    expect(msgs[1].parts[0]).toMatchObject({ type: "function_result" });
+  });
+
   it("clears history and skills", () => {
     const ctx = new ContextManager(STUB);
     ctx.addMessage(userMsg("hello"));
@@ -221,13 +248,16 @@ describe("ContextManager", () => {
 
   it("prunes history beyond maxHistoryMessages (50 default)", () => {
     const ctx = new ContextManager(STUB);
+    // Use alternating user/model so messages aren't collapsed by the
+    // consecutive-user-text merge.
     for (let i = 0; i < 60; i++) {
       ctx.addMessage(userMsg(`message ${i}`));
+      ctx.addMessage(modelMsg(`reply ${i}`));
     }
     const msgs = ctx.getMessages();
     expect(msgs.length).toBeLessThanOrEqual(50);
     expect((msgs[msgs.length - 1].parts[0] as { type: string; text: string }).text).toBe(
-      "message 59",
+      "reply 59",
     );
   });
 
@@ -235,11 +265,13 @@ describe("ContextManager", () => {
     const ctx = new ContextManager(STUB, 5);
     for (let i = 0; i < 10; i++) {
       ctx.addMessage(userMsg(`message ${i}`));
+      ctx.addMessage(modelMsg(`reply ${i}`));
     }
-    expect(ctx.getMessages()).toHaveLength(5);
-    expect((ctx.getMessages()[4].parts[0] as { type: string; text: string }).text).toBe(
-      "message 9",
-    );
+    // Window 5 with anchor preservation: the anchor merges with pruned[0]
+    // (both user-text) so the visible length is 4 (= 5 - 1 merged pair).
+    expect(ctx.getMessages()).toHaveLength(4);
+    const last = (ctx.getMessages()[3].parts[0] as { type: string; text: string }).text;
+    expect(last).toBe("reply 9");
   });
 
   it("prune does not leave an orphaned function_result as the first message", () => {
@@ -322,10 +354,39 @@ describe("ContextManager", () => {
     // Anchor preservation prepends "first" at index 0. Orphan user_results is gone.
     const msgs = ctx.getMessages();
     expect(msgs[0].role).toBe("user");
-    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("first");
-    // The first non-anchor message should be the clean "second" user message —
-    // proves the orphan user_results was trimmed by the head scan.
-    expect((msgs[1].parts[0] as { type: string; text: string }).text).toBe("second");
+    // Anchor and the head user_text("second") are both text-only user messages,
+    // so they're merged into one user turn with a separator. Both texts must
+    // survive in the merged head.
+    const head = (msgs[0].parts[0] as { type: string; text: string }).text;
+    expect(head).toContain("first");
+    expect(head).toContain("second");
+    expect(head).toContain("[earlier conversation pruned]");
+    // No consecutive same-role messages.
+    for (let i = 1; i < msgs.length; i++) {
+      expect(msgs[i].role).not.toBe(msgs[i - 1].role);
+    }
+  });
+
+  it("prune merges anchor into pruned[0] when both are text-only user messages (fixes Gemini 400)", () => {
+    // Without this merge, the anchor (original task) is prepended verbatim in
+    // front of a window whose head is also a user-text message — producing two
+    // consecutive `role: "user"` turns that Gemini rejects with INVALID_ARGUMENT.
+    const ctx = new ContextManager(STUB, 4);
+    ctx.addMessage(userMsg("original task"));
+    ctx.addMessage(modelMsg("ack"));
+    ctx.addMessage(userMsg("step 1"));
+    ctx.addMessage(modelMsg("doing 1"));
+    ctx.addMessage(userMsg("step 2")); // 5th → prune fires (window=4)
+
+    const msgs = ctx.getMessages();
+    // No consecutive same-role messages must remain.
+    for (let i = 1; i < msgs.length; i++) {
+      expect(msgs[i].role).not.toBe(msgs[i - 1].role);
+    }
+    // The anchor's text must still be present so the model retains the goal.
+    const head = (msgs[0].parts[0] as { type: string; text: string }).text;
+    expect(head).toContain("original task");
+    expect(head).toContain("[earlier conversation pruned]");
   });
 
   it("prune retains the function_call/result pair when the boundary falls cleanly", () => {
@@ -340,9 +401,12 @@ describe("ContextManager", () => {
     ctx.addMessage(modelWithCalls([{ id: "c2", name: "edit" }])); // 5th → prune
 
     const msgs = ctx.getMessages();
-    // First message is the preserved anchor "a"; second is "b" (head-scan target).
-    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("a");
-    expect((msgs[1].parts[0] as { type: string; text: string }).text).toBe("b");
+    // Anchor "a" and head-scan target "b" are both text-only user messages,
+    // so they merge into one user turn with a separator. Both texts survive.
+    const head = (msgs[0].parts[0] as { type: string; text: string }).text;
+    expect(head).toContain("a");
+    expect(head).toContain("b");
+    expect(head).toContain("[earlier conversation pruned]");
   });
 
   it("prune preserves the first user text message as anchor when pruning a long history", () => {
@@ -352,16 +416,17 @@ describe("ContextManager", () => {
     const ctx = new ContextManager(STUB, 10);
     ctx.addMessage(userMsg("build a card trading website with Next.js"));
     for (let i = 0; i < 50; i++) {
+      ctx.addMessage(modelMsg(`reply ${i}`));
       ctx.addMessage(userMsg(`follow-up ${i}`));
     }
 
     const msgs = ctx.getMessages();
     // Length capped by window
     expect(msgs.length).toBeLessThanOrEqual(10);
-    // Anchor: the original task is at the head
-    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe(
-      "build a card trading website with Next.js",
-    );
+    // Anchor preserved at the head; merged with the head-scan target since both
+    // are text-only user turns. The original task text must still be present.
+    const headText = (msgs[0].parts[0] as { type: string; text: string }).text;
+    expect(headText).toContain("build a card trading website with Next.js");
     // Tail: most recent follow-up is preserved
     expect((msgs[msgs.length - 1].parts[0] as { type: string; text: string }).text).toBe(
       "follow-up 49",
@@ -370,9 +435,12 @@ describe("ContextManager", () => {
 
   it("prune skips anchor preservation when maxHistoryMessages is 1 (no budget for anchor)", () => {
     // With only 1 slot, there's no room to keep an anchor AND any recent state.
-    // Behavior falls back to the original prune (last 1 message).
+    // Behavior falls back to the original prune (last 1 message). Uses an
+    // interleaved model message so the two user messages don't get merged
+    // by the consecutive-user-text collapse.
     const ctx = new ContextManager(STUB, 1);
     ctx.addMessage(userMsg("original task"));
+    ctx.addMessage(modelMsg("ack"));
     ctx.addMessage(userMsg("most recent"));
 
     const msgs = ctx.getMessages();

--- a/src/core/context.test.ts
+++ b/src/core/context.test.ts
@@ -307,25 +307,31 @@ describe("ContextManager", () => {
     expect(msgs[0].role).toBe("user");
   });
 
-  it("prune uses tail-scan to recover last clean user message when head scan fails", () => {
-    // Window: [user_results, model_calls, user_text, model_calls]
-    // Head scan skips user_results (orphan) and model_calls — fails.
-    // Tail scan finds user_text and uses it as the start.
+  it("prune head-scan finds a clean user message in the middle of the slice", () => {
+    // Window: [user_results, user_text, model_calls]  (last 3 of history)
+    // Head scan skips user_results (orphan) and lands on user_text("second").
+    // Anchor preservation prepends "first" → final: [first, second, model_calls].
     const ctx = new ContextManager(STUB, 4);
     ctx.addMessage(userMsg("first"));
     ctx.addMessage(modelWithCalls([{ id: "c1", name: "bash" }]));
     ctx.addMessage(userWithResults([{ id: "c1", name: "bash" }]));
-    ctx.addMessage(userMsg("second")); // clean user message in the tail
+    ctx.addMessage(userMsg("second")); // clean user message after the orphan
     ctx.addMessage(modelWithCalls([{ id: "c2", name: "bash" }]));
-    // 5th triggers prune → slice last 4 = [user_results, user_text("second"), model_calls, ...]
-    // Head scan: user_results → skip (orphan). user_text("second") → found!
+    // 5th triggers prune → slice last 3 = [user_results, user_text("second"), model_calls]
+    // Head scan: user_results → skip (orphan). user_text("second") → found.
+    // Anchor preservation prepends "first" at index 0. Orphan user_results is gone.
     const msgs = ctx.getMessages();
     expect(msgs[0].role).toBe("user");
-    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("second");
+    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("first");
+    // The first non-anchor message should be the clean "second" user message —
+    // proves the orphan user_results was trimmed by the head scan.
+    expect((msgs[1].parts[0] as { type: string; text: string }).text).toBe("second");
   });
 
   it("prune retains the function_call/result pair when the boundary falls cleanly", () => {
-    // maxHistoryMessages=4: slice starts exactly at a user text message — no skipping needed.
+    // maxHistoryMessages=4: slice last 3 = [user_results, user_text("b"), model_calls].
+    // Head scan skips user_results and lands on "b".
+    // Anchor preservation prepends "a" (the original task).
     const ctx = new ContextManager(STUB, 4);
     ctx.addMessage(userMsg("a"));
     ctx.addMessage(modelWithCalls([{ id: "c1", name: "read" }]));
@@ -334,9 +340,67 @@ describe("ContextManager", () => {
     ctx.addMessage(modelWithCalls([{ id: "c2", name: "edit" }])); // 5th → prune
 
     const msgs = ctx.getMessages();
-    // Slice of 4 starts at userWithResults — skipped; next clean start is userMsg("b")
+    // First message is the preserved anchor "a"; second is "b" (head-scan target).
+    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("a");
+    expect((msgs[1].parts[0] as { type: string; text: string }).text).toBe("b");
+  });
+
+  it("prune preserves the first user text message as anchor when pruning a long history", () => {
+    // The bug this guards against: a long session (or a resumed session whose
+    // history exceeds the per-turn window) silently dropped the original task
+    // message, leaving the LLM with no context for follow-ups like "continue".
+    const ctx = new ContextManager(STUB, 10);
+    ctx.addMessage(userMsg("build a card trading website with Next.js"));
+    for (let i = 0; i < 50; i++) {
+      ctx.addMessage(userMsg(`follow-up ${i}`));
+    }
+
+    const msgs = ctx.getMessages();
+    // Length capped by window
+    expect(msgs.length).toBeLessThanOrEqual(10);
+    // Anchor: the original task is at the head
+    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe(
+      "build a card trading website with Next.js",
+    );
+    // Tail: most recent follow-up is preserved
+    expect((msgs[msgs.length - 1].parts[0] as { type: string; text: string }).text).toBe(
+      "follow-up 49",
+    );
+  });
+
+  it("prune skips anchor preservation when maxHistoryMessages is 1 (no budget for anchor)", () => {
+    // With only 1 slot, there's no room to keep an anchor AND any recent state.
+    // Behavior falls back to the original prune (last 1 message).
+    const ctx = new ContextManager(STUB, 1);
+    ctx.addMessage(userMsg("original task"));
+    ctx.addMessage(userMsg("most recent"));
+
+    const msgs = ctx.getMessages();
+    expect(msgs).toHaveLength(1);
+    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("most recent");
+  });
+
+  it("prune skips anchor preservation when first message is not a clean user text", () => {
+    // If the first message is a tool result (e.g., from a re-imported partial
+    // session log), it's not a useful anchor — fall back to the original behavior.
+    const ctx = new ContextManager(STUB, 4);
+    ctx.restoreMessages([
+      // Synthetic first message: a user message containing only a function_result
+      // (not a usable anchor). Real sessions don't usually start like this, but
+      // a corrupt or partial log could.
+      userWithResults([{ id: "c0", name: "init" }]),
+    ]);
+    ctx.addMessage(modelMsg("model response"));
+    ctx.addMessage(userMsg("real task"));
+    ctx.addMessage(modelWithCalls([{ id: "c1", name: "read" }]));
+    ctx.addMessage(userWithResults([{ id: "c1", name: "read" }])); // 5th → prune
+
+    const msgs = ctx.getMessages();
+    // The first message must still be a clean user text message (provider invariant)
     expect(msgs[0].role).toBe("user");
-    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("b");
+    expect(msgs[0].parts.every((p) => p.type !== "function_result")).toBe(true);
+    // It should NOT be the corrupted first message
+    expect((msgs[0].parts[0] as { type: string; text: string }).text).toBe("real task");
   });
 });
 

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -53,7 +53,26 @@ export class ContextManager {
   }
 
   addMessage(message: Message): void {
-    this.history.push(message);
+    // Merge into the previous message when both are text-only `user` turns.
+    // This happens after restoring a session that ended on a user message (e.g.
+    // the agent crashed mid-turn, or a REPL-only slash command was logged):
+    // the user types again, producing two consecutive `user` messages, which
+    // providers reject with INVALID_ARGUMENT (role alternation violation).
+    // Carrying-`function_result` user messages are NOT merged — they pair with
+    // a prior tool call and must stay distinct.
+    const last = this.history[this.history.length - 1];
+    if (last && isUserTextOnly(last) && isUserTextOnly(message)) {
+      const mergedText =
+        last.parts.map((p) => (p as { type: "text"; text: string }).text).join("\n\n") +
+        "\n\n" +
+        message.parts.map((p) => (p as { type: "text"; text: string }).text).join("\n\n");
+      this.history[this.history.length - 1] = {
+        role: "user",
+        parts: [{ type: "text", text: mergedText }],
+      };
+    } else {
+      this.history.push(message);
+    }
     this.prune();
   }
 
@@ -166,6 +185,33 @@ export class ContextManager {
       }
     }
 
-    this.history = anchor ? [anchor, ...pruned] : pruned;
+    // If anchor and pruned[0] are both text-only user messages, prepending the
+    // anchor verbatim creates two consecutive `role: "user"` turns — providers
+    // reject this with INVALID_ARGUMENT. Merge the texts so the boundary stays
+    // a single user turn (separator marks the elided middle for the model).
+    if (anchor && pruned.length > 0 && isUserTextOnly(pruned[0])) {
+      const anchorText = anchor.parts
+        .map((p) => (p as { type: "text"; text: string }).text)
+        .join("\n\n");
+      const headText = pruned[0].parts
+        .map((p) => (p as { type: "text"; text: string }).text)
+        .join("\n\n");
+      const merged: Message = {
+        role: "user",
+        parts: [
+          {
+            type: "text",
+            text: `${anchorText}\n\n[earlier conversation pruned]\n\n${headText}`,
+          },
+        ],
+      };
+      this.history = [merged, ...pruned.slice(1)];
+    } else {
+      this.history = anchor ? [anchor, ...pruned] : pruned;
+    }
   }
+}
+
+function isUserTextOnly(msg: Message): boolean {
+  return msg.role === "user" && msg.parts.length > 0 && msg.parts.every((p) => p.type === "text");
 }

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -102,7 +102,23 @@ export class ContextManager {
   private prune(): void {
     if (this.history.length <= this.maxHistoryMessages) return;
 
-    const sliced = this.history.slice(-this.maxHistoryMessages);
+    // Reserve a slot to preserve the very first user text message — typically
+    // the original task that anchors the whole session. Without this, prune
+    // silently drops the goal once history exceeds the window, regardless of
+    // whether the session is resumed or grew organically. A5b's planned
+    // auto-compact will replace this with a real LLM summary; this is the
+    // cheap interim that prevents the agent saying "I have no context".
+    const first = this.history[0];
+    const anchor =
+      this.maxHistoryMessages > 1 &&
+      first?.role === "user" &&
+      first.parts.length > 0 &&
+      first.parts.every((p) => p.type === "text")
+        ? first
+        : null;
+
+    const windowSize = this.maxHistoryMessages - (anchor ? 1 : 0);
+    const sliced = this.history.slice(-windowSize);
 
     // Advance past any orphaned messages at the head of the slice so we never
     // send a function_result without its matching function_call (Gemini returns
@@ -116,39 +132,40 @@ export class ContextManager {
       startIdx++;
     }
 
+    let pruned: Message[];
     if (startIdx < sliced.length) {
-      this.history = sliced.slice(startIdx);
-      return;
-    }
-
-    // No clean user message found from the head — scan from the tail so we
-    // don't return a model-first window (providers reject with INVALID_ARGUMENT).
-    // This happens when a single user turn triggers so many tool-call/result
-    // pairs that the original user message scrolls out of the window.
-    let tailIdx = sliced.length - 1;
-    while (tailIdx >= 0) {
-      const msg = sliced[tailIdx];
-      if (msg.role === "user" && !msg.parts.some((p) => p.type === "function_result")) {
-        break;
+      pruned = sliced.slice(startIdx);
+    } else {
+      // No clean user message found from the head — scan from the tail so we
+      // don't return a model-first window (providers reject with INVALID_ARGUMENT).
+      // This happens when a single user turn triggers so many tool-call/result
+      // pairs that the original user message scrolls out of the window.
+      let tailIdx = sliced.length - 1;
+      while (tailIdx >= 0) {
+        const msg = sliced[tailIdx];
+        if (msg.role === "user" && !msg.parts.some((p) => p.type === "function_result")) {
+          break;
+        }
+        tailIdx--;
       }
-      tailIdx--;
+
+      if (tailIdx >= 0) {
+        pruned = sliced.slice(tailIdx);
+      } else {
+        // Truly pathological: no clean user text message anywhere in the window
+        // (e.g. maxHistoryMessages is so small the window is pure tool-call/result
+        // pairs). Prepend a synthetic anchor so history never starts with a model
+        // turn — providers require the first message to be a user text message.
+        pruned = [
+          {
+            role: "user",
+            parts: [{ type: "text", text: "(earlier context unavailable — history was pruned)" }],
+          },
+          ...sliced,
+        ];
+      }
     }
 
-    if (tailIdx >= 0) {
-      this.history = sliced.slice(tailIdx);
-      return;
-    }
-
-    // Truly pathological: no clean user text message anywhere in the window
-    // (e.g. maxHistoryMessages is so small the window is pure tool-call/result
-    // pairs). Prepend a synthetic anchor so history never starts with a model
-    // turn — providers require the first message to be a user text message.
-    this.history = [
-      {
-        role: "user",
-        parts: [{ type: "text", text: "(earlier context unavailable — history was pruned)" }],
-      },
-      ...sliced,
-    ];
+    this.history = anchor ? [anchor, ...pruned] : pruned;
   }
 }

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -259,13 +259,15 @@ describe("GeminiClient thoughtSignature handling", () => {
     expect(userMsg.parts[0].thoughtSignature).toBe("sig-abc");
   });
 
-  it("omits thoughtSignature on functionResponse when no signature was captured", async () => {
-    // Stream a function_call without a thoughtSignature (non-thinking model)
+  it("omits thoughtSignature on functionResponse when no signature was captured (non-thinking model)", async () => {
+    // Non-thinking model: signature is naturally absent and that's fine.
+    const nonThinking = new GeminiClient("fake-key", "gemini-2.0-flash");
+
     mockGenerateContentStream.mockReturnValueOnce(
       makeStream([{ functionCall: { id: "call-2", name: "read", args: { file_path: "f.ts" } } }]),
     );
 
-    for await (const event of client.stream([], "sys", [])) void event;
+    for await (const event of nonThinking.stream([], "sys", [])) void event;
 
     mockGenerateContentStream.mockReturnValueOnce(makeStream([{ text: "ok" }]));
 
@@ -289,13 +291,56 @@ describe("GeminiClient thoughtSignature handling", () => {
       },
     ];
 
-    for await (const event of client.stream(messagesWithResult, "sys", [])) void event;
+    for await (const event of nonThinking.stream(messagesWithResult, "sys", [])) void event;
 
     const secondCallContents = mockGenerateContentStream.mock.calls[1][0].contents;
     const modelMsg = secondCallContents[0];
     const userMsg = secondCallContents[1];
 
+    // Structured form preserved (no flatten); signature absent because non-thinking model.
+    expect(modelMsg.parts[0]).toHaveProperty("functionCall");
+    expect(userMsg.parts[0]).toHaveProperty("functionResponse");
     expect(modelMsg.parts[0]).not.toHaveProperty("thoughtSignature");
     expect(userMsg.parts[0]).not.toHaveProperty("thoughtSignature");
+  });
+
+  it("flattens unsignatured function_call/result to text for thinking models (fixes resume 400)", async () => {
+    // Default model is gemini-3-flash-preview (a thinking model). Without a
+    // captured signature, sending the call/response as structured parts would
+    // trip Gemini's 400 INVALID_ARGUMENT. The provider must downgrade to text.
+    mockGenerateContentStream.mockReturnValueOnce(makeStream([{ text: "ack" }]));
+
+    const messagesWithStaleTool = [
+      {
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "do the thing" }],
+      },
+      {
+        role: "model" as const,
+        parts: [
+          { type: "function_call" as const, id: "resume-1", name: "bash", args: { command: "ls" } },
+        ],
+      },
+      {
+        role: "user" as const,
+        parts: [{ type: "function_result" as const, id: "resume-1", name: "bash", result: "ok" }],
+      },
+      {
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "continue" }],
+      },
+    ];
+
+    for await (const event of client.stream(messagesWithStaleTool, "sys", [])) void event;
+
+    const sent = mockGenerateContentStream.mock.calls[0][0].contents;
+    const modelTurn = sent[1];
+    const userTurn = sent[2];
+
+    // Tool parts flattened to text — no functionCall / functionResponse anywhere.
+    expect(modelTurn.parts[0]).not.toHaveProperty("functionCall");
+    expect(userTurn.parts[0]).not.toHaveProperty("functionResponse");
+    expect(modelTurn.parts[0].text).toContain("[Tool call: bash(");
+    expect(userTurn.parts[0].text).toContain("[Tool result: bash →");
   });
 });

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -102,6 +102,7 @@ export class GeminiClient implements LLMClient {
     yield { type: "done" };
   }
   private messagesToContents(messages: Message[]): Content[] {
+    const requiresSignature = isThinkingModel(this.model);
     return messages.map((msg) => ({
       role: msg.role,
       parts: msg.parts.map((part) => {
@@ -110,13 +111,25 @@ export class GeminiClient implements LLMClient {
         }
         if (part.type === "function_call") {
           const sig = this.thoughtSignatures.get(part.id);
+          if (!sig && requiresSignature) {
+            // Thinking models (gemini-3.x, *-thinking variants) reject any
+            // functionCall without a thoughtSignature. After resume the
+            // in-memory map is empty — JSONL doesn't persist signatures — so a
+            // tool turn from a prior process would 400. Flatten to text so the
+            // model still sees what happened, just without structured pairing.
+            return { text: `[Tool call: ${part.name}(${JSON.stringify(part.args)})]` };
+          }
           return {
             functionCall: { id: part.id, name: part.name, args: part.args },
             ...(sig ? { thoughtSignature: sig } : {}),
           };
         }
-        // function_result — echo thoughtSignature back as required by Gemini thinking models
+        // function_result — must echo its function_call's thoughtSignature.
         const sig = this.thoughtSignatures.get(part.id);
+        if (!sig && requiresSignature) {
+          // Paired call was flattened above; serialize the result as text too.
+          return { text: `[Tool result: ${part.name} → ${part.result}]` };
+        }
         return {
           functionResponse: {
             id: part.id,
@@ -128,6 +141,13 @@ export class GeminiClient implements LLMClient {
       }),
     }));
   }
+}
+
+// Models that always emit (and require echoing) thoughtSignature on functionCall/Response.
+// On resume the signature is lost — the JSONL doesn't carry it — so calls to these models
+// would 400 unless we flatten unsignatured tool parts to text.
+function isThinkingModel(model: string): boolean {
+  return model.startsWith("gemini-3") || model.includes("thinking");
 }
 
 function definitionToFunctionDeclaration(def: ToolDefinition): FunctionDeclaration {

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -335,6 +335,42 @@ describe("Session.loadMessages — orphaned tool_result resilience", () => {
   });
 });
 
+describe("Session.loadMessages — consecutive user-text collapse", () => {
+  it("merges back-to-back user text entries so provider role alternation holds", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "First task" });
+    await session.log({ type: "assistant", content: "Working..." });
+    // Simulates the wedge: REPL-only slash command logged, then a follow-up
+    // prompt with no assistant response in between (e.g. agent crashed).
+    await session.log({ type: "user", content: "/exit" });
+    await session.log({ type: "user", content: "continue" });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+
+    // user → model → (merged user) — three messages, never two user in a row.
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toMatchObject({ role: "user", parts: [{ text: "First task" }] });
+    expect(messages[1]).toMatchObject({ role: "model" });
+    expect(messages[2]).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "/exit\n\ncontinue" }],
+    });
+  });
+
+  it("does not merge a function_result user message with a preceding text user message", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Run ls" });
+    await session.log({ type: "tool_call", name: "bash", args: { command: "ls" } });
+    await session.log({ type: "tool_result", name: "bash", result: "a.txt" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    // The user(text) at index 0 must remain distinct from user(function_result) at index 2.
+    expect(messages[0]).toMatchObject({ role: "user", parts: [{ type: "text" }] });
+    expect(messages[2]).toMatchObject({ role: "user", parts: [{ type: "function_result" }] });
+  });
+});
+
 describe("Session.loadMessages — malformed JSONL resilience", () => {
   it("skips malformed lines and still returns valid messages", async () => {
     const { writeFile, mkdir } = await import("node:fs/promises");

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -181,7 +181,45 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
   flushCalls();
   flushResults();
 
-  return messages;
+  return collapseConsecutiveUserText(messages);
+}
+
+/**
+ * Merge consecutive `role: "user"` text-only messages into one.
+ *
+ * Older JSONL logs may contain back-to-back `user` entries — typically because
+ * a REPL-only slash command like `/exit` was persisted before being intercepted,
+ * or because the agent crashed mid-turn so no `assistant` event followed the
+ * user input. Replaying them as separate messages violates provider role
+ * alternation (Gemini/Anthropic both 400 on consecutive same-role contents).
+ * Merging the text preserves the user's words without breaking the wire format.
+ *
+ * Only collapses *text-only* user messages — user messages carrying
+ * `function_result` parts must remain distinct (they pair with prior tool
+ * calls and merging would orphan them).
+ */
+function collapseConsecutiveUserText(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  for (const msg of messages) {
+    const last = result[result.length - 1];
+    if (last && isUserTextOnly(last) && isUserTextOnly(msg)) {
+      const mergedText =
+        last.parts.map((p) => (p as { type: "text"; text: string }).text).join("\n\n") +
+        "\n\n" +
+        msg.parts.map((p) => (p as { type: "text"; text: string }).text).join("\n\n");
+      result[result.length - 1] = {
+        role: "user",
+        parts: [{ type: "text", text: mergedText }],
+      };
+    } else {
+      result.push(msg);
+    }
+  }
+  return result;
+}
+
+function isUserTextOnly(msg: Message): boolean {
+  return msg.role === "user" && msg.parts.length > 0 && msg.parts.every((p) => p.type === "text");
 }
 
 export type SessionEntry =


### PR DESCRIPTION
## Summary

- Diagnoses and fixes the `Gemini: bad request (400). Request contains an invalid argument.` seen on every `continue` after resuming a session that involved tool calls on a Gemini thinking model (`gemini-3.x`, `*-thinking`).
- **Root cause**: thinking models require `thoughtSignature` to be echoed on every `functionCall` / `functionResponse`. Gemini emits the signature at stream time; the provider keeps it in an in-memory `Map` keyed by call id. The map is never persisted — on resume the new `GeminiClient` starts empty, sends resumed tool parts without signatures, and Gemini rejects.
- **Fix** in `src/providers/gemini.ts`: when the active model is a thinking model and the in-memory map has no signature for a `function_call` / `function_result` part, flatten that part to a text representation (`[Tool call: bash(...)]` / `[Tool result: ... → ...]`) instead of sending an unsignatured structured part. Non-thinking models keep the existing structured behavior.
- Bundled hardening also lands (see below) — caught while bisecting the original report. Originally this branch only held the prune-anchor fix; the Gemini diagnosis surfaced two related correctness issues in the same code paths.

## Two commits in this PR

1. **`3932f29` fix(context): preserve the first user message as anchor during prune** — original scope of the branch. When history exceeds `maxHistoryMessages`, prune() reserves a slot for the original user text message as an anchor at the head of the pruned window.
2. **`86f9430` fix(gemini): unblock thinking-model session resume** — the actual root-cause fix plus supporting hardening listed below.

## Hardening shipped alongside the Gemini fix

These live in the same code paths and reinforce the same invariant (resumed sessions must produce a clean message stream).

- **`src/cli/repl.ts`** — move `session.log({ type: \"user\" })` from before slash-command interception to after, so REPL-only commands (`/exit`, `/help`, `/clear`) are no longer persisted as user content. Without this, `/exit` was logged at quit time and replayed as a user message on resume — two consecutive user turns that Anthropic strictly rejects.
- **`src/state/session.ts`** — collapse consecutive text-only user messages in `reconstructMessages`. Heals pre-existing JSONLs that captured REPL-only commands as user content.
- **`src/core/context.ts`** — same collapse in `addMessage` (live path) and a merge between `anchor` and `pruned[0]` in `prune()` when both are text-only user turns. Not load-bearing for Gemini (it tolerates consecutive same-role text) but prevents the same wedge on Claude where role alternation is enforced.

## Tradeoff acknowledged

On resume against a thinking model, prior tool turns appear to the model as text, so its first follow-up may briefly echo `[Tool call: ...]` as text before issuing fresh, signed calls. The proper end-state is persisting `thoughtSignature` in the JSONL session log; this PR ships the immediate unblock and leaves that as a follow-up.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — 558 passed
- [x] **End-to-end against a real stuck session** — `gemini-3.1-pro-preview` was returning 400 on every `continue` after resume. With this PR, the request streams a response. Verified by loading an actual session JSONL (304 messages, many tool calls) and streaming from Gemini directly.
- [x] Non-thinking model path unchanged (`gemini-2.0-flash` test in `gemini.test.ts`).
- [x] Pre-existing prune invariant tests still pass (no model-first window, no orphaned-result-first, no empty history).
- [ ] Manual verification: resume the live card_trade session (300+ entries), confirm `continue` returns a streamed response instead of 400.

## Notes for reviewers

- The Gemini thinking-model detection is a name-prefix heuristic (`gemini-3` or contains `thinking`). It's narrow on purpose — non-thinking models go down the unchanged structured path.
- Several existing tests had to be updated because they relied on long runs of consecutive `userMsg(...)` (which now collapse). Replaced with alternating user/model patterns where the prune/compact behavior under test is what matters.
- The reported \"resume bug\" frame was originally about \"I don't currently have context\" (anchor preservation, commit 1). The Gemini 400 turned out to be a separate, deeper issue (commit 2). Both are bundled here because they share code paths and a reviewer reading either in isolation would naturally ask about the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)