### PR TITLE
docs: add mcp/ layer and missing state files to Source Structure in CLAUDE.md / AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,18 @@ src/
     registry.ts     # Discover SKILL.md files across 4 scoped directories
     loader.ts       # Parse SKILL.md frontmatter, !{cmd} preprocessing, $ARGUMENTS substitution
     builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill
+  mcp/            # MCP integration — bridges external tool servers into ToolRegistry
+    types.ts        # McpStdioServer, McpHttpServer, McpServerConfig, McpConfig, McpToolInfo
+    config.ts       # loadMcpConfig(agentDir) — reads ~/.opencli/mcp.json; expands ${VAR} refs
+    client.ts       # McpClient — connects via stdio or HTTP, enforces per-server callTimeout
+    adapter.ts      # mcpToolToTool() — wraps one MCP tool as a Tool (name: mcp__server__tool)
+    manager.ts      # McpManager — connects all servers in parallel, registers adapters
+    index.ts        # Re-exports all public types and classes
   state/
     config.ts       # ~/.opencli/config.json load/save; exports AGENT_DIR, Config (incl. anthropicApiKey)
     session.ts      # JSONL session logs at ~/.opencli/projects/<cwd>/; create, list, resume
+    settings.ts     # .opencli/settings.json load/save; holds project-level Permissions (HITL allow/deny list)
+    snapshot.ts     # SnapshotManager — git stash create/restore for per-session working-tree snapshots
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,18 @@ src/
     registry.ts     # Discover SKILL.md files across 4 scoped directories
     loader.ts       # Parse SKILL.md frontmatter, !{cmd} preprocessing, $ARGUMENTS substitution
     builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill
+  mcp/            # MCP integration — bridges external tool servers into ToolRegistry
+    types.ts        # McpStdioServer, McpHttpServer, McpServerConfig, McpConfig, McpToolInfo
+    config.ts       # loadMcpConfig(agentDir) — reads ~/.opencli/mcp.json; expands ${VAR} refs
+    client.ts       # McpClient — connects via stdio or HTTP, enforces per-server callTimeout
+    adapter.ts      # mcpToolToTool() — wraps one MCP tool as a Tool (name: mcp__server__tool)
+    manager.ts      # McpManager — connects all servers in parallel, registers adapters
+    index.ts        # Re-exports all public types and classes
   state/
     config.ts       # ~/.opencli/config.json load/save; exports AGENT_DIR, Config (incl. anthropicApiKey)
     session.ts      # JSONL session logs at ~/.opencli/projects/<cwd>/; create, list, resume
+    settings.ts     # .opencli/settings.json load/save; holds project-level Permissions (HITL allow/deny list)
+    snapshot.ts     # SnapshotManager — git stash create/restore for per-session working-tree snapshots
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

- The Source Structure quick-reference in both `CLAUDE.md` and `AGENTS.md` was missing three components added since the initial skeleton:
  - **`src/mcp/`** — the entire MCP integration layer (6 files), which has its own layer constraints, tool-naming convention (`mcp__server__tool`), and HITL behavior
  - **`src/state/settings.ts`** — project-level `Permissions` persistence added in the Phase 2 HITL work (commit `8fa5cba`)
  - **`src/state/snapshot.ts`** — `SnapshotManager` for git-based session snapshots
- `docs/architecture.md` already documented all three correctly (§6 MCP and §7 State); this brings the compact summary in `CLAUDE.md` / `AGENTS.md` into sync

Both files are updated in the same commit per the sync requirement in `CLAUDE.md`.

## Related issue

Closes #159

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (548 tests, 0 failures)
- [x] Doc-only change: no runtime behaviour affected
- [x] Verified each added entry against the actual files in `src/mcp/` and `src/state/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpYji9ZKZwbcRxCd8aFs6h)_