### PR TITLE
feat(permissions): add ask rules to force confirmation for SAFE_COMMANDS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ src/
   state/
     config.ts       # ~/.opencli/config.json load/save; exports AGENT_DIR, Config (incl. anthropicApiKey)
     session.ts      # JSONL session logs at ~/.opencli/projects/<cwd>/; create, list, resume
-    settings.ts     # .opencli/settings.json load/save; holds project-level Permissions (HITL allow/deny list)
+    settings.ts     # .opencli/settings.json load/save; holds project-level Permissions (HITL allow/ask/deny list)
     snapshot.ts     # SnapshotManager — git stash create/restore for per-session working-tree snapshots
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ src/
   state/
     config.ts       # ~/.opencli/config.json load/save; exports AGENT_DIR, Config (incl. anthropicApiKey)
     session.ts      # JSONL session logs at ~/.opencli/projects/<cwd>/; create, list, resume
-    settings.ts     # .opencli/settings.json load/save; holds project-level Permissions (HITL allow/deny list)
+    settings.ts     # .opencli/settings.json load/save; holds project-level Permissions (HITL allow/ask/deny list)
     snapshot.ts     # SnapshotManager — git stash create/restore for per-session working-tree snapshots
 ```
 

--- a/src/cli/confirm.test.ts
+++ b/src/cli/confirm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { globMatch, matchesDenyPattern } from "./confirm.js";
+import { globMatch, matchesDenyPattern, createForcesConfirmationFn } from "./confirm.js";
 
 describe("globMatch", () => {
   it("matches an exact string with no wildcards", () => {
@@ -81,5 +81,38 @@ describe("matchesDenyPattern", () => {
     const patterns = ['read({"file_path":"secret.txt"})'];
     expect(matchesDenyPattern(patterns, "read", { file_path: "secret.txt" })).toBe(true);
     expect(matchesDenyPattern(patterns, "read", { file_path: "other.txt" })).toBe(false);
+  });
+});
+
+describe("createForcesConfirmationFn", () => {
+  it("returns false for all calls when ask patterns list is empty", () => {
+    const fn = createForcesConfirmationFn([]);
+    expect(fn("bash", { command: "git status" })).toBe(false);
+    expect(fn("write", { file_path: "src/foo.ts" })).toBe(false);
+  });
+
+  it("returns true when bash command matches an ask pattern", () => {
+    const fn = createForcesConfirmationFn(["bash(git push*)"]);
+    expect(fn("bash", { command: "git push origin main" })).toBe(true);
+    expect(fn("bash", { command: "git status" })).toBe(false);
+  });
+
+  it("returns true when write path matches an ask pattern", () => {
+    const fn = createForcesConfirmationFn(["write(src/*)"]);
+    expect(fn("write", { file_path: "src/index.ts" })).toBe(true);
+    expect(fn("write", { file_path: "test/index.ts" })).toBe(false);
+  });
+
+  it("returns false for a non-matching tool name", () => {
+    const fn = createForcesConfirmationFn(["bash(git push*)"]);
+    expect(fn("write", { command: "git push origin main" })).toBe(false);
+  });
+
+  it("matches across multiple patterns", () => {
+    const fn = createForcesConfirmationFn(["bash(git push*)", "write(src/*)"]);
+    expect(fn("bash", { command: "git push origin main" })).toBe(true);
+    expect(fn("write", { file_path: "src/index.ts" })).toBe(true);
+    expect(fn("bash", { command: "git status" })).toBe(false);
+    expect(fn("write", { file_path: "test/index.ts" })).toBe(false);
   });
 });

--- a/src/cli/confirm.ts
+++ b/src/cli/confirm.ts
@@ -39,7 +39,26 @@ export function matchesDenyPattern(
   return false;
 }
 
-export async function createConfirmFn(): Promise<ConfirmFn> {
+/** Builds a sync function that returns true when a tool call matches one of the
+ *  given ask patterns and must therefore be confirmed even if the tool's own
+ *  requiresConfirmation would return false. */
+export function createForcesConfirmationFn(
+  askPatterns: string[],
+): (toolName: string, args: Record<string, unknown>) => boolean {
+  return (toolName, args) => {
+    if (askPatterns.length === 0) return false;
+    return matchesDenyPattern(askPatterns, toolName, args);
+  };
+}
+
+export interface ConfirmBundle {
+  confirmFn: ConfirmFn;
+  /** Returns true if the tool call matches an `ask` pattern and must be confirmed
+   *  even when the tool itself does not set requiresConfirmation. */
+  forcesConfirmation: (toolName: string, args: Record<string, unknown>) => boolean;
+}
+
+export async function createConfirmFn(): Promise<ConfirmBundle> {
   const [config, settings] = await Promise.all([loadConfig(), loadSettings()]);
 
   const globalAllowSet = new Set<string>(config.permissions?.allow ?? []);
@@ -48,8 +67,14 @@ export async function createConfirmFn(): Promise<ConfirmFn> {
     ...(config.permissions?.deny ?? []),
     ...(settings.permissions?.deny ?? []),
   ];
+  const askPatterns: string[] = [
+    ...(config.permissions?.ask ?? []),
+    ...(settings.permissions?.ask ?? []),
+  ];
 
-  return async (toolName, args) => {
+  const forcesConfirmation = createForcesConfirmationFn(askPatterns);
+
+  const confirmFn: ConfirmFn = async (toolName, args) => {
     if (!process.stdin.isTTY) return "deny";
 
     if (denyPatterns.length > 0 && matchesDenyPattern(denyPatterns, toolName, args)) {
@@ -120,4 +145,6 @@ export async function createConfirmFn(): Promise<ConfirmFn> {
 
     return "allow";
   };
+
+  return { confirmFn, forcesConfirmation };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -237,7 +237,9 @@ async function runSingle(
   if (autoApprove) {
     agent.setConfirmFn(async () => "allow");
   } else if (process.stdin.isTTY) {
-    agent.setConfirmFn(await createConfirmFn());
+    const { confirmFn, forcesConfirmation } = await createConfirmFn();
+    agent.setConfirmFn(confirmFn);
+    agent.setForcesConfirmationFn(forcesConfirmation);
   }
   // no confirmFn → executor auto-denies tools that require confirmation
 

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -33,7 +33,9 @@ export async function runRepl(
   onExit?: () => Promise<void>,
   snapshotManager?: SnapshotManager,
 ): Promise<void> {
-  agent.setConfirmFn(await createConfirmFn());
+  const { confirmFn, forcesConfirmation } = await createConfirmFn();
+  agent.setConfirmFn(confirmFn);
+  agent.setForcesConfirmationFn(forcesConfirmation);
   printInfo(`OpenCLI — type /help for commands, Ctrl+C to exit\n`);
 
   let session: Session;

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -49,6 +49,7 @@ export type AgentRunMode = "react" | "plan";
 export class Agent {
   private context: ContextManager;
   private confirmFn?: ConfirmFn;
+  private forcesConfirmationFn?: (toolName: string, args: Record<string, unknown>) => boolean;
   private model: string;
   private obs?: ObservabilityHandler;
   private snapshotManager?: SnapshotManager;
@@ -78,6 +79,10 @@ export class Agent {
 
   setConfirmFn(fn: ConfirmFn): void {
     this.confirmFn = fn;
+  }
+
+  setForcesConfirmationFn(fn: (toolName: string, args: Record<string, unknown>) => boolean): void {
+    this.forcesConfirmationFn = fn;
   }
 
   setSessionTmpDir(dir: string): void {
@@ -233,6 +238,7 @@ export class Agent {
         tmpDir: this.context.getSessionTmpDir(),
         readOnly: mode === "plan",
         confirmFn: this.confirmFn,
+        forcesConfirmation: this.forcesConfirmationFn,
         obs: this.obs,
         snapshot: this.snapshotManager,
         cwd: process.cwd(),

--- a/src/core/executor.test.ts
+++ b/src/core/executor.test.ts
@@ -475,6 +475,75 @@ describe("executeCalls — confirmation", () => {
     expect(confirmFn).toHaveBeenCalledWith("risky", { command: "rm -rf /" });
     expect(results[0].result).toBe("done");
   });
+
+  it("calls confirmFn when forcesConfirmation returns true even if requiresConfirmation is false", async () => {
+    const confirmFn = vi.fn(async () => "allow" as const);
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "safe",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "ok" }),
+      requiresConfirmation: () => false,
+    });
+
+    const { results } = await executeCalls([makeToolCall("safe", { command: "git push" })], {
+      tools: registry,
+      skills: makeSkillRegistry({}),
+      context: new ContextManager(),
+      confirmFn,
+      forcesConfirmation: (_toolName, args) => (args.command as string) === "git push",
+    });
+
+    expect(confirmFn).toHaveBeenCalledWith("safe", { command: "git push" });
+    expect(results[0].result).toBe("ok");
+  });
+
+  it("denies when forcesConfirmation returns true and confirmFn denies", async () => {
+    const executeMock = vi.fn(async () => ({ success: true, output: "ran" }));
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "safe",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: executeMock,
+      requiresConfirmation: () => false,
+    });
+    const confirmFn = vi.fn(async () => "deny" as const);
+
+    const { results } = await executeCalls([makeToolCall("safe", { command: "git push" })], {
+      tools: registry,
+      skills: makeSkillRegistry({}),
+      context: new ContextManager(),
+      confirmFn,
+      forcesConfirmation: () => true,
+    });
+
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(results[0].result).toContain("denied");
+  });
+
+  it("skips confirmFn when forcesConfirmation returns false and requiresConfirmation returns false", async () => {
+    const confirmFn = vi.fn(async () => "allow" as const);
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "safe",
+      description: "",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ success: true, output: "ok" }),
+      requiresConfirmation: () => false,
+    });
+
+    await executeCalls([makeToolCall("safe")], {
+      tools: registry,
+      skills: makeSkillRegistry({}),
+      context: new ContextManager(),
+      confirmFn,
+      forcesConfirmation: () => false,
+    });
+
+    expect(confirmFn).not.toHaveBeenCalled();
+  });
 });
 
 describe("truncateOutput", () => {

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -27,6 +27,9 @@ export interface ExecutorDeps {
   tmpDir?: string;
   readOnly?: boolean;
   confirmFn?: ConfirmFn;
+  /** Returns true when a tool call matches an `ask` permission pattern and must be
+   *  confirmed even though the tool's own requiresConfirmation returns false. */
+  forcesConfirmation?: (toolName: string, args: Record<string, unknown>) => boolean;
   obs?: ObservabilityHandler;
   snapshot?: SnapshotManager;
   cwd?: string;
@@ -81,7 +84,10 @@ async function executeOneCall(
       ...sig,
     };
   }
-  if (tool?.requiresConfirmation?.(call.args as Record<string, unknown>)) {
+  const needsConfirm =
+    tool?.requiresConfirmation?.(call.args as Record<string, unknown>) ||
+    deps.forcesConfirmation?.(call.name, call.args as Record<string, unknown>);
+  if (needsConfirm) {
     const decision = deps.confirmFn
       ? await deps.confirmFn(call.name, call.args as Record<string, unknown>)
       : "deny";

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -6,6 +6,7 @@ const CONFIG_FILE = join(AGENT_DIR, "config.json");
 
 export interface Permissions {
   allow?: string[];
+  ask?: string[];
   deny?: string[];
 }
 


### PR DESCRIPTION
## Summary

- Adds `ask?: string[]` to the `Permissions` type in both `config.ts` and `settings.ts`, completing the deny side of Phase 2 (#34) with an ask-side counterpart
- Users can now list `"toolName(argGlob)"` patterns under `permissions.ask` in `.opencli/settings.json` (project-scoped) or `~/.opencli/config.json` (global) to force the HITL confirmation dialog even for commands the tool itself considers safe — e.g., forcing a prompt before any `git push`
- Exports `createForcesConfirmationFn(askPatterns)` from `confirm.ts` — a pure synchronous function, easily unit-tested without mocks
- Adds `ExecutorDeps.forcesConfirmation?` and gates confirmation on `requiresConfirmation || forcesConfirmation`
- Adds `Agent.setForcesConfirmationFn()` to wire the function through to the executor; `createConfirmFn` returns `{ confirmFn, forcesConfirmation }` and both are set from `repl.ts` and `cli/index.ts`
- Evaluation order: deny → (allow short-circuits ask) → ask → default tool behaviour

## Related issue

Closes #34 (Part of Phase 2 — ask rules; Phase 3 AI-based classification is a separate stretch goal)

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (601 tests, 0 failures)
- [x] 5 new unit tests for `createForcesConfirmationFn` covering: empty patterns, bash match, write match, no tool match, multi-pattern merge
- [x] 3 new executor tests: forces confirmation when `requiresConfirmation` is false, denies when `forcesConfirmation` triggers and `confirmFn` denies, skips `confirmFn` when both return false

---
_Generated by [Claude Code](https://claude.ai/code/session_0141SHjwe6zcA1AdeugsYpwR)_