### PR TITLE
fix(resume): persist thoughtSignature in JSONL so resume matches live path

### DIFF
--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -50,6 +50,7 @@ export async function runAgentTurn(
             type: "tool_call",
             name: event.name,
             args: event.args,
+            ...(event.thoughtSignature ? { thoughtSignature: event.thoughtSignature } : {}),
           });
           if (COMPACT_TOOLS.has(event.name)) {
             printToolCallCompact(event.name, event.args);

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -14,7 +14,12 @@ import type { CompactResult } from "./compact.js";
 
 export type AgentEvent =
   | { type: "text"; text: string }
-  | { type: "tool_call"; name: string; args: Record<string, unknown> }
+  | {
+      type: "tool_call";
+      name: string;
+      args: Record<string, unknown>;
+      thoughtSignature?: string;
+    }
   | { type: "tool_result"; name: string; result: string }
   | { type: "skill_activated"; name: string }
   | { type: "error"; message: string }
@@ -141,11 +146,13 @@ export class Agent {
             id: event.id,
             name: event.name,
             args: event.args,
+            ...(event.thoughtSignature ? { thoughtSignature: event.thoughtSignature } : {}),
           });
           yield {
             type: "tool_call",
             name: event.name,
             args: event.args,
+            ...(event.thoughtSignature ? { thoughtSignature: event.thoughtSignature } : {}),
           };
         } else if (event.type === "usage") {
           usageInputTokens = event.inputTokens;

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -67,6 +67,9 @@ async function executeOneCall(
   deps: ExecutorDeps,
 ): Promise<FunctionResultPart> {
   const tool = deps.tools.get(call.name);
+  // Propagate the call's thoughtSignature onto every result we return — Gemini
+  // thinking models require the same signature echoed back on functionResponse.
+  const sig = call.thoughtSignature ? { thoughtSignature: call.thoughtSignature } : {};
 
   if (deps.readOnly && !tool?.readonly) {
     deps.obs?.({ type: "tool_denied", name: call.name, reason: "plan_mode" });
@@ -75,6 +78,7 @@ async function executeOneCall(
       id: call.id,
       name: call.name,
       result: `Error: '${call.name}' is blocked in plan mode. Use read, glob, or grep to explore the codebase.`,
+      ...sig,
     };
   }
   if (tool?.requiresConfirmation?.(call.args as Record<string, unknown>)) {
@@ -94,6 +98,7 @@ async function executeOneCall(
         result: deps.confirmFn
           ? `Blocked: user denied '${call.name}' tool call.`
           : `Blocked: '${call.name}' requires confirmation but is running non-interactively. Pass --yes to auto-approve.`,
+        ...sig,
       };
     }
   }
@@ -123,6 +128,7 @@ async function executeOneCall(
     id: call.id,
     name: call.name,
     result: output,
+    ...sig,
   };
 }
 

--- a/src/providers/gemini.test.ts
+++ b/src/providers/gemini.test.ts
@@ -198,7 +198,7 @@ describe("GeminiClient thoughtSignature handling", () => {
     };
   }
 
-  it("does not include thoughtSignature in yielded StreamEvent", async () => {
+  it("includes thoughtSignature on the yielded StreamEvent so callers can persist it", async () => {
     mockGenerateContentStream.mockReturnValue(
       makeStream([
         {
@@ -213,9 +213,12 @@ describe("GeminiClient thoughtSignature handling", () => {
       events.push(event);
     }
 
-    const callEvent = events.find((e) => e.type === "function_call");
+    const callEvent = events.find((e) => e.type === "function_call") as {
+      type: string;
+      thoughtSignature?: string;
+    };
     expect(callEvent).toBeDefined();
-    expect(callEvent).not.toHaveProperty("thoughtSignature");
+    expect(callEvent.thoughtSignature).toBe("sig-abc");
   });
 
   it("echoes thoughtSignature on functionResponse when the call ID is known", async () => {
@@ -302,6 +305,55 @@ describe("GeminiClient thoughtSignature handling", () => {
     expect(userMsg.parts[0]).toHaveProperty("functionResponse");
     expect(modelMsg.parts[0]).not.toHaveProperty("thoughtSignature");
     expect(userMsg.parts[0]).not.toHaveProperty("thoughtSignature");
+  });
+
+  it("uses part-level thoughtSignature when the in-memory map is empty (resumed session)", async () => {
+    // Simulates resume: GeminiClient has never streamed, so thoughtSignatures
+    // is empty. The signature must come from the part itself (persisted in
+    // session JSONL and propagated by reconstructMessages) so the structured
+    // functionCall/functionResponse payload matches what a live session sends.
+    mockGenerateContentStream.mockReturnValueOnce(makeStream([{ text: "ok" }]));
+
+    const restoredHistory = [
+      { role: "user" as const, parts: [{ type: "text" as const, text: "task" }] },
+      {
+        role: "model" as const,
+        parts: [
+          {
+            type: "function_call" as const,
+            id: "resume-1",
+            name: "bash",
+            args: { command: "ls" },
+            thoughtSignature: "sig-from-jsonl",
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        parts: [
+          {
+            type: "function_result" as const,
+            id: "resume-1",
+            name: "bash",
+            result: "ok",
+            thoughtSignature: "sig-from-jsonl",
+          },
+        ],
+      },
+      { role: "user" as const, parts: [{ type: "text" as const, text: "continue" }] },
+    ];
+
+    for await (const event of client.stream(restoredHistory, "sys", [])) void event;
+
+    const sent = mockGenerateContentStream.mock.calls[0][0].contents;
+    const modelPart = sent[1].parts[0];
+    const userResultPart = sent[2].parts[0];
+
+    // Structured form preserved — no flatten — and signature carried through.
+    expect(modelPart).toHaveProperty("functionCall");
+    expect(modelPart.thoughtSignature).toBe("sig-from-jsonl");
+    expect(userResultPart).toHaveProperty("functionResponse");
+    expect(userResultPart.thoughtSignature).toBe("sig-from-jsonl");
   });
 
   it("flattens unsignatured function_call/result to text for thinking models (fixes resume 400)", async () => {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -86,6 +86,7 @@ export class GeminiClient implements LLMClient {
               id,
               name: part.functionCall.name ?? "",
               args: (part.functionCall.args ?? {}) as Record<string, unknown>,
+              ...(sig ? { thoughtSignature: sig } : {}),
             };
           }
         }
@@ -110,13 +111,15 @@ export class GeminiClient implements LLMClient {
           return { text: part.text };
         }
         if (part.type === "function_call") {
-          const sig = this.thoughtSignatures.get(part.id);
+          // Prefer the signature carried on the part itself — populated either
+          // from this stream's emit or restored from the session JSONL. Fall
+          // back to the in-memory map for backward compatibility with parts
+          // built before signatures were threaded through.
+          const sig = part.thoughtSignature ?? this.thoughtSignatures.get(part.id);
           if (!sig && requiresSignature) {
-            // Thinking models (gemini-3.x, *-thinking variants) reject any
-            // functionCall without a thoughtSignature. After resume the
-            // in-memory map is empty — JSONL doesn't persist signatures — so a
-            // tool turn from a prior process would 400. Flatten to text so the
-            // model still sees what happened, just without structured pairing.
+            // No signature available (old JSONL recorded before sig persistence
+            // landed). Thinking models reject unsignatured functionCall — fall
+            // back to a text representation so the conversation still streams.
             return { text: `[Tool call: ${part.name}(${JSON.stringify(part.args)})]` };
           }
           return {
@@ -125,9 +128,8 @@ export class GeminiClient implements LLMClient {
           };
         }
         // function_result — must echo its function_call's thoughtSignature.
-        const sig = this.thoughtSignatures.get(part.id);
+        const sig = part.thoughtSignature ?? this.thoughtSignatures.get(part.id);
         if (!sig && requiresSignature) {
-          // Paired call was flattened above; serialize the result as text too.
           return { text: `[Tool result: ${part.name} → ${part.result}]` };
         }
         return {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -18,6 +18,11 @@ export interface FunctionCallPart {
   id: string;
   name: string;
   args: Record<string, unknown>;
+  // Gemini thinking models (gemini-3.x, *-thinking) emit a thoughtSignature on
+  // every functionCall and require it to be echoed back when the corresponding
+  // functionResponse is sent. Persisted in the session JSONL so resumed sessions
+  // can reproduce the exact same wire payload as an unbroken session.
+  thoughtSignature?: string;
 }
 
 export interface FunctionResultPart {
@@ -25,6 +30,10 @@ export interface FunctionResultPart {
   id: string;
   name: string;
   result: string;
+  // Same signature as the paired FunctionCallPart. Set when the result is
+  // constructed (executor) or restored (reconstructMessages); echoed by the
+  // Gemini provider on the outgoing functionResponse.
+  thoughtSignature?: string;
 }
 
 export type MessagePart = TextPart | FunctionCallPart | FunctionResultPart;
@@ -43,6 +52,12 @@ export interface ToolResult {
 // Normalized stream event types emitted by all provider clients
 export type StreamEvent =
   | { type: "text"; text: string }
-  | { type: "function_call"; id: string; name: string; args: Record<string, unknown> }
+  | {
+      type: "function_call";
+      id: string;
+      name: string;
+      args: Record<string, unknown>;
+      thoughtSignature?: string;
+    }
   | { type: "usage"; inputTokens: number; outputTokens: number }
   | { type: "done" };

--- a/src/state/session.e2e.test.ts
+++ b/src/state/session.e2e.test.ts
@@ -73,6 +73,119 @@ describe("Session save → resume round-trip (E2E)", () => {
     expect(allText).toContain("E2E Project");
   });
 
+  it("threads thoughtSignature from stream event → AgentEvent.tool_call (runner logs it from there)", async () => {
+    // Confirms the live half of the chain: a function_call StreamEvent carrying
+    // a signature emerges from agent.run() as an AgentEvent.tool_call also
+    // carrying that signature. The runner reads the AgentEvent and persists it
+    // to the session JSONL (one straight-line line in runner.ts).
+    const SIG = "live-sig-cafebabe";
+
+    let streamCallNum = 0;
+    const client: LLMClient = {
+      async *stream(): AsyncGenerator<StreamEvent> {
+        streamCallNum++;
+        if (streamCallNum === 1) {
+          yield {
+            type: "function_call",
+            id: "live-call-1",
+            name: "list_files",
+            args: { path: "/tmp" },
+            thoughtSignature: SIG,
+          };
+          yield { type: "done" };
+        } else {
+          // Second stream iteration after tool execution — just finish.
+          yield { type: "text", text: "done." };
+          yield { type: "done" };
+        }
+      },
+    };
+
+    const tools = new ToolRegistry();
+    tools.register({
+      name: "list_files",
+      description: "List files",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+      readonly: true,
+      execute: async () => ({ success: true, output: "a.txt\nb.txt" }),
+    });
+
+    const agent = new Agent(client, tools, new SkillRegistry());
+
+    let observedSig: string | undefined = undefined;
+    for await (const ev of agent.run("list /tmp")) {
+      if (ev.type === "tool_call") {
+        observedSig = (ev as { thoughtSignature?: string }).thoughtSignature;
+      }
+    }
+    expect(observedSig).toBe(SIG);
+  });
+
+  it("persists thoughtSignature through stream → JSONL → resume → next stream", async () => {
+    // Verifies the symmetry contract: a session that captured a tool call with
+    // a signature live, when resumed, sends the SAME structured signed payload
+    // on its next request — not flattened text.
+    //
+    // Stage 1: live turn that streams a function_call carrying a signature.
+    //   The agent executes the (fake) tool and the runner-style logging is
+    //   simulated by writing the entries directly to the Session.
+    // Stage 2: fresh agent loads the session JSONL and runs a follow-up turn.
+    //   The captured `Message[]` going into the next stream must show the
+    //   signature on both the FunctionCallPart and the FunctionResultPart.
+
+    const SIG = "test-sig-deadbeef-from-stream";
+
+    // ── Stage 1: write a session log that reflects a live signed tool call ──
+    const session = await Session.create(FAKE_CWD);
+    await session.log({ type: "user", content: "list files" });
+    await session.log({
+      type: "tool_call",
+      name: "list_files",
+      args: { path: "/tmp" },
+      thoughtSignature: SIG,
+    });
+    await session.log({ type: "tool_result", name: "list_files", result: "a.txt\nb.txt" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    // ── Stage 2: resume into a fresh agent and observe the next stream call ─
+    const { messages: restored } = await Session.loadMessages(session.id, FAKE_CWD);
+
+    // Sanity: signature survives restore on BOTH paired parts.
+    const callPart = restored.flatMap((m) => m.parts).find((p) => p.type === "function_call") as
+      | { thoughtSignature?: string }
+      | undefined;
+    const resultPart = restored
+      .flatMap((m) => m.parts)
+      .find((p) => p.type === "function_result") as { thoughtSignature?: string } | undefined;
+    expect(callPart?.thoughtSignature).toBe(SIG);
+    expect(resultPart?.thoughtSignature).toBe(SIG);
+
+    // The fresh agent's first stream call should see the structured parts
+    // with their signatures still attached — proving that the resume path's
+    // wire payload would match the live path's (which always carries them).
+    let firstCallMessages: Message[] = [];
+    const client: LLMClient = {
+      async *stream(msgs, _sys, _tools): AsyncGenerator<StreamEvent> {
+        firstCallMessages = msgs;
+        yield { type: "text", text: "ok" };
+        yield { type: "done" };
+      },
+    };
+
+    const agent = new Agent(client, new ToolRegistry(), new SkillRegistry());
+    agent.restoreMessages(restored);
+    for await (const _e of agent.run("anything else?")) void _e;
+
+    const sentCallPart = firstCallMessages
+      .flatMap((m) => m.parts)
+      .find((p) => p.type === "function_call") as { thoughtSignature?: string } | undefined;
+    const sentResultPart = firstCallMessages
+      .flatMap((m) => m.parts)
+      .find((p) => p.type === "function_result") as { thoughtSignature?: string } | undefined;
+    expect(sentCallPart?.thoughtSignature).toBe(SIG);
+    expect(sentResultPart?.thoughtSignature).toBe(SIG);
+  });
+
   it("reconstructs function_call / function_result pairs with matching IDs", async () => {
     const session = await Session.create(FAKE_CWD);
 

--- a/src/state/session.test.ts
+++ b/src/state/session.test.ts
@@ -335,6 +335,56 @@ describe("Session.loadMessages — orphaned tool_result resilience", () => {
   });
 });
 
+describe("Session.loadMessages — thoughtSignature persistence", () => {
+  it("restores thoughtSignature onto FunctionCallPart from the tool_call entry", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Run" });
+    await session.log({
+      type: "tool_call",
+      name: "bash",
+      args: { command: "ls" },
+      thoughtSignature: "sig-abc",
+    });
+    await session.log({ type: "tool_result", name: "bash", result: "ok" });
+    await session.log({ type: "assistant", content: "Done." });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    const callPart = messages[1].parts[0] as { type: string; thoughtSignature?: string };
+    expect(callPart.type).toBe("function_call");
+    expect(callPart.thoughtSignature).toBe("sig-abc");
+  });
+
+  it("propagates the call's thoughtSignature onto the matching FunctionResultPart", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Run" });
+    await session.log({
+      type: "tool_call",
+      name: "bash",
+      args: { command: "ls" },
+      thoughtSignature: "sig-xyz",
+    });
+    await session.log({ type: "tool_result", name: "bash", result: "ok" });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    const resultPart = messages[2].parts[0] as { type: string; thoughtSignature?: string };
+    expect(resultPart.type).toBe("function_result");
+    expect(resultPart.thoughtSignature).toBe("sig-xyz");
+  });
+
+  it("omits thoughtSignature when the tool_call entry didn't carry one (legacy JSONL)", async () => {
+    const session = await Session.create(CWD);
+    await session.log({ type: "user", content: "Run" });
+    await session.log({ type: "tool_call", name: "bash", args: { command: "ls" } });
+    await session.log({ type: "tool_result", name: "bash", result: "ok" });
+
+    const { messages } = await Session.loadMessages(session.id, CWD);
+    const callPart = messages[1].parts[0] as unknown as Record<string, unknown>;
+    const resultPart = messages[2].parts[0] as unknown as Record<string, unknown>;
+    expect(callPart).not.toHaveProperty("thoughtSignature");
+    expect(resultPart).not.toHaveProperty("thoughtSignature");
+  });
+});
+
 describe("Session.loadMessages — consecutive user-text collapse", () => {
   it("merges back-to-back user text entries so provider role alternation holds", async () => {
     const session = await Session.create(CWD);

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -118,22 +118,23 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
   // Pending batches accumulate until we know where they belong
   let pendingCalls: FunctionCallPart[] = [];
   let pendingResults: FunctionResultPart[] = [];
-  // Queue of call IDs waiting for their matching results; ensures each
-  // function_result references the same ID as its function_call (required by the Anthropic API).
-  let pendingCallIds: string[] = [];
+  // Queue of pending calls' (id, signature) pairs waiting for their matching
+  // results. The id pair is required by Anthropic's tool_use_id contract; the
+  // signature is needed so Gemini thinking-model functionResponse can echo it.
+  let pendingCallMeta: { id: string; thoughtSignature?: string }[] = [];
 
   function flushCalls(): void {
     if (pendingCalls.length === 0) return;
     messages.push({ role: "model", parts: pendingCalls });
     pendingCalls = [];
-    // pendingCallIds intentionally kept — results still need them
+    // pendingCallMeta intentionally kept — results still need it
   }
 
   function flushResults(): void {
     if (pendingResults.length === 0) return;
     messages.push({ role: "user", parts: pendingResults });
     pendingResults = [];
-    pendingCallIds = [];
+    pendingCallMeta = [];
   }
 
   for (const entry of entries) {
@@ -146,28 +147,32 @@ function reconstructMessages(entries: SessionEntry[]): Message[] {
       // New tool_call batch: if there were results from a previous round, flush them first
       flushResults();
       const id = `resume-call-${++idCounter}`;
-      pendingCallIds.push(id);
+      pendingCallMeta.push({ id, thoughtSignature: entry.thoughtSignature });
       pendingCalls.push({
         type: "function_call",
         id,
         name: entry.name,
         args: entry.args,
+        ...(entry.thoughtSignature ? { thoughtSignature: entry.thoughtSignature } : {}),
       });
     } else if (entry.type === "tool_result") {
       // Results follow their calls — flush the pending call batch into a model message
       flushCalls();
-      if (pendingCallIds.length === 0) {
+      if (pendingCallMeta.length === 0) {
         process.stderr.write(
           `[opencli] warn: orphaned tool_result for "${entry.name}" (no matching tool_call) — skipping\n`,
         );
         continue;
       }
-      const id = pendingCallIds.shift()!;
+      const meta = pendingCallMeta.shift()!;
       pendingResults.push({
         type: "function_result",
-        id,
+        id: meta.id,
         name: entry.name,
         result: entry.result,
+        // Echo the paired call's signature so Gemini thinking-model
+        // functionResponse can carry it on the next request.
+        ...(meta.thoughtSignature ? { thoughtSignature: meta.thoughtSignature } : {}),
       });
     } else if (entry.type === "assistant" && entry.content) {
       flushCalls();
@@ -226,7 +231,17 @@ export type SessionEntry =
   | { type: "session_start"; timestamp: string; cwd: string }
   | { type: "user"; timestamp: string; content: string }
   | { type: "assistant"; timestamp: string; content: string }
-  | { type: "tool_call"; timestamp: string; name: string; args: Record<string, unknown> }
+  | {
+      type: "tool_call";
+      timestamp: string;
+      name: string;
+      args: Record<string, unknown>;
+      // Gemini thinking-model signature for the originating functionCall.
+      // Persisted so a resumed session sends the same structured payload as an
+      // unbroken one; reconstructMessages propagates it onto the FunctionCallPart
+      // and the matching FunctionResultPart.
+      thoughtSignature?: string;
+    }
   | { type: "tool_result"; timestamp: string; name: string; result: string };
 
 type WithoutTimestamp<T> = T extends unknown ? Omit<T, "timestamp"> : never;


### PR DESCRIPTION
## Summary

Closes the symmetry gap left over from #154: resuming a session and continuing one in the same process now produce the **same wire payload** to Gemini when both originate from a session logged with this change.

Before this PR:
- **Live path**: tool calls in the in-window history carry their `thoughtSignature` in `GeminiClient.thoughtSignatures` (populated during stream) → request to Gemini contains structured `functionCall` / `functionResponse` parts with signatures.
- **Resume path**: the same in-window messages are reconstructed from JSONL but `thoughtSignature` was never persisted → in-memory map empty → #154's thinking-model flatten kicks in → request to Gemini contains **text** `[Tool call: …]` / `[Tool result: …]`.

After this PR: signatures are persisted in the JSONL and threaded back onto both the `FunctionCallPart` and the matching `FunctionResultPart` on restore, so the resume request is byte-for-byte equivalent to a live request through the same window.

## What changed

- `providers/types.ts` — `thoughtSignature?: string` added to `FunctionCallPart`, `FunctionResultPart`, and `StreamEvent.function_call`.
- `providers/gemini.ts` — emit `thoughtSignature` on the stream event; in `messagesToContents` prefer `part.thoughtSignature`, fall back to the in-memory map for any parts built before this change.
- `core/agent.ts` — copy the event's signature onto the `FunctionCallPart` appended to the model message; `AgentEvent.tool_call` now also carries it for downstream loggers.
- `core/executor.ts` — every `FunctionResultPart` constructed from a `FunctionCallPart` inherits its signature (covers happy path, plan-mode denial, and confirmation-denied paths).
- `cli/runner.ts` — log `thoughtSignature` on the session `tool_call` entry.
- `state/session.ts` — `SessionEntry.tool_call` gains optional `thoughtSignature`; `reconstructMessages` restores it onto the `FunctionCallPart` and propagates the same value onto the matching `FunctionResultPart` via a renamed `pendingCallMeta` queue.

## Backward compatibility

JSONL files written before this change have no `thoughtSignature` on their `tool_call` entries. The thinking-model flatten path added in #154 still catches those and degrades to text, so old sessions keep working — they just don't get full structured replay until they accumulate new turns. New sessions get full fidelity from the first tool call.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — 563 passed (+5 new, 1 updated assertion).
- [x] New `session.test.ts` tests: round-trip thoughtSignature → FunctionCallPart; propagation to FunctionResultPart; legacy entries unchanged.
- [x] New `gemini.test.ts` test: restored history with part-level signatures produces structured `functionCall`/`functionResponse` (not flattened text). Existing flatten path test still passes for sessions without signatures.
- [x] Updated `gemini.test.ts` assertion: `StreamEvent.function_call` now intentionally carries `thoughtSignature`.
- [x] End-to-end against the legacy stuck session (no signatures): still resumes via flatten fallback, no 400.

## Notes for reviewers

- The in-memory `thoughtSignatures` map in `GeminiClient` is kept as a fallback rather than removed. With part-level signatures, it's mostly redundant — but it lets historical in-process turns keep working if for any reason a part lacks the field.
- The `pendingCallIds: string[]` queue in `reconstructMessages` is renamed to `pendingCallMeta: { id; thoughtSignature? }[]` so the result's signature can be matched to its originating call by FIFO.
- The flatten-on-missing-sig path in `messagesToContents` is still reachable (legacy JSONLs); it just no longer covers fresh sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)