### PR TITLE
docs: document env_error_loop guard and add missing observability events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ src/
    - Before each execution, check `tool.requiresConfirmation(args)`; if true, invoke `confirmFn` (interactive y/n/always dialog in REPL; auto-deny in non-interactive mode unless `--yes`)
 5. Append event-driven reminders to the last tool result (e.g. after `edit` → "run tests")
 6. Feed results back as a user message; repeat from step 2 until no function calls
-7. **Safety guards**: max-turns limit (default 50, `--max-turns` to override); stuck-loop detection aborts after 3 identical consecutive call signatures
+7. **Safety guards**: max-turns limit (default 50, `--max-turns` to override); stuck-loop detection aborts after 3 identical consecutive call signatures; env-error-loop detection aborts after 3 consecutive turns with the same OS-level error (EPERM, EACCES, ENOSPC, etc.)
 
 **Plan mode** (`Agent.run(input, "plan")`): restricts tools to `read/glob/grep/think`, appends a plan-specific system prompt suffix, and sets `readOnly` on the executor so write tools are blocked at two layers. The REPL's `/plan <task>` command runs a plan pass, then shows `[@clack/prompts select]` Approve / Edit / Cancel before switching to react mode for execution.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ src/
    - Before each execution, check `tool.requiresConfirmation(args)`; if true, invoke `confirmFn` (interactive y/n/always dialog in REPL; auto-deny in non-interactive mode unless `--yes`)
 5. Append event-driven reminders to the last tool result (e.g. after `edit` → "run tests")
 6. Feed results back as a user message; repeat from step 2 until no function calls
-7. **Safety guards**: max-turns limit (default 50, `--max-turns` to override); stuck-loop detection aborts after 3 identical consecutive call signatures
+7. **Safety guards**: max-turns limit (default 50, `--max-turns` to override); stuck-loop detection aborts after 3 identical consecutive call signatures; env-error-loop detection aborts after 3 consecutive turns with the same OS-level error (EPERM, EACCES, ENOSPC, etc.)
 
 **Plan mode** (`Agent.run(input, "plan")`): restricts tools to `read/glob/grep/think`, appends a plan-specific system prompt suffix, and sets `readOnly` on the executor so write tools are blocked at two layers. The REPL's `/plan <task>` command runs a plan pass, then shows `[@clack/prompts select]` Approve / Edit / Cancel before switching to react mode for execution.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture — OpenCLI
 
-_Last updated: 2026-05-09. Keep in sync with the code — update this doc in the same commit as any structural change it describes._
+_Last updated: 2026-06-05. Keep in sync with the code — update this doc in the same commit as any structural change it describes._
 
 ## Design principles
 
@@ -114,7 +114,7 @@ src/core/
 
 5. If no function calls → yield { type: "done" }, return.
 
-6. Safety guards (checked each turn before tool execution):
+6. Safety guards (before tool execution):
    a. Max-turns (default 50, --max-turns to override):
       if turns > maxTurns → yield error event, return.
    b. Stuck-loop (3 identical consecutive call signatures):
@@ -122,10 +122,15 @@ src/core/
 
 7. Execute all pending calls via executeCalls() (see executor below).
 
-8. Append event-driven reminders to last tool result (AGENT_REMINDERS).
+8. Env-error-loop guard (after tool execution): if the same OS-level error
+   pattern (EPERM, EACCES, ENOSPC, EMFILE, ENOMEM, "permission denied", etc.)
+   appears in tool results across 3 consecutive turns → yield error event, return.
+   These are environment conditions that code changes cannot fix.
+
+9. Append event-driven reminders to last tool result (AGENT_REMINDERS).
    Each reminder fires at most once per session (firedReminders Set).
 
-9. Append tool results as a user message to context. Go to step 3.
+10. Append tool results as a user message to context. Go to step 3.
 ```
 
 #### Plan mode
@@ -170,7 +175,12 @@ Event types:
 | `tool_exec_start` | Before `tool.execute()` |
 | `tool_exec_end` | After `tool.execute()` (latency, success, output bytes) |
 | `tool_denied` | When a call is blocked (plan_mode / user_denied / non_interactive) |
-| `guard_triggered` | When max-turns or stuck-loop fires |
+| `guard_triggered` | When a safety guard fires (max_turns, stuck_loop, or env_error_loop) |
+| `empty_response_retry` | When LLM returns an empty stream (no text, no tool calls) — retried once |
+| `compact_threshold_warned` | When context ratio first crosses 60% of the compaction budget this session |
+| `compact_started` | Before a compaction starts (auto at 75% ratio, or manual via `/compact`) |
+| `compact_completed` | After `compactHistory()` returns successfully |
+| `compact_failed` | When `compactHistory()` throws — turn proceeds with full history |
 
 #### Context management (`context.ts`)
 


### PR DESCRIPTION
## Summary

- **`docs/architecture.md`**: adds the `env_error_loop` guard as step 8 of the agentic loop (after tool execution), renumbers subsequent steps, fixes the `guard_triggered` observability row to list all three guards, and adds five previously-undocumented event types (`empty_response_retry`, `compact_threshold_warned`, `compact_started`, `compact_completed`, `compact_failed`) that were introduced with the A5b auto-compact feature
- **`CLAUDE.md` / `AGENTS.md`**: extends the safety-guards sentence to mention `env_error_loop` alongside max-turns and stuck-loop, keeping all three files in sync

Closes part of #43

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all 650 tests pass, 0 failures
- [x] No code changes — diff is documentation only
- [x] Verified that `ENV_ERROR_PATTERNS`, `checkEnvErrorGuard`, and `env_error_loop` in `observability.ts` match the new descriptions exactly
- [x] Verified all five new event rows match the `ObservabilityEvent` union type in `src/core/observability.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01APvjjq6QDBLrwgpn97x6xk)_