### PR TITLE
docs: mark A5a as implemented in a5-compact-context.md

### DIFF
--- a/docs/design/a5-compact-context.md
+++ b/docs/design/a5-compact-context.md
@@ -1,6 +1,6 @@
 # Design: A5 — /compact + /context
 
-_Status: Staged into A5a (Ready for implementation) and A5b (Ready for design review after A5a ships). Tracking issues: [#26](https://github.com/zjshen14/opencli/issues/26) (A5a), [#27](https://github.com/zjshen14/opencli/issues/27) (A5b). Phase: [Roadmap A5](../roadmap.md)._
+_Status: A5a Implemented — merged in 4aba15e (2026-05-17), closes [#112](https://github.com/zjshen14/opencli/issues/112). A5b blocked pending real-session data from A5a; tracking [#113](https://github.com/zjshen14/opencli/issues/113). Phase: [Roadmap A5](../roadmap.md)._
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates the `_Status:` line in `docs/design/a5-compact-context.md` to reflect that A5a (`/compact` and `/context` commands) was implemented and merged in commit `4aba15e` on 2026-05-17 via PR #114
- Fixes the stale A5b tracking issue reference (`#27` → `#113`)
- `CLAUDE.md` explicitly requires: *"The status line must never read 'Ready for implementation' for code that is already on `main`."*

Closes #177

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (607 tests)
- [x] `docs/design/a5-compact-context.md` status line no longer reads "Ready for implementation"
- [x] Status line correctly cites merge commit `4aba15e` (2026-05-17) and closed issue #112
- [x] Status line correctly references open A5b issue #113

https://claude.ai/code/session_019UXDVQXYruETKwbUNcRhEs

---
_Generated by [Claude Code](https://claude.ai/code/session_019UXDVQXYruETKwbUNcRhEs)_