### PR TITLE
docs: fix architecture.md — add multi_edit to reminders and confirmation table

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,8 +192,8 @@ Template placeholders: `{CWD}`, `{SESSION_TMP}`, `{TOOL_CATALOG}`, `{GIT_CONTEXT
 **Skill content** is held in a separate `skillContent[]` array, never pruned, tagged as `<skill_content name="...">`. Prepended as a synthetic `## Active Skills` user message when `getMessages()` is called.
 
 **Event-driven reminders** (`AGENT_REMINDERS` in `prompt.ts`): after each tool-execution round, `buildReminder()` appends a short reminder to the last tool result. Currently fires on:
-- `write` or `edit` → "verify the change works — find and run the project's test command"
-- `write` or `edit` → "don't add features or refactoring beyond what was asked"
+- `write`, `edit`, or `multi_edit` → "verify the change works — find and run the project's test command"
+- `write`, `edit`, or `multi_edit` → "don't add features or refactoring beyond what was asked"
 - `bash` with `git` in the command → "never commit or push without an explicit user request"
 Each reminder fires at most once per session.
 
@@ -395,6 +395,7 @@ Only if all three pass is `tool.execute(params)` called.
 | `bash` | Any command not in `SAFE_COMMANDS` allowlist |
 | `write` | Path outside `process.cwd()` |
 | `edit` | Path outside `process.cwd()` |
+| `multi_edit` | Path outside `process.cwd()` |
 
 ---
 


### PR DESCRIPTION
## Summary

- The AGENT_REMINDERS description in `docs/architecture.md` said "write or edit" but the code (`isWriteCall` in `src/core/prompt.ts`) has included `multi_edit` since PR #208.
- The `requiresConfirmation` policy table was missing `multi_edit`, which triggers confirmation for paths outside `process.cwd()` — identical behavior to `edit`.

These two omissions were left after PR #207 (which added `multi_edit` to the file lists and `Tool` interface docs) and PR #208 (which fixed the code). This PR closes the remaining doc gap.

## Test plan
- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (642 tests, 0 failures)
- [x] No code changes — docs only; no runtime behavior is affected

Part of #43

https://claude.ai/code/session_01NRhVj7LV8swkrfMhJcVr5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRhVj7LV8swkrfMhJcVr5c)_