### PR TITLE
fix(confirm): extend file_path extraction to cover multi_edit

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -562,7 +562,7 @@ The HITL confirmation function (`createConfirmFn` in `repl.ts`) persists "Yes al
 **Allow vs deny formats are different:**
 
 - `allow` entries use the exact-args key format `toolName:JSON(args)` (e.g. `bash:{"command":"git status"}`) or the tool-wildcard `toolName:*`. These are exact-match strings written by the "Yes always" flow.
-- `deny` entries use a glob-pattern format `toolName(argGlob)` where `*` matches any sequence (e.g. `bash(rm -rf *)`, `write(.env*)`, `bash(*)` to deny all bash). The matched arg is `args.command` for `bash`, `args.file_path` for `write`/`edit`, and `JSON.stringify(args)` for any other tool. Pattern globbing is implemented in `src/cli/confirm.ts` (`globMatch` + `matchesDenyPattern`).
+- `deny` entries use a glob-pattern format `toolName(argGlob)` where `*` matches any sequence (e.g. `bash(rm -rf *)`, `write(.env*)`, `bash(*)` to deny all bash). The matched arg is `args.command` for `bash`, `args.file_path` for `write`/`edit`/`multi_edit`, and `JSON.stringify(args)` for any other tool. Pattern globbing is implemented in `src/cli/confirm.ts` (`globMatch` + `matchesDenyPattern`).
 
 **Order of evaluation in `createConfirmFn`:** `deny` patterns are checked first and short-circuit to a deny decision regardless of any matching `allow` entry. Only if no deny pattern matches does the function consult the `allow` list and (failing that) prompt the user interactively. Both global and project-scoped `deny` lists are unioned.
 

--- a/src/cli/confirm.test.ts
+++ b/src/cli/confirm.test.ts
@@ -77,6 +77,22 @@ describe("matchesDenyPattern", () => {
     expect(matchesDenyPattern(patterns, "bash", { command: "git status" })).toBe(false);
   });
 
+  it("matches multi_edit patterns against file_path", () => {
+    const patterns = ["multi_edit(.env*)"];
+    expect(
+      matchesDenyPattern(patterns, "multi_edit", {
+        file_path: ".env",
+        edits: [{ old_string: "a", new_string: "b" }],
+      }),
+    ).toBe(true);
+    expect(
+      matchesDenyPattern(patterns, "multi_edit", {
+        file_path: "src/foo.ts",
+        edits: [{ old_string: "a", new_string: "b" }],
+      }),
+    ).toBe(false);
+  });
+
   it("uses JSON stringify for unknown tools", () => {
     const patterns = ['read({"file_path":"secret.txt"})'];
     expect(matchesDenyPattern(patterns, "read", { file_path: "secret.txt" })).toBe(true);
@@ -101,6 +117,12 @@ describe("createForcesConfirmationFn", () => {
     const fn = createForcesConfirmationFn(["write(src/*)"]);
     expect(fn("write", { file_path: "src/index.ts" })).toBe(true);
     expect(fn("write", { file_path: "test/index.ts" })).toBe(false);
+  });
+
+  it("returns true when multi_edit path matches an ask pattern", () => {
+    const fn = createForcesConfirmationFn(["multi_edit(.env*)"]);
+    expect(fn("multi_edit", { file_path: ".env", edits: [] })).toBe(true);
+    expect(fn("multi_edit", { file_path: "src/foo.ts", edits: [] })).toBe(false);
   });
 
   it("returns false for a non-matching tool name", () => {

--- a/src/cli/confirm.ts
+++ b/src/cli/confirm.ts
@@ -5,7 +5,7 @@ import { loadSettings, saveSettings } from "../state/settings.js";
 import { selectKey } from "./input.js";
 
 // Pattern format for deny rules: "toolName(argGlob)" where * matches any chars.
-// bash → matches args.command; write/edit → args.file_path; others → JSON(args).
+// bash → matches args.command; write/edit/multi_edit → args.file_path; others → JSON(args).
 // Example: "bash(rm -rf *)" or "write(src/cli/*)" or "bash(*)" (all bash).
 
 export function globMatch(pattern: string, str: string): boolean {
@@ -23,7 +23,7 @@ export function matchesDenyPattern(
   const primaryArg =
     toolName === "bash"
       ? String(args.command ?? "")
-      : toolName === "write" || toolName === "edit"
+      : toolName === "write" || toolName === "edit" || toolName === "multi_edit"
         ? String(args.file_path ?? "")
         : JSON.stringify(args);
 
@@ -102,7 +102,7 @@ export async function createConfirmFn(): Promise<ConfirmBundle> {
     const detail =
       toolName === "bash"
         ? (args.command as string)
-        : toolName === "write" || toolName === "edit"
+        : toolName === "write" || toolName === "edit" || toolName === "multi_edit"
           ? (args.file_path as string)
           : JSON.stringify(args);
 


### PR DESCRIPTION
## Summary

- `matchesDenyPattern` extracted `args.file_path` for `write`/`edit` but fell through to `JSON.stringify(args)` for `multi_edit`. Deny patterns like `multi_edit(.env*)` never matched on the file path — they compared against the full JSON dump of the edits array instead.
- The HITL confirmation dialog had the same gap: the detail string shown to the user was `JSON.stringify(args)` for `multi_edit`, potentially printing hundreds of lines of `old_string`/`new_string` content instead of just the file path.
- Fixes both locations in `src/cli/confirm.ts` by adding `|| toolName === "multi_edit"` to the `write`/`edit` branches. Updates the inline comment and `docs/architecture.md` to reflect the corrected extraction rule.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (650 tests)
- [x] New test: `matchesDenyPattern` matches `multi_edit(.env*)` against `file_path`, not `JSON.stringify`
- [x] New test: `createForcesConfirmationFn` returns `true` when `multi_edit` path matches an `ask` pattern

https://claude.ai/code/session_0135YADJv3WSdSdq3aGpTdYx

---
_Generated by [Claude Code](https://claude.ai/code/session_0135YADJv3WSdSdq3aGpTdYx)_