### PR TITLE
fix(runner): show error when edit tool fails instead of silently swallowing it

### DIFF
--- a/src/cli/renderer.test.ts
+++ b/src/cli/renderer.test.ts
@@ -413,9 +413,17 @@ describe("print functions write to stderr/stdout", () => {
     expect(output).toContain("bash");
   });
 
-  it("printToolResult skips edit tool", () => {
+  it("printToolResult skips edit tool (success and error are routed via runner.ts)", () => {
     printToolResult("edit", "anything");
     expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("printToolResultExpanded shows ✗ for failed edit (runner calls this on edit error)", () => {
+    printToolResultExpanded("edit", "Error: old_string not found in file");
+    const output = stripAnsi(stderr());
+    expect(output).toContain("✗");
+    expect(output).toContain("old_string not found in file");
+    expect(output).not.toContain("✓");
   });
 
   it("printToolResult writes compact summary for short bash output (≤5 lines)", () => {

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -8,6 +8,7 @@ import {
   printToolCallCompact,
   printToolResult,
   printToolResultCompact,
+  printToolResultExpanded,
   printEditDiff,
   printSkillActivated,
   printError,
@@ -75,8 +76,12 @@ export async function runAgentTurn(
           if (COMPACT_TOOLS.has(event.name)) {
             printToolResultCompact(event.name, event.result);
           } else if (event.name === "edit") {
-            const edit = pendingEdits.shift();
-            if (edit) printEditDiff(edit.old_string, edit.new_string, edit.file_path);
+            const edit = pendingEdits.shift(); // always shift to keep array in sync
+            if (event.result.startsWith("Error:")) {
+              printToolResultExpanded("edit", event.result);
+            } else if (edit) {
+              printEditDiff(edit.old_string, edit.new_string, edit.file_path);
+            }
           } else {
             printToolResult(event.name, event.result);
           }


### PR DESCRIPTION
## Summary

- When the `edit` tool returns an error (`old_string not found`, ambiguous match, file not found, etc.), `runner.ts` was silently discarding `event.result` and rendering the proposed diff via `printEditDiff` anyway — as if the edit had succeeded.
- Users saw a coloured diff appear on screen but the actual edit never happened. The only clue was that the agent retried with no visible explanation.
- **Fix**: check whether `event.result.startsWith("Error:")` in the `tool_result` handler before deciding what to render:
  - **On failure** → `printToolResultExpanded("edit", event.result)` — red `✗` + full error text, same style as other failed tools
  - **On success** → `printEditDiff(...)` as before
- The `pendingEdits` array is always `shift()`-ed on `tool_result` (regardless of success/failure) to keep it in sync with `tool_call` events.

## Related issue

Closes #161

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (549 tests)
- [x] New renderer test: `printToolResultExpanded("edit", "Error: old_string not found in file")` renders `✗` and error text
- [x] Existing test `printToolResult skips edit tool` updated with a clarifying comment explaining routing lives in `runner.ts`
- [x] Manual scenario: ask agent to edit a file with an incorrect `old_string`; error now appears as `✗ edit   Error: old_string not found in file` instead of a phantom diff

https://claude.ai/code/session_01Vd62aH2P9BhJTmQ5p8T27w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vd62aH2P9BhJTmQ5p8T27w)_