### PR TITLE
refactor(agent): extract run() loop body into focused helper methods

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -6,7 +6,12 @@ import { ContextManager } from "./context.js";
 import { executeCalls } from "./executor.js";
 import type { ConfirmFn } from "./executor.js";
 import { buildReminder, buildPlanSuffix } from "./prompt.js";
-import type { FunctionCallPart, Message } from "../providers/types.js";
+import type {
+  FunctionCallPart,
+  FunctionResultPart,
+  Message,
+  ToolDefinition,
+} from "../providers/types.js";
 import type { ObservabilityHandler } from "./observability.js";
 import type { SnapshotManager } from "../state/snapshot.js";
 import { compactHistory, contextWindowFor, COMPACTION_TARGET_TOKENS } from "./compact.js";
@@ -34,6 +39,25 @@ const AUTO_COMPACT_TRIGGER_RATIO = 0.75;
 const DEFAULT_MAX_TURNS = 50;
 const STUCK_THRESHOLD = 3;
 const ENV_ERROR_THRESHOLD = 3;
+
+// Per-turn mutable state passed through the run() pipeline. Each guard reads
+// and updates the fields it owns; the loop is otherwise stateless. Kept as a
+// plain interface (not a class) so guard methods can mutate counters without
+// ceremony.
+interface TurnState {
+  turns: number;
+  lastCallSig: string;
+  stuckCount: number;
+  envErrorPattern: string;
+  envErrorCount: number;
+  emptyRetried: boolean;
+  firedReminders: Set<string>;
+}
+
+interface TurnSetup {
+  toolDefinitions: ToolDefinition[];
+  systemInstruction: string;
+}
 
 // OS-level errors that code changes cannot fix. If the same pattern appears in
 // tool results across ENV_ERROR_THRESHOLD consecutive turns, the loop aborts.
@@ -118,223 +142,302 @@ export class Agent {
       parts: [{ type: "text", text: userInput }],
     });
 
-    const allToolDefs = [...this.tools.all().map(toolToDefinition), activateSkillDefinition];
-
-    let toolDefinitions = allToolDefs;
-    let systemInstruction: string;
-
-    if (mode === "plan") {
-      const readonlyTools = this.tools.all().filter((t) => t.readonly);
-      toolDefinitions = [...readonlyTools.map(toolToDefinition), activateSkillDefinition];
-      const planSuffix = buildPlanSuffix(new Set(readonlyTools.map((t) => t.name)));
-      systemInstruction = this.context.getSystemInstruction(toolDefinitions) + planSuffix;
-    } else {
-      systemInstruction = this.context.getSystemInstruction(allToolDefs);
-    }
+    const setup = this.buildTurnSetup(mode);
 
     // A5b auto-compact: fires only at this turn-boundary position — before any
-    // LLM call or tool execution this turn. Any LLM/network errors inside
-    // maybeAutoCompact are caught by it; the turn always proceeds.
-    // Skipped in plan mode: read-only exploration shouldn't spend tokens on a
-    // compaction round-trip; the react turn that follows will trigger it.
+    // LLM call or tool execution this turn. Skipped in plan mode: read-only
+    // exploration shouldn't spend tokens on a compaction round-trip.
     if (mode !== "plan") {
-      for (const notice of await this.maybeAutoCompact(systemInstruction)) {
+      for (const notice of await this.maybeAutoCompact(setup.systemInstruction)) {
         yield notice;
       }
     }
 
-    let turns = 0;
-    let lastCallSig = "";
-    let stuckCount = 0;
-    let envErrorPattern = "";
-    let envErrorCount = 0;
-    let emptyRetried = false;
-    const firedReminders = new Set<string>();
+    const state: TurnState = {
+      turns: 0,
+      lastCallSig: "",
+      stuckCount: 0,
+      envErrorPattern: "",
+      envErrorCount: 0,
+      emptyRetried: false,
+      firedReminders: new Set<string>(),
+    };
 
     while (true) {
-      const pendingCalls: FunctionCallPart[] = [];
-      let responseText = "";
+      // 1. Stream from LLM (collect text + tool calls; observability)
+      const { text, pendingCalls } = yield* this.streamLLM(setup);
 
-      const messages = this.context.getMessages();
-      const estimatedTokens = Math.round(
-        (JSON.stringify(messages).length + systemInstruction.length) / 4,
-      );
-      this.obs?.({ type: "context_snapshot", messageCount: messages.length, estimatedTokens });
-      this.obs?.({ type: "llm_call_start", model: this.model, inputMessages: messages.length });
-      const callStart = Date.now();
-      let usageInputTokens = 0;
-      let usageOutputTokens = 0;
+      // 2. Record assistant message in context
+      this.recordAssistantMessage(text, pendingCalls);
 
-      for await (const event of this.client.stream(messages, systemInstruction, toolDefinitions)) {
-        if (event.type === "text") {
-          responseText += event.text;
-          yield { type: "text", text: event.text };
-        } else if (event.type === "function_call") {
-          pendingCalls.push({
-            type: "function_call",
-            id: event.id,
-            name: event.name,
-            args: event.args,
-            ...(event.thoughtSignature ? { thoughtSignature: event.thoughtSignature } : {}),
-          });
-          yield {
-            type: "tool_call",
-            name: event.name,
-            args: event.args,
-            ...(event.thoughtSignature ? { thoughtSignature: event.thoughtSignature } : {}),
-          };
-        } else if (event.type === "usage") {
-          usageInputTokens = event.inputTokens;
-          usageOutputTokens = event.outputTokens;
-        }
-      }
-
-      this.obs?.({
-        type: "llm_call_end",
-        model: this.model,
-        inputTokens: usageInputTokens,
-        outputTokens: usageOutputTokens,
-        latencyMs: Date.now() - callStart,
-      });
-
-      const assistantParts: Message["parts"] = [];
-      if (responseText) assistantParts.push({ type: "text", text: responseText });
-      assistantParts.push(...pendingCalls);
-      if (assistantParts.length > 0) {
-        this.context.addMessage({ role: "model", parts: assistantParts });
-      }
-
+      // 3. Done / empty-retry — exits early if no tool calls
       if (pendingCalls.length === 0) {
-        if (responseText.trim() === "" && !emptyRetried) {
-          // Empty stream (no text, no tool calls) is likely a transient provider issue
-          // (safety filter, output truncation, parse failure). Retry once before
-          // treating as intentional done — nothing was added to context, so the
-          // retry sees the same conversation state.
-          emptyRetried = true;
+        if (text.trim() === "" && !state.emptyRetried) {
+          // Empty stream is likely a transient provider issue (safety filter,
+          // output truncation, parse failure). Nothing was added to context,
+          // so the retry sees the same conversation state.
+          state.emptyRetried = true;
           this.obs?.({ type: "empty_response_retry" });
           continue;
         }
         yield { type: "done" };
         return;
       }
-      emptyRetried = false;
+      state.emptyRetried = false;
 
-      // Max turns guard
-      turns++;
-      if (turns > this.maxTurns) {
-        this.obs?.({
-          type: "guard_triggered",
-          guard: "max_turns",
-          reason: `Reached ${this.maxTurns} turns`,
-        });
-        yield {
-          type: "error",
-          message: `Reached maximum iterations (${this.maxTurns}). Try breaking the task into smaller steps.`,
-        };
+      // 4. Loop guards (max-turns, stuck-loop) — abort with an error event if hit
+      state.turns++;
+      const maxTurnsAbort = this.checkMaxTurnsGuard(state);
+      if (maxTurnsAbort) {
+        yield maxTurnsAbort;
+        return;
+      }
+      const stuckAbort = this.checkStuckLoopGuard(state, pendingCalls);
+      if (stuckAbort) {
+        yield stuckAbort;
         return;
       }
 
-      // Stuck-loop detection: same tool(s) + same args N times in a row
-      const sig = JSON.stringify(pendingCalls.map((c) => ({ name: c.name, args: c.args })));
-      if (sig === lastCallSig) {
-        stuckCount++;
-        if (stuckCount >= STUCK_THRESHOLD) {
-          this.obs?.({
-            type: "guard_triggered",
-            guard: "stuck_loop",
-            reason: `${STUCK_THRESHOLD} identical consecutive call signatures`,
-          });
-          yield {
-            type: "error",
-            message: `Detected ${STUCK_THRESHOLD} identical tool calls in a row — stopping to avoid a loop.`,
-          };
-          return;
-        }
-      } else {
-        lastCallSig = sig;
-        stuckCount = 1;
+      // 5. Execute pending tool calls
+      const results = await this.executeTurnTools(pendingCalls, mode);
+
+      // 6. Drain any snapshot warning produced this turn
+      yield* this.drainSnapshotWarnings();
+
+      // 7. Environment-error guard (OS-level errors that code changes can't fix)
+      const envAbort = this.checkEnvErrorGuard(state, results);
+      if (envAbort) {
+        yield envAbort;
+        return;
       }
 
-      const { results } = await executeCalls(pendingCalls, {
-        tools: this.tools,
-        skills: this.skills,
-        context: this.context,
-        tmpDir: this.context.getSessionTmpDir(),
-        readOnly: mode === "plan",
-        confirmFn: this.confirmFn,
-        forcesConfirmation: this.forcesConfirmationFn,
-        obs: this.obs,
-        snapshot: this.snapshotManager,
-        cwd: process.cwd(),
-      });
+      // 8. Append event-driven reminder to the last tool result (e.g. edit → "run tests")
+      this.applyReminderToLastResult(state, pendingCalls, results);
 
-      // Surface any snapshot warning produced this turn as an error event.
-      // drainWarning() clears it so it is only emitted once per failure.
-      const snapshotWarning = this.snapshotManager?.drainWarning();
-      if (snapshotWarning) {
-        yield { type: "error", message: `[snapshot] ${snapshotWarning}` };
-      }
+      // 9. Yield skill activations + tool results to the caller
+      yield* this.yieldSkillActivations(pendingCalls);
+      yield* this.yieldToolResults(results);
 
-      // Environmental error guard: OS-level errors (EPERM, EACCES, etc.) cannot
-      // be fixed by editing code. If the same pattern recurs across consecutive
-      // turns, stop and surface a diagnosis instead of burning more turns.
-      const combinedResults = results.map((r) => r.result).join("\n");
-      const matchedPattern = ENV_ERROR_PATTERNS.find((p) =>
-        combinedResults.toLowerCase().includes(p.toLowerCase()),
-      );
-      if (matchedPattern) {
-        if (matchedPattern === envErrorPattern) {
-          envErrorCount++;
-        } else {
-          envErrorPattern = matchedPattern;
-          envErrorCount = 1;
-        }
-        if (envErrorCount >= ENV_ERROR_THRESHOLD) {
-          this.obs?.({
-            type: "guard_triggered",
-            guard: "env_error_loop",
-            reason: `"${matchedPattern}" in ${ENV_ERROR_THRESHOLD} consecutive turns`,
-          });
-          yield {
-            type: "error",
-            message: `Detected "${matchedPattern}" in ${ENV_ERROR_THRESHOLD} consecutive turns. This looks like an OS or environment restriction that code changes cannot fix — check permissions, network settings, or sandbox configuration.`,
-          };
-          return;
-        }
-      } else {
-        envErrorPattern = "";
-        envErrorCount = 0;
-      }
+      // 10. Record results in context so the next LLM turn sees them
+      this.recordToolResults(results);
+    }
+  }
 
-      // Append an event-driven reminder to the last tool result based on what
-      // tools just ran — fires only when relevant (e.g. edit → "run tests").
-      const reminder = buildReminder(
-        pendingCalls.map((c) => ({ name: c.name, args: c.args })),
-        firedReminders,
-      );
-      if (reminder && results.length > 0) {
-        results[results.length - 1] = {
-          ...results[results.length - 1],
-          result: results[results.length - 1].result + reminder,
-        };
-      }
+  // ────────────────────────────────────────────────────────────────────────
+  // Helpers below decompose the run() loop into named steps. Each owns one
+  // concern, can be unit-tested in isolation, and either yields events,
+  // mutates the TurnState, mutates context, or returns an abort event for
+  // the caller to yield. Splitting them up keeps run() readable as a 10-step
+  // pipeline rather than a 200-line generator.
+  // ────────────────────────────────────────────────────────────────────────
 
-      const skillCalls = pendingCalls.filter((c) => c.name === "activate_skill");
-      for (const call of skillCalls) {
-        yield { type: "skill_activated", name: call.args.name as string };
-      }
+  private buildTurnSetup(mode: AgentRunMode): TurnSetup {
+    const allToolDefs = [...this.tools.all().map(toolToDefinition), activateSkillDefinition];
+    if (mode === "plan") {
+      const readonlyTools = this.tools.all().filter((t) => t.readonly);
+      const toolDefinitions = [...readonlyTools.map(toolToDefinition), activateSkillDefinition];
+      const planSuffix = buildPlanSuffix(new Set(readonlyTools.map((t) => t.name)));
+      const systemInstruction = this.context.getSystemInstruction(toolDefinitions) + planSuffix;
+      return { toolDefinitions, systemInstruction };
+    }
+    return {
+      toolDefinitions: allToolDefs,
+      systemInstruction: this.context.getSystemInstruction(allToolDefs),
+    };
+  }
 
-      for (const result of results) {
-        yield { type: "tool_result", name: result.name, result: result.result };
-      }
+  private async *streamLLM(
+    setup: TurnSetup,
+  ): AsyncGenerator<AgentEvent, { text: string; pendingCalls: FunctionCallPart[] }> {
+    const messages = this.context.getMessages();
+    const estimatedTokens = Math.round(
+      (JSON.stringify(messages).length + setup.systemInstruction.length) / 4,
+    );
+    this.obs?.({ type: "context_snapshot", messageCount: messages.length, estimatedTokens });
+    this.obs?.({ type: "llm_call_start", model: this.model, inputMessages: messages.length });
 
-      if (results.length > 0) {
-        this.context.addMessage({
-          role: "user",
-          parts: results,
+    const callStart = Date.now();
+    let usageInputTokens = 0;
+    let usageOutputTokens = 0;
+    let text = "";
+    const pendingCalls: FunctionCallPart[] = [];
+
+    for await (const event of this.client.stream(
+      messages,
+      setup.systemInstruction,
+      setup.toolDefinitions,
+    )) {
+      if (event.type === "text") {
+        text += event.text;
+        yield { type: "text", text: event.text };
+      } else if (event.type === "function_call") {
+        pendingCalls.push({
+          type: "function_call",
+          id: event.id,
+          name: event.name,
+          args: event.args,
+          ...(event.thoughtSignature ? { thoughtSignature: event.thoughtSignature } : {}),
         });
+        yield {
+          type: "tool_call",
+          name: event.name,
+          args: event.args,
+          ...(event.thoughtSignature ? { thoughtSignature: event.thoughtSignature } : {}),
+        };
+      } else if (event.type === "usage") {
+        usageInputTokens = event.inputTokens;
+        usageOutputTokens = event.outputTokens;
       }
     }
+
+    this.obs?.({
+      type: "llm_call_end",
+      model: this.model,
+      inputTokens: usageInputTokens,
+      outputTokens: usageOutputTokens,
+      latencyMs: Date.now() - callStart,
+    });
+
+    return { text, pendingCalls };
+  }
+
+  private recordAssistantMessage(text: string, pendingCalls: FunctionCallPart[]): void {
+    const assistantParts: Message["parts"] = [];
+    if (text) assistantParts.push({ type: "text", text });
+    assistantParts.push(...pendingCalls);
+    if (assistantParts.length > 0) {
+      this.context.addMessage({ role: "model", parts: assistantParts });
+    }
+  }
+
+  private checkMaxTurnsGuard(state: TurnState): AgentEvent | null {
+    if (state.turns <= this.maxTurns) return null;
+    this.obs?.({
+      type: "guard_triggered",
+      guard: "max_turns",
+      reason: `Reached ${this.maxTurns} turns`,
+    });
+    return {
+      type: "error",
+      message: `Reached maximum iterations (${this.maxTurns}). Try breaking the task into smaller steps.`,
+    };
+  }
+
+  private checkStuckLoopGuard(
+    state: TurnState,
+    pendingCalls: FunctionCallPart[],
+  ): AgentEvent | null {
+    const sig = JSON.stringify(pendingCalls.map((c) => ({ name: c.name, args: c.args })));
+    if (sig !== state.lastCallSig) {
+      state.lastCallSig = sig;
+      state.stuckCount = 1;
+      return null;
+    }
+    state.stuckCount++;
+    if (state.stuckCount < STUCK_THRESHOLD) return null;
+    this.obs?.({
+      type: "guard_triggered",
+      guard: "stuck_loop",
+      reason: `${STUCK_THRESHOLD} identical consecutive call signatures`,
+    });
+    return {
+      type: "error",
+      message: `Detected ${STUCK_THRESHOLD} identical tool calls in a row — stopping to avoid a loop.`,
+    };
+  }
+
+  private async executeTurnTools(
+    pendingCalls: FunctionCallPart[],
+    mode: AgentRunMode,
+  ): Promise<FunctionResultPart[]> {
+    const { results } = await executeCalls(pendingCalls, {
+      tools: this.tools,
+      skills: this.skills,
+      context: this.context,
+      tmpDir: this.context.getSessionTmpDir(),
+      readOnly: mode === "plan",
+      confirmFn: this.confirmFn,
+      forcesConfirmation: this.forcesConfirmationFn,
+      obs: this.obs,
+      snapshot: this.snapshotManager,
+      cwd: process.cwd(),
+    });
+    return results;
+  }
+
+  // drainWarning() clears the warning so it is only emitted once per failure.
+  private *drainSnapshotWarnings(): Generator<AgentEvent> {
+    const snapshotWarning = this.snapshotManager?.drainWarning();
+    if (snapshotWarning) {
+      yield { type: "error", message: `[snapshot] ${snapshotWarning}` };
+    }
+  }
+
+  private checkEnvErrorGuard(state: TurnState, results: FunctionResultPart[]): AgentEvent | null {
+    const combinedResults = results
+      .map((r) => r.result)
+      .join("\n")
+      .toLowerCase();
+    const matchedPattern = ENV_ERROR_PATTERNS.find((p) =>
+      combinedResults.includes(p.toLowerCase()),
+    );
+    if (!matchedPattern) {
+      state.envErrorPattern = "";
+      state.envErrorCount = 0;
+      return null;
+    }
+    if (matchedPattern === state.envErrorPattern) {
+      state.envErrorCount++;
+    } else {
+      state.envErrorPattern = matchedPattern;
+      state.envErrorCount = 1;
+    }
+    if (state.envErrorCount < ENV_ERROR_THRESHOLD) return null;
+    this.obs?.({
+      type: "guard_triggered",
+      guard: "env_error_loop",
+      reason: `"${matchedPattern}" in ${ENV_ERROR_THRESHOLD} consecutive turns`,
+    });
+    return {
+      type: "error",
+      message: `Detected "${matchedPattern}" in ${ENV_ERROR_THRESHOLD} consecutive turns. This looks like an OS or environment restriction that code changes cannot fix — check permissions, network settings, or sandbox configuration.`,
+    };
+  }
+
+  private applyReminderToLastResult(
+    state: TurnState,
+    pendingCalls: FunctionCallPart[],
+    results: FunctionResultPart[],
+  ): void {
+    const reminder = buildReminder(
+      pendingCalls.map((c) => ({ name: c.name, args: c.args })),
+      state.firedReminders,
+    );
+    if (reminder && results.length > 0) {
+      results[results.length - 1] = {
+        ...results[results.length - 1],
+        result: results[results.length - 1].result + reminder,
+      };
+    }
+  }
+
+  private *yieldSkillActivations(pendingCalls: FunctionCallPart[]): Generator<AgentEvent> {
+    for (const call of pendingCalls) {
+      if (call.name === "activate_skill") {
+        yield { type: "skill_activated", name: call.args.name as string };
+      }
+    }
+  }
+
+  private *yieldToolResults(results: FunctionResultPart[]): Generator<AgentEvent> {
+    for (const result of results) {
+      yield { type: "tool_result", name: result.name, result: result.result };
+    }
+  }
+
+  private recordToolResults(results: FunctionResultPart[]): void {
+    if (results.length === 0) return;
+    this.context.addMessage({ role: "user", parts: results });
   }
 
   async compact(): Promise<CompactResult> {


### PR DESCRIPTION
## Summary

\`run()\` had grown to 224 lines doing five distinct jobs interleaved: turn setup, stream collection, exit checks, four safety guards (max-turns, stuck-loop, env-error, empty-retry), tool execution, snapshot warning drain, reminder synthesis, and event yielding. Every new guard since A1 made the diff uglier and the tests harder to write.

This PR splits the loop body into named private methods, leaving \`run()\` as a clean 10-step pipeline:

\`\`\`
1. streamLLM(setup)                       → text + pendingCalls + obs events
2. recordAssistantMessage(...)            → context mutation
3. exit checks (done / empty-retry)       → inline
4. checkMaxTurnsGuard / checkStuckLoopGuard → abort events
5. executeTurnTools(...)                  → tool execution
6. drainSnapshotWarnings()                → error event if any
7. checkEnvErrorGuard(...)                → abort event if hit
8. applyReminderToLastResult(...)         → mutates results in place
9. yieldSkillActivations + yieldToolResults → events to caller
10. recordToolResults(...)                → context mutation
\`\`\`

## Numbers

| | Before | After |
|---|---|---|
| \`run()\` body | 224 lines | 88 lines (**-60%**) |
| File total | 455 lines | 558 lines (+23%, mostly method signatures + JSDoc) |
| Tests | 645 passing | **645 passing — no test modifications** |
| Public API | unchanged | unchanged |

## Notable shape decisions

- \`streamLLM\` is \`AsyncGenerator<AgentEvent, { text, pendingCalls }>\` — uses TS's generator return-value typing so the caller can \`yield*\` for the events and destructure the collected state in one statement.
- Guard methods return \`AgentEvent | null\` rather than throwing; the caller yields-and-returns. Mirrors the snapshot-warning yield pattern already in the loop. Easy to test (call the method on a \`TurnState\` fixture, assert the returned event).
- \`TurnState\` is a plain interface (not a class) so guards can mutate counters without ceremony. Pure value type, easy to construct in tests.

## Related issue

Tracks [#60 — replace agentic while-loop with explicit state machine](https://github.com/zjshen14/opencli/issues/60). The extracted methods are exactly the transitions the state machine would exhibit; this PR lands the readability win now without committing to a specific state-machine library or shape. The full state machine refactor (formal \`State\` enum, transition table, etc.) can layer on top if/when we need it.

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm test\` — 645 tests pass
- [x] No test file modifications (full coverage of behavior carried forward)
- [x] \`run()\` body now reads as a numbered sequence; each step delegates to a named helper
- [ ] Manual: run a real REPL session, confirm tool calls, snapshots, env-error guard, and auto-compact all work as before

## Notes for reviewers

This is a pure refactor — no behavior change. The right way to review is to skim each extracted method and verify it captures the exact lines it replaced. The four most subtle ones:

1. **\`streamLLM\`** — captures the LLM stream collection plus the \`context_snapshot\` / \`llm_call_start\` / \`llm_call_end\` observability triplet. Uses generator return-value typing.
2. **\`checkStuckLoopGuard\`** — the \"different signature, reset to 1\" branch is now an early return rather than an else-block, but the behavior is the same. \`stuckCount = 1\` (not 0) on first sight matches the previous code.
3. **\`checkEnvErrorGuard\`** — same: \"no match, reset counters\" branch is an early return; the rest matches.
4. **\`drainSnapshotWarnings\`** — sync generator (not async) because \`snapshotManager.drainWarning()\` is sync; both work as \`yield*\` targets.

The maybeAutoCompact() gate, manual \`compact()\` method, \`getContextStats()\`, \`undoLastTurn()\`, and \`clearHistory()\` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)