### PR TITLE
docs(readme): document OPENCLI_SYSTEM_MD and OPENCLI_MAX_TOOL_OUTPUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Environment variables take precedence over config file:
 | `OPENCLI_MODEL` | Model override (beats `--model` and config) |
 | `OPENCLI_SANDBOX` | Sandbox mode override: `auto` \| `strict` \| `off` |
 | `OPENCLI_SNAPSHOT` | Set to `off` to disable git snapshot/rewind |
+| `OPENCLI_SYSTEM_MD` | Path to a Markdown file that overrides the default system instruction (for prompt hill-climbing) |
+| `OPENCLI_MAX_TOOL_OUTPUT` | Max chars before bash/grep/glob/web_fetch output is middle-truncated (default: 20 000) |
 
 ## Sandbox Isolation
 


### PR DESCRIPTION
## Summary

Two environment variables read by the code but missing from the README's env-var table (under **Configuration**):

- **\`OPENCLI_SYSTEM_MD\`** (\`src/core/prompt.ts\`) — path to a Markdown file that overrides the default system instruction; used for prompt hill-climbing.
- **\`OPENCLI_MAX_TOOL_OUTPUT\`** (\`src/core/executor.ts\`, \`src/tools/web/fetch.ts\`) — max chars before bash/grep/glob/web_fetch output is middle-truncated. Default 20 000.

Both are documented in CLAUDE.md already; the user-facing README was the gap. Wording matches CLAUDE.md's Configuration section.

## Related issue

Closes #195

## Test plan

- [x] \`npm run format:check\` — clean
- [x] Both variables verified to actually exist in the code at the paths cited in #195
- [x] Wording aligned with CLAUDE.md's Configuration section

🤖 Generated with [Claude Code](https://claude.com/claude-code)