### PR TITLE
feat: add /undo command to remove the last agent turn from history

### DIFF
--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -22,6 +22,7 @@ const BUILTIN_COMMANDS: SlashCommand[] = [
   { name: "compact", description: "summarize older conversation history to free context" },
   { name: "context", description: "show current token usage vs. context window" },
   { name: "rewind", description: "undo agent file changes since last snapshot" },
+  { name: "undo", description: "remove the last user message and agent response from history" },
   { name: "clear", description: "clear conversation history" },
   { name: "exit", description: "exit the agent" },
 ];
@@ -87,6 +88,15 @@ export async function runRepl(
     if (input === "/clear") {
       agent.clearHistory();
       printInfo("History cleared.");
+      continue;
+    }
+    if (input === "/undo") {
+      const removed = agent.undoLastTurn();
+      if (removed === 0) {
+        printInfo("Nothing to undo — conversation is empty.");
+      } else {
+        printInfo(`Undid last turn (${removed} message${removed === 1 ? "" : "s"} removed).`);
+      }
       continue;
     }
     if (input === "/exit" || input === "/quit") {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -326,6 +326,10 @@ export class Agent {
     };
   }
 
+  undoLastTurn(): number {
+    return this.context.popTurn();
+  }
+
   clearHistory(): void {
     this.context.clear();
   }

--- a/src/core/context.test.ts
+++ b/src/core/context.test.ts
@@ -472,6 +472,65 @@ describe("ContextManager", () => {
   });
 });
 
+describe("ContextManager — popTurn", () => {
+  it("returns 0 and leaves history empty when called on empty context", () => {
+    const ctx = new ContextManager(STUB);
+    expect(ctx.popTurn()).toBe(0);
+    expect(ctx.getMessages()).toEqual([]);
+  });
+
+  it("removes a single user message when there is no model response yet", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("hello"));
+    expect(ctx.popTurn()).toBe(1);
+    expect(ctx.getMessages()).toEqual([]);
+  });
+
+  it("removes the last user message and its model response", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("first"));
+    ctx.addMessage(modelMsg("first reply"));
+    ctx.addMessage(userMsg("second"));
+    ctx.addMessage(modelMsg("second reply"));
+    expect(ctx.popTurn()).toBe(2);
+    expect(ctx.getMessages()).toEqual([userMsg("first"), modelMsg("first reply")]);
+  });
+
+  it("removes a full tool-call round-trip with the triggering user message", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("run a tool"));
+    ctx.addMessage(modelWithCalls([{ id: "c1", name: "bash" }]));
+    ctx.addMessage(userWithResults([{ id: "c1", name: "bash" }]));
+    ctx.addMessage(modelMsg("done"));
+    expect(ctx.popTurn()).toBe(4);
+    expect(ctx.getMessages()).toEqual([]);
+  });
+
+  it("preserves earlier turns when undoing the last one", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("turn 1"));
+    ctx.addMessage(modelMsg("reply 1"));
+    ctx.addMessage(userMsg("turn 2"));
+    ctx.addMessage(modelWithCalls([{ id: "c1", name: "read" }]));
+    ctx.addMessage(userWithResults([{ id: "c1", name: "read" }]));
+    ctx.addMessage(modelMsg("reply 2"));
+    expect(ctx.popTurn()).toBe(4);
+    expect(ctx.getMessages()).toEqual([userMsg("turn 1"), modelMsg("reply 1")]);
+  });
+
+  it("can be called multiple times to undo successive turns", () => {
+    const ctx = new ContextManager(STUB);
+    ctx.addMessage(userMsg("a"));
+    ctx.addMessage(modelMsg("a reply"));
+    ctx.addMessage(userMsg("b"));
+    ctx.addMessage(modelMsg("b reply"));
+    ctx.popTurn();
+    ctx.popTurn();
+    expect(ctx.getMessages()).toEqual([]);
+    expect(ctx.popTurn()).toBe(0);
+  });
+});
+
 describe("ContextManager — messageCount and maxMessages getters", () => {
   it("messageCount is 0 initially", () => {
     const ctx = new ContextManager(STUB);

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -110,6 +110,18 @@ export class ContextManager {
     return this.maxHistoryMessages;
   }
 
+  popTurn(): number {
+    for (let i = this.history.length - 1; i >= 0; i--) {
+      const msg = this.history[i];
+      if (msg.role === "user" && !msg.parts.some((p) => p.type === "function_result")) {
+        const removed = this.history.length - i;
+        this.history = this.history.slice(0, i);
+        return removed;
+      }
+    }
+    return 0;
+  }
+
   clear(): void {
     this.history = [];
     this.skillContent = [];


### PR DESCRIPTION
## Summary

- Adds `/undo` slash command to the REPL that removes the last user message plus all subsequent agent messages (including any tool call round-trips) from conversation history
- Lets users recover from a wrong prompt or a bad agent response without clearing the entire session
- Implements `ContextManager.popTurn()` (scans backwards for the last clean user text message, truncates from that index) and exposes it via `Agent.undoLastTurn()`

## Related issue

Part of #43 (quick win: `/undo` command from the "Priority Feature Backlog")

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (599 tests, 0 failures)
- [x] 6 new unit tests for `ContextManager.popTurn()` covering: empty history, single user message, user+model pair, full tool-call round-trip, preserving earlier turns, and repeated undo calls

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwCpYYQZJm98S3u1utYxfw)_