### PR TITLE
docs: update A5 design doc status to reflect A5a implementation

### DIFF
--- a/docs/design/a5-compact-context.md
+++ b/docs/design/a5-compact-context.md
@@ -1,6 +1,6 @@
 # Design: A5 — /compact + /context
 
-_Status: Staged into A5a (Ready for implementation) and A5b (Ready for design review after A5a ships). Tracking issues: [#26](https://github.com/zjshen14/opencli/issues/26) (A5a), [#27](https://github.com/zjshen14/opencli/issues/27) (A5b). Phase: [Roadmap A5](../roadmap.md)._
+_Status: A5a Implemented — merged in dd5acbd (2026-05-17). A5b pending — blocked on real-session Phase 2 validation, tracked in [#113](https://github.com/zjshen14/opencli/issues/113). Tracking issue: [#26](https://github.com/zjshen14/opencli/issues/26). Phase: [Roadmap A5](../roadmap.md)._
 
 ---
 


### PR DESCRIPTION
## Summary

- `docs/design/a5-compact-context.md` still read "Staged into A5a (Ready for implementation)" even though A5a (`/compact` + `/context`) shipped in commit `dd5acbd` (2026-05-17)
- CLAUDE.md explicitly requires: _"The status line must never read 'Ready for implementation' for code that is already on `main`."_
- Also fixes a stale A5b tracking reference: the doc pointed to closed issue #27; updated to the active tracking issue #113

## Changes

Single line in `docs/design/a5-compact-context.md`:

**Before:**
```
_Status: Staged into A5a (Ready for implementation) and A5b (Ready for design review after A5a ships). Tracking issues: #26 (A5a), #27 (A5b). Phase: Roadmap A5._
```

**After:**
```
_Status: A5a Implemented — merged in dd5acbd (2026-05-17). A5b pending — blocked on real-session Phase 2 validation, tracked in #113. Tracking issue: #26. Phase: Roadmap A5._
```

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (607 tests, 0 failures)
- [x] No code changes — doc-only fix

Part of #26

https://claude.ai/code/session_01TTPfMyekzBrAPdmwj1MxXf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTPfMyekzBrAPdmwj1MxXf)_