### PR TITLE
fix(sandbox): expand strict-mode read paths so the shell actually loads on macOS Tahoe + Homebrew

### DIFF
--- a/src/tools/exec/sandbox/sandbox-exec.ts
+++ b/src/tools/exec/sandbox/sandbox-exec.ts
@@ -20,7 +20,14 @@ function buildStrictProfile(cwd: string): string {
 (allow ipc*)
 (allow process-info* (target others))
 
-; Reads: cwd + minimum system paths required for binaries to load
+; Reads: cwd + minimum system paths required for binaries to load.
+; Without these, /bin/sh and dyld can't load and the shell exits with
+; SIGABRT before our command ever runs.
+;
+; The (literal "/") allow lets dyld stat the root directory during path
+; resolution — without it everything below SIGABRTs on macOS 13+, even
+; though every accessed path is itself allowed by one of the subpath rules.
+(allow file-read* (literal "/"))
 (allow file-read* (subpath "${cwd}"))
 (allow file-read* (subpath "/usr"))
 (allow file-read* (subpath "/bin"))
@@ -29,9 +36,18 @@ function buildStrictProfile(cwd: string): string {
 (allow file-read* (subpath "/Library"))
 (allow file-read* (subpath "/private/etc"))
 (allow file-read* (subpath "/private/var/db"))
+(allow file-read* (subpath "/private/var/select"))
 (allow file-read* (subpath "/dev"))
 (allow file-read* (subpath "/private/tmp"))
 (allow file-read* (subpath "/private/var/folders"))
+; macOS 13+ cryptex sealed system content. Sub-mount of /System so the
+; subpath rule above doesn't reach it; required on Ventura/Sonoma/Sequoia/Tahoe.
+(allow file-read* (subpath "/System/Volumes/Preboot"))
+; Homebrew binaries — common tools like node, python3, gh live here.
+; Without these, strict mode is unusable on any project that depends on
+; a Homebrew-installed runtime.
+(allow file-read* (subpath "/opt/homebrew"))
+(allow file-read* (subpath "/usr/local"))
 
 ; Writes: only cwd + tmp
 (allow file-write* (subpath "${cwd}"))


### PR DESCRIPTION
## Summary

PR #155 shipped strict mode, but locally all three of its substantive tests fail on macOS 26 (Tahoe) with Apple Silicon Homebrew. Symptom: even \`/bin/sh -c \"echo hello\"\` exits with status 134 (SIGABRT) before the command runs. The empty stdout in the failing assertions traces to dyld being unable to load the shell.

Three additions to the strict profile:

1. **\`(allow file-read* (literal \"/\"))\`** — dyld stats \`/\` itself during path resolution. Without it the kernel SIGABRTs the shell even though every accessed sub-path is allowed individually. This is the actual fix; everything else is incremental.
2. **\`(subpath \"/System/Volumes/Preboot\")\`** — macOS 13+ moved part of the sealed system into a cryptex mount. The existing \`(subpath \"/System\")\` doesn't reach across that mount boundary on Ventura/Sonoma/Sequoia/Tahoe.
3. **\`(subpath \"/opt/homebrew\")\` and \`(subpath \"/usr/local\")\`** — strict mode is unusable on machines whose \`node\`, \`python3\`, \`gh\` etc. come from Homebrew without these paths. Covers Apple Silicon and Intel/MacPorts.

Also added \`(subpath \"/private/var/select\")\` to silence a benign \"Error opening /private/var/select/sh: Operation not permitted\" the shell-selection lookup produces.

## Related issue

No tracking issue — fixing a regression in PR #155. Closes the gap revealed by the existing tests once you run them on macOS 26.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm test\` — 622 tests pass (was 619 failing 3)
- [x] All 18 \`sandbox-exec.test.ts\` tests pass deterministically
- [x] \"blocks reads from ~/.ssh\" still passes — the new allows are all under root-owned system or sandbox-irrelevant directories
- [ ] CI: macOS runner should pass (the regression was masked on CI by an older macOS image — worth confirming once this rebuilds)

## Notes for reviewers

The behavior change is **narrow and safe**: strict still blocks every user-data path that mattered before (\`~/.ssh\`, \`~/.aws\`, \`~/Documents\`, browser data, etc.). The new allows are all root-owned system locations or Homebrew dirs (which contain binaries, not secrets).

The \`(literal \"/\")\` allow is the surprising one and deserves a callout — it lets the sandbox stat the root directory entry itself but doesn't grant any subpath read. The reason this is needed only on newer macOS is that dyld changed its path-resolution behavior to check the root inode at startup. Without it, even a profile that allows reads on every individual subpath fails because dyld never gets that far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)