### PR TITLE
docs(architecture): document the deny pattern format added in #156

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -534,12 +534,19 @@ Environment variables override config file values:
 {
   "permissions": {
     "allow": ["bash:git status", "bash:npm test"],
-    "deny":  []
+    "deny":  ["bash(rm -rf *)", "write(.env*)", "edit(package-lock.json)"]
   }
 }
 ```
 
-The HITL confirmation function (`createConfirmFn` in `repl.ts`) persists "Yes always" decisions to this file so they survive across sessions. The project-scoped file is checked first; a global `~/.opencli/settings.json` is the fallback for user-wide rules.
+The HITL confirmation function (`createConfirmFn` in `repl.ts`) persists "Yes always" decisions to the `allow` list so they survive across sessions. The project-scoped file is checked first; a global `~/.opencli/settings.json` is the fallback for user-wide rules.
+
+**Allow vs deny formats are different:**
+
+- `allow` entries use the exact-args key format `toolName:JSON(args)` (e.g. `bash:{"command":"git status"}`) or the tool-wildcard `toolName:*`. These are exact-match strings written by the "Yes always" flow.
+- `deny` entries use a glob-pattern format `toolName(argGlob)` where `*` matches any sequence (e.g. `bash(rm -rf *)`, `write(.env*)`, `bash(*)` to deny all bash). The matched arg is `args.command` for `bash`, `args.file_path` for `write`/`edit`, and `JSON.stringify(args)` for any other tool. Pattern globbing is implemented in `src/cli/confirm.ts` (`globMatch` + `matchesDenyPattern`).
+
+**Order of evaluation in `createConfirmFn`:** `deny` patterns are checked first and short-circuit to a deny decision regardless of any matching `allow` entry. Only if no deny pattern matches does the function consult the `allow` list and (failing that) prompt the user interactively. Both global and project-scoped `deny` lists are unioned.
 
 #### Sessions (`~/.opencli/projects/<encoded-cwd>/<session-id>.jsonl`)
 


### PR DESCRIPTION
## Summary

PR #156 added pattern-based deny rules to the permissions system, but [docs/architecture.md](docs/architecture.md) still showed \`\"deny\": []\` as an empty placeholder. Readers couldn't tell:

- The pattern format (\`toolName(argGlob)\` with \`*\` wildcards, **not** the exact-match key format that \`allow\` uses)
- Which arg is matched (\`bash\` → \`command\`, \`write\`/\`edit\` → \`file_path\`, others → \`JSON.stringify(args)\`)
- That \`deny\` short-circuits \`allow\` (so a deny pattern always wins, even against a matching allow entry)

This PR documents all three in the existing Settings section.

## Related issue

No tracking issue — documentation follow-up for #156.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm test\` — all pass
- [x] Example deny patterns match what \`src/cli/confirm.ts\` (\`globMatch\`, \`matchesDenyPattern\`) actually parses

## Notes for reviewers

I considered adding a similar permissions blurb to the README, but the existing README doesn't document \`.opencli/settings.json\` at all — it stops at the \`config\` command. Felt right to keep the README scope unchanged and only update the architecture doc, which is where the Settings format already lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)