### PR TITLE
docs: add multi_edit and tool composition fields to source structure docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ src/
   tools/
     base.ts         # Tool interface + JSONSchema type
     registry.ts     # ToolRegistry: register, execute, list
-    file/           # read, write, edit, glob, grep, ls
+    file/           # read, write, edit, multi_edit, glob, grep, ls
     exec/           # bash (with requiresConfirmation for non-safe commands); sandbox/ (bwrap, sandbox-exec, passthrough)
     web/            # web_fetch tool
     task/           # todo_write and todo_read tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ src/
   tools/
     base.ts         # Tool interface + JSONSchema type
     registry.ts     # ToolRegistry: register, execute, list
-    file/           # read, write, edit, glob, grep, ls
+    file/           # read, write, edit, multi_edit, glob, grep, ls
     exec/           # bash (with requiresConfirmation for non-safe commands); sandbox/ (bwrap, sandbox-exec, passthrough)
     web/            # web_fetch tool
     task/           # todo_write and todo_read tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -266,6 +266,7 @@ src/tools/
     read.ts        Read file contents (offset + limit support).
     write.ts       Create or overwrite files (requiresConfirmation outside CWD).
     edit.ts        Exact old_string → new_string replacement (fails if ambiguous).
+    multi-edit.ts  Apply an ordered list of edits to one file as a single confirmed unit (singleConfirmation).
     glob.ts        Find files by pattern.
     grep.ts        Regex search across file contents.
     ls.ts          List directory contents.
@@ -337,6 +338,12 @@ interface SandboxRunner {
 #### Tool interface
 
 ```typescript
+/** Passed to every tool's execute() by ToolRegistry — gives composed tools a way
+ *  to call sub-tools by name without routing back through the executor's confirmation gate. */
+interface ToolExecutionContext {
+  registry: ToolRunner; // ToolRunner is a minimal subset of ToolRegistry
+}
+
 interface Tool {
   name: string;
   description: string;
@@ -345,7 +352,7 @@ interface Tool {
   /** true = read-only; passed in plan mode. false/undefined = write tool, blocked in plan mode. */
   readonly?: boolean;
 
-  execute: (params: Record<string, unknown>) => Promise<ToolResult>;
+  execute: (params: Record<string, unknown>, ctx?: ToolExecutionContext) => Promise<ToolResult>;
 
   /** Return true to require interactive confirmation before execution. */
   requiresConfirmation?: (args: Record<string, unknown>) => boolean;
@@ -353,6 +360,15 @@ interface Tool {
   /** Return an error string if params are invalid, null if valid.
    *  Called by ToolRegistry.execute() before execute() — after required-field check. */
   validate?: (params: Record<string, unknown>) => string | null;
+
+  /** Names of sub-tools this tool invokes via ctx.registry (tool composition).
+   *  ToolRegistry refuses to run a composed tool that delegates to a confirmation-gated
+   *  sub-tool unless the composing tool also sets singleConfirmation: true. */
+  composedOf?: string[];
+
+  /** When true, the parent confirmation covers all sub-tool invocations.
+   *  Required whenever composedOf includes a tool with requiresConfirmation. */
+  singleConfirmation?: boolean;
 }
 
 interface ToolResult {


### PR DESCRIPTION
## Summary

- `multi_edit` was added in #193 but `CLAUDE.md`, `AGENTS.md`, and `docs/architecture.md` were never updated to reflect it
- Add `multi_edit` to the `file/` tool list in `CLAUDE.md` and `AGENTS.md`
- Add `multi-edit.ts` to the `file/` section of the `src/tools/` tree in `docs/architecture.md`
- Update the Tool interface code block in `docs/architecture.md` to include `ToolExecutionContext`, the updated `execute(params, ctx?)` signature, and the new `composedOf` / `singleConfirmation` composition fields

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (641 tests, 0 failures)
- [x] Doc-only change — no runtime behaviour changed; verified diff shows only the three doc files

https://claude.ai/code/session_01B4z4YjgZqJufbmQwp272qF

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4z4YjgZqJufbmQwp272qF)_