### PR TITLE
prompt: strengthen parallel-tool-call rule with cost framing and example

### DIFF
--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -216,7 +216,8 @@ After every code change:
 
 ## Tool Usage
 
-- Run independent tool calls in parallel (searches, reads, lookups)
+- **Batch independent tool calls in one response.** Each separate LLM turn is a 20-50 second round-trip; emitting six \`read\` calls across six turns wastes minutes of wall time. Always batch when you can: multiple \`read\` / \`glob\` / \`grep\` / \`ls\` / \`web_fetch\` calls, and multiple \`write\` calls for files whose contents don't depend on each other. Don't batch when there's a real ordering dependency: multiple \`edit\` calls on the same file, or any sequence where one tool's output determines the next tool's args.
+  - Example: when exploring a component, emit \`read\` calls for \`Navbar.tsx\`, \`Footer.tsx\`, \`layout.tsx\`, \`page.tsx\` together in one response — not one per turn.
 - Use \`grep\`/\`glob\` to locate code before reading whole files; never read a file you don't need
 - One \`edit\` call per file per turn to avoid conflicts
 - **edit**: always \`read\` the file first; \`old_string\` must match exactly — whitespace and indentation included; if it fails with "not found", re-read and try again with the exact content


### PR DESCRIPTION
## Summary

The card_trade session forensics (2026-05-17T22-00-06-184) showed the agent doing one tool call per turn even when calls were trivially independent:

\`\`\`
LLM thinking gap | Next call
            38.5s   read
            40.2s   read     ← four independent reads,
            38.1s   read     ← four LLM turns instead of one
            39.2s   read
\`\`\`

Each gap is a full LLM round-trip with the Gemini thinking model (median 17.7s, P90 48.4s in that session). Four reads in four turns ≈ 160s wall-clock; the same four reads in one response ≈ 40s.

The existing prompt line *\"Run independent tool calls in parallel (searches, reads, lookups)\"* was too soft. The model interpreted it as a permission rather than a directive, and ignored it from turn 2 onward.

Replacement leads with the cost, lists what to batch and what not to batch, and gives one concrete example matching the observed failure mode.

## Related issue

No tracking issue — direct response to the latency analysis we did on the live card_trade session.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm test\` — all 622 tests pass
- [ ] Manual verification: re-run a multi-file exploration session and confirm the agent emits batched read calls in one response instead of one-per-turn

## Notes for reviewers

This is the most leveraged single-line prompt change available right now: dominant factor in wall-clock latency for thinking-model sessions, no behavior change anywhere else. Worth shipping even if the example tone reads a bit over-prescriptive — the underlying model needs the explicit nudge.

I deliberately did NOT touch the existing \"One \`edit\` call per file per turn\" line below; that rule remains the operative constraint for edits, and the new rule's \"Don't batch: multiple \`edit\` calls on the same file\" clause aligns with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)