### PR TITLE
fix(prompt): include multi_edit in write-tool reminder conditions

### DIFF
--- a/src/core/prompt.test.ts
+++ b/src/core/prompt.test.ts
@@ -75,6 +75,12 @@ describe("buildReminder", () => {
     expect(buildReminder(calls)).toContain("verify the change works");
   });
 
+  it("fires test reminder after multi_edit call", () => {
+    const calls = [{ name: "multi_edit", args: { file_path: "foo.ts", edits: [] } }];
+    expect(buildReminder(calls)).toContain("verify the change works");
+    expect(buildReminder(calls)).toContain("don't add features");
+  });
+
   it("fires git reminder only when bash command includes git", () => {
     const gitCall = [{ name: "bash", args: { command: "git status" } }];
     const nonGitCall = [{ name: "bash", args: { command: "npm test" } }];

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -67,10 +67,12 @@ export interface AgentReminder {
   shouldFire: (calls: ReadonlyArray<{ name: string; args: Record<string, unknown> }>) => boolean;
 }
 
+const isWriteCall = (name: string) => name === "write" || name === "edit" || name === "multi_edit";
+
 export const AGENT_REMINDERS: AgentReminder[] = [
   {
     text: "verify the change works — find and run the project's test command before reporting done",
-    shouldFire: (calls) => calls.some((c) => c.name === "write" || c.name === "edit"),
+    shouldFire: (calls) => calls.some((c) => isWriteCall(c.name)),
   },
   {
     text: "never commit or push without an explicit user request",
@@ -79,7 +81,7 @@ export const AGENT_REMINDERS: AgentReminder[] = [
   },
   {
     text: "don't add features or refactoring beyond what was asked",
-    shouldFire: (calls) => calls.some((c) => c.name === "write" || c.name === "edit"),
+    shouldFire: (calls) => calls.some((c) => isWriteCall(c.name)),
   },
 ];
 


### PR DESCRIPTION
## Summary

- `AGENT_REMINDERS` checked for `write` and `edit` calls but not `multi_edit`, so the "verify the change works" and "don't add features" reminders never fired after a `multi_edit` turn
- Introduces a small `isWriteCall` helper to consolidate the three-way check in one place
- Adds a test case confirming `multi_edit` triggers both write-related reminders

## Root cause

The reminders were not updated when `multi_edit` was added in 3695156. Since `multi_edit` internally calls `edit` via `ToolRegistry`, the executor only sees the `multi_edit` call in the call list — not the inner `edit` sub-calls — so the original conditions never matched.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (642 tests)
- [x] New test: `fires test reminder after multi_edit call` in `src/core/prompt.test.ts`

https://claude.ai/code/session_01Ab5ZPJAZtvf3DbCZGNJqdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab5ZPJAZtvf3DbCZGNJqdU)_