### PR TITLE
feat(eval): workflow_dispatch eval + first parity baseline

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,43 @@
+name: Eval Matrix
+
+# Manual-only trigger. Real API calls cost real money (~$1-2 per full 3-provider
+# run) so we do NOT run on PR. See docs/design/d1-eval-harness.md.
+on:
+  workflow_dispatch:
+
+jobs:
+  eval:
+    name: Run cross-provider eval matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      EVAL_JSON_OUT: eval-results.json
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run eval matrix
+        run: npm run eval
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ github.run_id }}
+          path: eval-results.json
+          if-no-files-found: error

--- a/docs/design/d1-eval-harness.md
+++ b/docs/design/d1-eval-harness.md
@@ -697,9 +697,11 @@ These live in `src/eval/*.test.ts` and run as part of `npm test` (no API calls).
 | Command | When | Cost |
 |---|---|---|
 | `npm test` | Every PR (automated) | Free — harness unit tests only |
-| `npm run eval` | Manual trigger on PRs; auto on release | ~$1–5 per full run (~10–20 min at 5 s/scenario avg) |
+| `npm run eval` | Manual trigger via [Eval Matrix workflow](../../.github/workflows/eval.yml) (workflow_dispatch only) | ~$1–5 per full run (~5–20 min depending on column count) |
 
-`EVAL_JSON_OUT=results.json npm run eval` writes a machine-readable artifact for regression diffing. CI can archive this and compare to the previous release using `jq '.passRates'`.
+`EVAL_JSON_OUT=results.json npm run eval` writes a machine-readable artifact for regression diffing. The workflow uploads the JSON as a run artifact; committed baselines live under [`docs/eval/`](../eval/).
+
+**Why not PR-triggered.** Real API calls cost money and are subject to provider tail latency / rate limits. Running on every PR would be hostile to contributors (cost) and produce flaky red builds (latency). Manual-only refreshes anchor the baseline at meaningful points (pre-Phase-B, post-B2, etc.).
 
 ---
 

--- a/docs/eval/baseline-2026-06-01.json
+++ b/docs/eval/baseline-2026-06-01.json
@@ -1,0 +1,158 @@
+{
+  "timestamp": "2026-06-01T17:41:25.740Z",
+  "providers": [
+    "gemini"
+  ],
+  "scenarios": [
+    {
+      "id": "add-clamp-function",
+      "category": "feature-add",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "add-counter-reset",
+      "category": "feature-add",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "add-input-validation",
+      "category": "feature-add",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "add-math-tests",
+      "category": "multi-file",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "add-power-function",
+      "category": "feature-add",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "add-version-constant",
+      "category": "feature-add",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "create-and-wire-formatter",
+      "category": "multi-file",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "explain-counter-class",
+      "category": "read-explain",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "explain-math-module",
+      "category": "read-explain",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "explain-task-interface",
+      "category": "read-explain",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "extract-duplicate-validation",
+      "category": "refactor",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "fix-missing-return",
+      "category": "bug-fix",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "fix-null-guard",
+      "category": "bug-fix",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "fix-off-by-one",
+      "category": "bug-fix",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "fix-strict-equality",
+      "category": "bug-fix",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "fix-subtract-operator",
+      "category": "bug-fix",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "list-util-exports",
+      "category": "read-explain",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "multi-edit-coordinated-fixes",
+      "category": "bug-fix",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "rename-internal-variable",
+      "category": "refactor",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "split-long-function",
+      "category": "refactor",
+      "results": {
+        "gemini": "pass"
+      }
+    },
+    {
+      "id": "update-interface-and-impl",
+      "category": "multi-file",
+      "results": {
+        "gemini": "pass"
+      }
+    }
+  ],
+  "passRates": {
+    "gemini": 1
+  }
+}

--- a/docs/eval/baseline-2026-06-01.md
+++ b/docs/eval/baseline-2026-06-01.md
@@ -1,0 +1,51 @@
+# Eval baseline — 2026-06-01
+
+Snapshot of the [D1 cross-provider scenario matrix](../design/d1-eval-harness.md) against `main` as of this date. This satisfies the roadmap's pre-Phase-B gate: **a parity baseline exists before B-work begins**.
+
+## Run metadata
+
+| Field | Value |
+|---|---|
+| Date | 2026-06-01 |
+| Commit | [`870a87e`](https://github.com/zjshen14/opencli/commit/870a87e) |
+| Scenarios | 21 (20 original + `multi-edit-coordinated-fixes` added in #204) |
+| Providers run | gemini |
+| Providers pending | anthropic, openai _(see "Coverage gap" below)_ |
+| Total duration | 313s wall (~5 min) |
+| Raw JSON | [`baseline-2026-06-01.json`](./baseline-2026-06-01.json) |
+
+## Results
+
+| Provider | Model | Pass rate |
+|---|---|---|
+| gemini | `gemini-3.1-flash-lite-preview` | 21/21 (100%) |
+
+Per-scenario breakdown is in the JSON artifact.
+
+## Latency observations
+
+Most scenarios complete in 2–20 s. One outlier in this run:
+
+- `add-version-constant` — **74 s** (vs ~14 s typical). Single observation; unclear whether retries inside the agent loop, the provider's API tail, or scenario-specific behavior. Not actionable yet — flag if it reproduces.
+
+## Coverage gap (honest)
+
+This baseline is **one column wide**. The matrix code in [src/eval/config.ts](../../src/eval/config.ts) supports anthropic + openai (Haiku 4.5 and gpt-4o-mini by default), but those columns require:
+
+- An `ANTHROPIC_API_KEY` repo secret for the GH Actions workflow
+- An `OPENAI_API_KEY` repo secret for the GH Actions workflow
+
+The roadmap's pre-Phase-B sequencing rule says *"parity baseline must exist before B-work begins"*. With one column, that's technically a single-provider baseline — sufficient to detect Gemini regressions during B-phase work, but not yet a cross-vendor parity claim. The other two columns should be filled in before B2 (OpenAI Responses) ships, so OpenAI's pre-B2 trajectory is documented.
+
+## How to refresh
+
+Manual trigger only — real API calls cost real money (~$1–2 per full 3-provider run).
+
+**Locally:**
+```bash
+EVAL_JSON_OUT=docs/eval/baseline-YYYY-MM-DD.json \
+  GEMINI_API_KEY=... ANTHROPIC_API_KEY=... OPENAI_API_KEY=... \
+  npm run eval
+```
+
+**Via GitHub Actions:** trigger the [Eval Matrix workflow](../../.github/workflows/eval.yml) under Actions → Eval Matrix → Run workflow. Requires the three `*_API_KEY` repo secrets to be set.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,7 +77,7 @@ See [`docs/evaluation.md`](evaluation.md) for the full strategy, scoring rubric,
 | # | Milestone | Sequencing |
 |---|---|---|
 | **D0** | **Eval foundation** | Now — document current coverage; publish rubric |
-| **D1** | **Scenario suite + provider parity matrix** | Before Phase B — 20 tasks × N providers in CI; parity baseline must exist before B-work begins |
+| **D1** | **Scenario suite + provider parity matrix** | Before Phase B — 20 tasks × N providers in CI; parity baseline must exist before B-work begins. First baseline published 2026-06-01: [`docs/eval/baseline-2026-06-01.md`](eval/baseline-2026-06-01.md) (Gemini only; Anthropic + OpenAI columns pending repo secrets). |
 | **D2** | **Contract evals** (sandbox, plan mode, HITL, headless schema) | Alongside A6 — all A-phase properties must be testable before A closes |
 | **D3** | **SWE-bench Verified harness** | After B5a — stable default config needed before publishing a number |
 | **D4** | **Custom cross-vendor routing benchmark** | After B5b — publishable artifact comparing single-vendor vs cross-vendor routing |


### PR DESCRIPTION
## Summary

D1's design doc was marked Implemented when the matrix code shipped, but two operational pieces it described were never wired:

- **`.github/workflows/eval.yml`** — the doc said *"Manual trigger on PRs; auto on release"*; no workflow existed. Adds `workflow_dispatch`-only Actions job that runs the full matrix and uploads the JSON as a run artifact. **Not** PR-triggered (real API cost, provider tail latency — see the updated CI Integration section in the design doc).
- **`docs/eval/baseline-2026-06-01.json` + `.md`** — the first published parity baseline against current `main` (`870a87e`). Gemini column only for now: 21/21 pass (`gemini-3.1-flash-lite-preview`), 313 s wall, one latency outlier flagged in the md (`add-version-constant` at 74 s). One observation, not actionable yet.

Satisfies the roadmap's pre-Phase-B gate (*"parity baseline must exist before B-work begins"*) for the Gemini column. Anthropic + OpenAI columns require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` repo secrets — both will be filled in before B2 ships so OpenAI's pre-B2 trajectory is documented.

Also updates `docs/roadmap.md` to link the baseline from the D1 row.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — 656 passed
- [x] Local `EVAL_JSON_OUT=... GEMINI_API_KEY=... npm run eval` — 21/21 pass
- [ ] After merge: trigger the new Eval Matrix workflow once to confirm the YAML is valid against the runner (will skip with a clean message if no API-key secrets are set)
- [ ] Before B2: add Anthropic + OpenAI repo secrets and refresh the baseline as a 3-column run

🤖 Generated with [Claude Code](https://claude.com/claude-code)