### PR TITLE
feat: inject periodic mid-loop reminder every 5 turns to counter instruction drift

### DIFF
--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -5,6 +5,7 @@ import { SkillRegistry } from "../skills/registry.js";
 import type { LLMClient } from "../providers/client.js";
 import type { Message, StreamEvent, ToolDefinition } from "../providers/types.js";
 import { contextWindowFor, COMPACTION_TARGET_TOKENS } from "./compact.js";
+import { PERIODIC_REMINDER_INTERVAL } from "./prompt.js";
 
 // A client that always requests the same tool call (never finishes on its own)
 function makeLoopingClient(toolName = "noop", args: Record<string, unknown> = {}): LLMClient {
@@ -805,5 +806,123 @@ describe("Agent activate_skill — conversation well-formedness", () => {
       (p) => p.type === "function_result" && (p as { name: string }).name === "activate_skill",
     );
     expect(hasFnResult).toBe(true);
+  });
+});
+
+describe("Agent periodic reminder injection", () => {
+  it(`appends reminder to the last tool result at turn ${PERIODIC_REMINDER_INTERVAL}`, async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        if (callCount <= PERIODIC_REMINDER_INTERVAL) {
+          yield {
+            type: "function_call",
+            id: `c${callCount}`,
+            name: "noop",
+            args: { n: callCount }, // vary args to avoid stuck-loop detection
+          } as StreamEvent;
+        }
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+
+    const agent = new Agent(
+      client,
+      makeNoopRegistry(),
+      new SkillRegistry(),
+      undefined,
+      undefined,
+      PERIODIC_REMINDER_INTERVAL + 5,
+    );
+    const events = await collectEvents(agent, "go");
+
+    const toolResults = events
+      .filter((e) => e.type === "tool_result")
+      .map((e) => e as { type: "tool_result"; result: string; name: string });
+
+    expect(toolResults).toHaveLength(PERIODIC_REMINDER_INTERVAL);
+    // Only the last result (at turn PERIODIC_REMINDER_INTERVAL) carries the reminder
+    const lastResult = toolResults[toolResults.length - 1];
+    expect(lastResult?.result).toContain("[reminder:");
+    expect(lastResult?.result).toContain("commit only when explicitly asked");
+
+    for (const r of toolResults.slice(0, -1)) {
+      expect(r.result).not.toContain("commit only when explicitly asked");
+    }
+  });
+
+  it("does not append reminder before the interval is reached", async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        if (callCount < PERIODIC_REMINDER_INTERVAL) {
+          yield {
+            type: "function_call",
+            id: `c${callCount}`,
+            name: "noop",
+            args: { n: callCount },
+          } as StreamEvent;
+        }
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+
+    const agent = new Agent(
+      client,
+      makeNoopRegistry(),
+      new SkillRegistry(),
+      undefined,
+      undefined,
+      PERIODIC_REMINDER_INTERVAL + 5,
+    );
+    const events = await collectEvents(agent, "go");
+
+    const toolResults = events
+      .filter((e) => e.type === "tool_result")
+      .map((e) => e as { type: "tool_result"; result: string });
+
+    for (const r of toolResults) {
+      expect(r.result).not.toContain("commit only when explicitly asked");
+    }
+  });
+
+  it("fires again at the second multiple of the interval", async () => {
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream() {
+        callCount++;
+        if (callCount <= PERIODIC_REMINDER_INTERVAL * 2) {
+          yield {
+            type: "function_call",
+            id: `c${callCount}`,
+            name: "noop",
+            args: { n: callCount },
+          } as StreamEvent;
+        }
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+
+    const agent = new Agent(
+      client,
+      makeNoopRegistry(),
+      new SkillRegistry(),
+      undefined,
+      undefined,
+      PERIODIC_REMINDER_INTERVAL * 2 + 5,
+    );
+    const events = await collectEvents(agent, "go");
+
+    const toolResults = events
+      .filter((e) => e.type === "tool_result")
+      .map((e) => e as { type: "tool_result"; result: string });
+
+    const reminderResults = toolResults.filter((r) =>
+      r.result.includes("commit only when explicitly asked"),
+    );
+    // Reminders fired at turns 5 and 10
+    expect(reminderResults).toHaveLength(2);
   });
 });

--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -845,10 +845,10 @@ describe("Agent periodic reminder injection", () => {
     // Only the last result (at turn PERIODIC_REMINDER_INTERVAL) carries the reminder
     const lastResult = toolResults[toolResults.length - 1];
     expect(lastResult?.result).toContain("[reminder:");
-    expect(lastResult?.result).toContain("commit only when explicitly asked");
+    expect(lastResult?.result).toContain("never commit or push without an explicit user request");
 
     for (const r of toolResults.slice(0, -1)) {
-      expect(r.result).not.toContain("commit only when explicitly asked");
+      expect(r.result).not.toContain("[reminder:");
     }
   });
 
@@ -884,7 +884,7 @@ describe("Agent periodic reminder injection", () => {
       .map((e) => e as { type: "tool_result"; result: string });
 
     for (const r of toolResults) {
-      expect(r.result).not.toContain("commit only when explicitly asked");
+      expect(r.result).not.toContain("[reminder:");
     }
   });
 
@@ -920,7 +920,7 @@ describe("Agent periodic reminder injection", () => {
       .map((e) => e as { type: "tool_result"; result: string });
 
     const reminderResults = toolResults.filter((r) =>
-      r.result.includes("commit only when explicitly asked"),
+      r.result.includes("never commit or push without an explicit user request"),
     );
     // Reminders fired at turns 5 and 10
     expect(reminderResults).toHaveLength(2);

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -5,7 +5,7 @@ import { toolToDefinition, activateSkillDefinition } from "../providers/schema.j
 import { ContextManager } from "./context.js";
 import { executeCalls } from "./executor.js";
 import type { ConfirmFn } from "./executor.js";
-import { buildReminder, buildPlanSuffix } from "./prompt.js";
+import { buildReminder, buildPlanSuffix, buildPeriodicReminder } from "./prompt.js";
 import type { FunctionCallPart, Message } from "../providers/types.js";
 import type { ObservabilityHandler } from "./observability.js";
 import type { SnapshotManager } from "../state/snapshot.js";
@@ -306,16 +306,18 @@ export class Agent {
         envErrorCount = 0;
       }
 
-      // Append an event-driven reminder to the last tool result based on what
-      // tools just ran — fires only when relevant (e.g. edit → "run tests").
-      const reminder = buildReminder(
+      // Append reminders to the last tool result: event-driven (fires when relevant
+      // tools run) and periodic (every N turns to counter long-session drift).
+      const eventReminder = buildReminder(
         pendingCalls.map((c) => ({ name: c.name, args: c.args })),
         firedReminders,
       );
-      if (reminder && results.length > 0) {
+      const periodicReminder = buildPeriodicReminder(turns);
+      const combined = eventReminder + periodicReminder;
+      if (combined && results.length > 0) {
         results[results.length - 1] = {
           ...results[results.length - 1],
-          result: results[results.length - 1].result + reminder,
+          result: results[results.length - 1].result + combined,
         };
       }
 

--- a/src/core/prompt.test.ts
+++ b/src/core/prompt.test.ts
@@ -133,8 +133,8 @@ describe("buildPeriodicReminder", () => {
     for (const t of [PERIODIC_REMINDER_INTERVAL, PERIODIC_REMINDER_INTERVAL * 2]) {
       const r = buildPeriodicReminder(t);
       expect(r).toContain("[reminder:");
-      expect(r).toContain("commit only when explicitly asked");
-      expect(r).toContain("run tests after changes");
+      expect(r).toContain("never commit or push without an explicit user request");
+      expect(r).toContain("verify the change works");
     }
   });
 });

--- a/src/core/prompt.test.ts
+++ b/src/core/prompt.test.ts
@@ -7,6 +7,8 @@ import {
   DEFAULT_SYSTEM_INSTRUCTION,
   getGitContext,
   buildReminder,
+  buildPeriodicReminder,
+  PERIODIC_REMINDER_INTERVAL,
   renderSystemInstruction,
   buildPlanSuffix,
 } from "./prompt.js";
@@ -113,6 +115,27 @@ describe("buildReminder", () => {
     const calls = [{ name: "edit", args: {} }];
     expect(buildReminder(calls)).toContain("verify the change works");
     expect(buildReminder(calls)).toContain("verify the change works");
+  });
+});
+
+describe("buildPeriodicReminder", () => {
+  it("returns empty string for turn 0", () => {
+    expect(buildPeriodicReminder(0)).toBe("");
+  });
+
+  it("returns empty string for turns that are not multiples of the interval", () => {
+    for (let t = 1; t < PERIODIC_REMINDER_INTERVAL; t++) {
+      expect(buildPeriodicReminder(t)).toBe("");
+    }
+  });
+
+  it("returns a [reminder: ...] block at each multiple of the interval", () => {
+    for (const t of [PERIODIC_REMINDER_INTERVAL, PERIODIC_REMINDER_INTERVAL * 2]) {
+      const r = buildPeriodicReminder(t);
+      expect(r).toContain("[reminder:");
+      expect(r).toContain("commit only when explicitly asked");
+      expect(r).toContain("run tests after changes");
+    }
   });
 });
 

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -60,21 +60,6 @@ export function getGitContext(): string {
   }
 }
 
-// ── Periodic mid-loop reminders ──────────────────────────────────────────────
-
-/** Inject a brief reminder every N tool-call turns to counter instruction drift in long sessions. */
-export const PERIODIC_REMINDER_INTERVAL = 5;
-
-const PERIODIC_REMINDER_TEXT =
-  "commit only when explicitly asked; prefer targeted edits over full rewrites; run tests after changes";
-
-export function buildPeriodicReminder(turn: number): string {
-  if (turn > 0 && turn % PERIODIC_REMINDER_INTERVAL === 0) {
-    return `\n\n[reminder: ${PERIODIC_REMINDER_TEXT}]`;
-  }
-  return "";
-}
-
 // ── Event-driven reminders ────────────────────────────────────────────────────
 
 export interface AgentReminder {
@@ -111,6 +96,21 @@ export function buildReminder(
   if (triggered.length === 0) return "";
   triggered.forEach((r) => firedReminders?.add(r.text));
   return `\n\n[reminder: ${triggered.map((r) => r.text).join("; ")}]`;
+}
+
+// ── Periodic mid-loop reminders ──────────────────────────────────────────────
+
+/** Inject a brief reminder every N tool-call turns to counter instruction drift in long sessions. */
+export const PERIODIC_REMINDER_INTERVAL = 5;
+
+// Derived from AGENT_REMINDERS so both channels stay in sync and never teach divergent rules.
+const PERIODIC_REMINDER_TEXT = AGENT_REMINDERS.map((r) => r.text).join("; ");
+
+export function buildPeriodicReminder(turn: number): string {
+  if (turn > 0 && turn % PERIODIC_REMINDER_INTERVAL === 0) {
+    return `\n\n[reminder: ${PERIODIC_REMINDER_TEXT}]`;
+  }
+  return "";
 }
 
 // ── System instruction rendering ─────────────────────────────────────────────

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -60,6 +60,21 @@ export function getGitContext(): string {
   }
 }
 
+// ── Periodic mid-loop reminders ──────────────────────────────────────────────
+
+/** Inject a brief reminder every N tool-call turns to counter instruction drift in long sessions. */
+export const PERIODIC_REMINDER_INTERVAL = 5;
+
+const PERIODIC_REMINDER_TEXT =
+  "commit only when explicitly asked; prefer targeted edits over full rewrites; run tests after changes";
+
+export function buildPeriodicReminder(turn: number): string {
+  if (turn > 0 && turn % PERIODIC_REMINDER_INTERVAL === 0) {
+    return `\n\n[reminder: ${PERIODIC_REMINDER_TEXT}]`;
+  }
+  return "";
+}
+
 // ── Event-driven reminders ────────────────────────────────────────────────────
 
 export interface AgentReminder {


### PR DESCRIPTION
## Summary

- Adds `buildPeriodicReminder(turn)` to `src/core/prompt.ts` that returns a compact `[reminder: ...]` block every `PERIODIC_REMINDER_INTERVAL` (5) turns, and empty string otherwise
- Wires it into `applyReminderToLastResult` in `src/core/agent.ts` alongside the existing event-driven reminders
- Adds 3 unit tests in `prompt.test.ts` and 3 integration tests in `agent.test.ts` covering: fires at multiples of the interval, silent before the interval, fires again at the second multiple

## Related issue

Part of #19 — item 5: "Mid-loop system-reminder injection"

## Why

Event-driven reminders (`AGENT_REMINDERS`) fire at most once per run and only when specific tools are called (writes, git). In long sessions the model drifts from git rules, edit discipline, and testing requirements. A periodic reminder re-anchors it cheaply (~10 tokens every 5 turns) without disrupting short sessions where the interval is never reached.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (654 tests, 0 failures)
- [x] New `buildPeriodicReminder` unit tests: fires at turn 5, 10; silent at turns 1–4; silent at turn 0
- [x] Agent integration tests: reminder appears in the `tool_result` event at exactly turn 5 and turn 10; absent before

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwDBfCRj6VdggzUNJpudh9)_