### PR TITLE
fix(renderer): expand compact-tool results on error instead of green ✓

### DIFF
--- a/src/cli/renderer.test.ts
+++ b/src/cli/renderer.test.ts
@@ -530,6 +530,23 @@ describe("print functions write to stderr/stdout", () => {
     expect(stderrSpy).not.toHaveBeenCalled();
   });
 
+  it("printToolResultCompact expands on error instead of showing a misleading ✓", () => {
+    printToolResultCompact("read", "Error: ENOENT: no such file or directory, open 'missing.ts'");
+    const output = stripAnsi(stderr());
+    // Should use ✗ + red, not ✓ + dim — the previous behaviour put a green
+    // success mark next to an error message.
+    expect(output).toContain("✗");
+    expect(output).not.toContain("✓");
+    expect(output).toContain("ENOENT");
+  });
+
+  it("printToolResultCompact still shows ✓ for non-error results", () => {
+    printToolResultCompact("read", "1\timport foo from 'bar';");
+    const output = stripAnsi(stderr());
+    expect(output).toContain("✓");
+    expect(output).not.toContain("✗");
+  });
+
   it("printEditDiff writes + and - lines to stderr", () => {
     printEditDiff("old content\n", "new content\n", "src/foo.ts");
     const output = stderr();

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -161,9 +161,15 @@ export function printToolCallCompact(name: string, args: Record<string, unknown>
   process.stderr.write(chalk.dim(`  ○ ${name.padEnd(6)}${arg}`) + "\n");
 }
 
-// Overwrites the compact call line with a ✓ result summary
+// Overwrites the compact call line with a ✓ result summary, or expands the
+// row when the tool failed — otherwise a misleading green ✓ would appear next
+// to an error message (e.g. "✓ read   ENOENT: no such file or directory ...").
 export function printToolResultCompact(name: string, result: string): void {
   if (name === "think") return; // think results are silent — the call line is enough
+  if (result.trim().startsWith("Error:")) {
+    printToolResultExpanded(name, result);
+    return;
+  }
   const summary = summariseResult(name, result);
   process.stderr.write(chalk.dim(`  ✓ ${summary}`) + "\n");
 }


### PR DESCRIPTION
## Summary

For tools in \`COMPACT_TOOLS\` (\`read\`/\`glob\`/\`grep\`/\`ls\`/\`think\`/\`todo_*\`), \`printToolResultCompact\` rendered every result as a dim green \`✓ summary\` line — including errors. So a failed \`read\` showed:

\`\`\`
✓ read   Error: ENOENT: no such file or directory ...
\`\`\`

The non-compact path in \`printToolResult\` already checked for \`Error:\` and routed to \`printToolResultExpanded\` (✗ in red plus the body). The compact path bypassed that check.

Fix adds the same \`Error:\` guard. Two new tests cover the new branch (expanded on error) and confirm the success path is unchanged.

## Related issue

Closes the last remaining acceptance-criterion gap in #89 (A6 — inline diffs + compact tool rows). The other A6 items (edit diff, short-result compaction, long-output expansion, error expansion for non-compact tools) were already in place.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm test\` — all pass
- [x] New tests in \`renderer.test.ts\`:
  - \`read → expanded ✗ when result starts with \"Error:\"\`
  - \`read → compact ✓ for normal results (existing behaviour preserved)\`
- [ ] Manual: run a session, trigger a \`read\` on a missing path, confirm the rendered output shows red ✗ and the error body

## Notes for reviewers

Two-line behaviour change wrapped in a short helper conditional. Minimal blast radius. The error-detection heuristic (\`result.trim().startsWith(\"Error:\")\`) matches the convention all tools use for surfacing failures and the convention \`printToolResult\` already relied on — kept consistent so the two paths can't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)