### PR TITLE
feat(skills): add /changelog built-in skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ src/
   skills/
     registry.ts     # Discover SKILL.md files across 4 scoped directories
     loader.ts       # Parse SKILL.md frontmatter, !{cmd} preprocessing, $ARGUMENTS substitution
-    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill
+    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill, changelog
   mcp/            # MCP integration — bridges external tool servers into ToolRegistry
     types.ts        # McpStdioServer, McpHttpServer, McpServerConfig, McpConfig, McpToolInfo
     config.ts       # loadMcpConfig(agentDir) — reads ~/.opencli/mcp.json; expands ${VAR} refs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ src/
   skills/
     registry.ts     # Discover SKILL.md files across 4 scoped directories
     loader.ts       # Parse SKILL.md frontmatter, !{cmd} preprocessing, $ARGUMENTS substitution
-    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill
+    builtin/        # review, commit, explain, debug, test, gh-issue, gh-pr, branch, run-tests, typecheck, lint, new-skill, changelog
   mcp/            # MCP integration — bridges external tool servers into ToolRegistry
     types.ts        # McpStdioServer, McpHttpServer, McpServerConfig, McpConfig, McpToolInfo
     config.ts       # loadMcpConfig(agentDir) — reads ~/.opencli/mcp.json; expands ${VAR} refs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -406,6 +406,7 @@ src/skills/
     gh-pr/       Open, review, check CI, merge GitHub PRs
     branch/      Create feature branches tied to issue numbers
     new-skill/   Scaffold a custom SKILL.md interactively (disable-agent-invocation)
+    changelog/   Generate a changelog from recent git history
 ```
 
 #### Discovery priority (first match wins)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -96,6 +96,7 @@ At session start, `SkillRegistry.discover()` is called and the catalog (name + d
 | `/lint` | Run linter, auto-fix what's fixable, report the rest | No |
 | `/explain` | Explain code or a concept | No |
 | `/test` | Write tests for a function or module | No |
+| `/changelog` | Generate a changelog or release notes from recent git history | No |
 | `/new-skill` | Scaffold a new custom SKILL.md file interactively | Yes |
 
 ---

--- a/src/skills/builtin/changelog/SKILL.md
+++ b/src/skills/builtin/changelog/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: changelog
+description: Generate a changelog or release notes from recent git history. Use when asked to write a changelog, summarize recent commits, or produce release notes.
+allowed-tools: Bash Read
+---
+
+Generate a user-facing changelog grouped into Added / Changed / Fixed sections.
+
+Recent git history:
+!{git log --oneline -30 2>/dev/null || echo "(no git history available)"}
+
+Recent tags:
+!{git tag --sort=-creatordate 2>/dev/null | head -5 || echo "(no tags)"}
+
+Scope: $ARGUMENTS
+
+---
+
+Steps:
+1. If Scope is non-empty (e.g. a git ref range like `v1.2.0..HEAD` or a target version tag), run `git log --oneline <scope>` to get the relevant commits; otherwise use the recent history shown above.
+2. Group commits into **Added**, **Changed**, and **Fixed** — skip merge commits and CI/chore noise.
+3. Write clean, user-facing bullet points — rephrase commit messages for clarity rather than copying them verbatim.
+4. Output as Markdown with a version heading if a version was specified.


### PR DESCRIPTION
## Summary

- Adds `src/skills/builtin/changelog/SKILL.md` — a new built-in skill that gathers recent git history via `!{git log}` and `!{git tag}` shell preprocessors, then instructs the agent to group commits into **Added / Changed / Fixed** sections
- Accepts an optional `$ARGUMENTS` for a git ref range (e.g. `v1.2.0..HEAD`) or target version tag; falls back to the last 30 commits when empty
- Updates all four required doc locations per `CLAUDE.md`: `docs/skills.md` table, `docs/architecture.md` skill list + file tree, and the `builtin/` comment in both `CLAUDE.md` and `AGENTS.md`

## Related issue

Closes #196

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (630 tests)
- [x] `src/skills/registry.test.ts` passes — confirms built-in skill discovery still works
- [x] `src/skills/loader.test.ts` passes — confirms SKILL.md parsing + `!{cmd}` + `$ARGUMENTS` substitution work correctly
- [ ] Manual: start REPL, verify `/changelog` appears in the slash-command popup
- [ ] Manual: run `/changelog` (no args) — produces a grouped changelog from recent commits
- [ ] Manual: run `/changelog v1.0.0..HEAD` — uses the specified ref range

https://claude.ai/code/session_01R4RMxTbLe8wuvnUWMqSHrA

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4RMxTbLe8wuvnUWMqSHrA)_