### PR TITLE
fix(renderer): handle multi_edit in toolStyle, formatToolArgs, and summariseResult

### DIFF
--- a/src/cli/renderer.test.ts
+++ b/src/cli/renderer.test.ts
@@ -56,6 +56,12 @@ describe("toolStyle", () => {
     expect(icon).toBe("✎");
   });
 
+  it("returns yellow + ✎ for multi_edit", () => {
+    const { color, icon } = toolStyle("multi_edit");
+    expect(color).toBe("yellow");
+    expect(icon).toBe("✎");
+  });
+
   it("returns cyan + ⟳ for unknown tools", () => {
     const { color, icon } = toolStyle("read");
     expect(color).toBe("cyan");
@@ -73,6 +79,40 @@ describe("formatToolArgs", () => {
       }),
     );
     expect(result).toBe("src/foo.ts");
+  });
+
+  it("returns file_path and edit count for multi_edit", () => {
+    const result = stripAnsi(
+      formatToolArgs("multi_edit", {
+        file_path: "src/foo.ts",
+        edits: [
+          { old_string: "x", new_string: "y" },
+          { old_string: "a", new_string: "b" },
+        ],
+      }),
+    );
+    expect(result).toBe("src/foo.ts  (2 edits)");
+  });
+
+  it("uses singular edit count for multi_edit with one edit", () => {
+    const result = stripAnsi(
+      formatToolArgs("multi_edit", {
+        file_path: "src/foo.ts",
+        edits: [{ old_string: "x", new_string: "y" }],
+      }),
+    );
+    expect(result).toBe("src/foo.ts  (1 edit)");
+  });
+
+  it("does not dump edits JSON for multi_edit display", () => {
+    const result = stripAnsi(
+      formatToolArgs("multi_edit", {
+        file_path: "src/foo.ts",
+        edits: [{ old_string: "very long old string content", new_string: "new" }],
+      }),
+    );
+    expect(result).not.toContain("old_string");
+    expect(result).not.toContain("very long old string content");
   });
 
   it("extracts file_path as primary arg", () => {
@@ -203,6 +243,20 @@ describe("summariseResult", () => {
     it("returns 'written' regardless of result content", () => {
       const result = stripAnsi(summariseResult("write", "anything"));
       expect(result).toContain("written");
+    });
+  });
+
+  describe("multi_edit", () => {
+    it("shows result without name/content collision", () => {
+      const result = stripAnsi(summariseResult("multi_edit", "Applied 3 edits to src/foo.ts"));
+      expect(result).toContain("multi_edit");
+      expect(result).toContain("Applied 3 edits to src/foo.ts");
+    });
+
+    it("preserves spacing between name and result", () => {
+      const result = stripAnsi(summariseResult("multi_edit", "Applied 1 edit to src/bar.ts"));
+      // "multi_edit" followed by spaces then result — no collision
+      expect(result).toMatch(/multi_edit\s+Applied/);
     });
   });
 

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -206,13 +206,18 @@ export type ChalkColor = "magenta" | "yellow" | "cyan" | "white";
 
 export function toolStyle(name: string): { color: ChalkColor; icon: string } {
   if (name === "bash") return { color: "magenta", icon: "❯" };
-  if (name === "write" || name === "edit") return { color: "yellow", icon: "✎" };
+  if (name === "write" || name === "edit" || name === "multi_edit")
+    return { color: "yellow", icon: "✎" };
   return { color: "cyan", icon: "⟳" };
 }
 
 export function formatToolArgs(name: string, args: Record<string, unknown>): string {
   if (name === "edit" && typeof args.file_path === "string") {
     return chalk.dim(args.file_path);
+  }
+  if (name === "multi_edit" && typeof args.file_path === "string") {
+    const n = Array.isArray(args.edits) ? args.edits.length : "?";
+    return chalk.dim(`${args.file_path}  (${n} edit${n === 1 ? "" : "s"})`);
   }
   // pattern before path so grep/glob show the search term rather than the directory
   const pathArg = args.file_path ?? args.pattern ?? args.path ?? args.command ?? null;
@@ -253,6 +258,9 @@ export function summariseResult(name: string, result: string): string {
   }
   if (name === "write") {
     return `${name.padEnd(6)}${chalk.dim("written")}`;
+  }
+  if (name === "multi_edit") {
+    return `multi_edit  ${chalk.dim(trimmed.slice(0, 80))}`;
   }
   if (name === "ls") {
     const entries = trimmed && trimmed !== "(empty directory)" ? trimmed.split("\n").length : 0;


### PR DESCRIPTION
## Summary

- `toolStyle("multi_edit")` was returning cyan/⟳ (the unknown-tool fallback) instead of yellow/✎ to match `edit` and `write`
- `formatToolArgs("multi_edit", { file_path, edits: [...] })` was falling through to the generic path-with-extras case, which JSON-dumps the `edits` array — potentially hundreds of lines of `old_string`/`new_string` content — into the bordered terminal box; now renders as `file.ts  (N edits)`
- `summariseResult("multi_edit", result)` fell through to the generic `name.padEnd(6)` case; since "multi_edit" is 10 chars, padEnd(6) is a no-op and the name was concatenated directly onto the result string without a space (e.g. `"multi_editApplied 3 edits…"`); now has an explicit case like `ls`, `write`, and `todo`

These were introduced when `multi_edit` was added but the renderer wasn't updated. Previous follow-up PRs (#207, #208, #209) fixed docs and `AGENT_REMINDERS` but this renderer gap remained.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (648 tests)
- [x] 5 new tests added to `renderer.test.ts` covering the three fixed functions for `multi_edit`
- [x] Verified `toolStyle("multi_edit")` → `{ color: "yellow", icon: "✎" }`
- [x] Verified `formatToolArgs("multi_edit", { file_path: "src/foo.ts", edits: [{...}, {...}] })` → `"src/foo.ts  (2 edits)"` (no edits JSON leaked)
- [x] Verified `summariseResult("multi_edit", "Applied 3 edits to src/foo.ts")` → `"multi_edit  Applied 3 edits…"` (space preserved)

https://claude.ai/code/session_01GJvsuynvCqumP8f4SPMS3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJvsuynvCqumP8f4SPMS3V)_