### PR TITLE
fix(renderer): add spacing separator for long tool names in printToolResultExpanded

### DIFF
--- a/src/cli/renderer.test.ts
+++ b/src/cli/renderer.test.ts
@@ -549,6 +549,25 @@ describe("print functions write to stderr/stdout", () => {
     expect(output).toContain("more lines");
   });
 
+  it("printToolResultExpanded separates long tool names from error message", () => {
+    // multi_edit is 10 chars — padEnd(6) adds no space, so the name would
+    // collide with the error text without the explicit two-space separator.
+    printToolResultExpanded("multi_edit", "Error: old_string not found in file");
+    const output = stripAnsi(stderr());
+    expect(output).toContain("✗");
+    expect(output).toContain("multi_edit");
+    expect(output).toContain("Error: old_string not found in file");
+    expect(output).toMatch(/multi_edit\s+Error:/);
+  });
+
+  it("printToolResultExpanded separates long tool names from line-count text", () => {
+    const longOutput = Array.from({ length: 7 }, (_, i) => `line${i + 1}`).join("\n");
+    printToolResultExpanded("web_fetch", longOutput);
+    const output = stripAnsi(stderr());
+    expect(output).toContain("✓");
+    expect(output).toMatch(/web_fetch\s+\(\d+ lines\)/);
+  });
+
   it("printToolCallCompact writes ○ line to stderr", () => {
     printToolCallCompact("read", { file_path: "src/foo.ts" });
     const output = stripAnsi(stderr());

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -113,10 +113,13 @@ export function printToolResultExpanded(name: string, result: string): void {
   const trimmed = result.trim();
   const isError = trimmed.startsWith("Error:");
   const lines = trimmed ? trimmed.split("\n") : [];
+  // For names ≥6 chars padEnd(6) adds no separator; always emit two spaces so
+  // the name never runs directly into the status text.
+  const nameCol = name.length < 6 ? name.padEnd(6) : `${name}  `;
 
   if (isError) {
     const errMsg = lines[0]?.slice(0, 80) ?? "Error";
-    process.stderr.write(chalk.red(`  ✗ ${name.padEnd(6)}${errMsg}`) + "\n");
+    process.stderr.write(chalk.red(`  ✗ ${nameCol}${errMsg}`) + "\n");
     const bodyLines = lines.slice(1, MAX_EXPANDED_LINES);
     for (const line of bodyLines) {
       process.stderr.write(chalk.dim(`     ${line}`) + "\n");
@@ -127,7 +130,7 @@ export function printToolResultExpanded(name: string, result: string): void {
       );
     }
   } else {
-    process.stderr.write(chalk.dim(`  ✓ ${name.padEnd(6)}(${lines.length} lines)`) + "\n");
+    process.stderr.write(chalk.dim(`  ✓ ${nameCol}(${lines.length} lines)`) + "\n");
     const displayLines = lines.slice(0, MAX_EXPANDED_LINES);
     for (const line of displayLines) {
       process.stderr.write(chalk.dim(`     ${line}`) + "\n");


### PR DESCRIPTION
## Summary

- **Bug**: `printToolResultExpanded` used `name.padEnd(6)` to format the tool name column, but for names ≥ 6 characters (`multi_edit` at 10, `web_fetch` at 9, `todo_write` at 10, `todo_read` at 9), `padEnd(6)` adds zero spaces — so the name runs directly into the error message or `(N lines)` text. For example, a `multi_edit` error rendered as `✗ multi_editError: old_string not found in file`.
- **Fix**: For names shorter than 6 chars, keep `padEnd(6)` (existing behaviour); for names ≥ 6 chars, append two explicit spaces — matching the pattern `summariseResult` uses for `multi_edit` (added in PR #210).
- **Same class of bug** as the one fixed in `summariseResult` by PR #210; `printToolResultExpanded` was missed in that pass.

Closes part of #43

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all 652 tests pass
- [x] Added `printToolResultExpanded separates long tool names from error message` — asserts `multi_edit\s+Error:` in output
- [x] Added `printToolResultExpanded separates long tool names from line-count text` — asserts `web_fetch\s+(N lines)` in output
- [x] Existing short-name tests (`bash`, `edit`) still pass — behaviour unchanged for names < 6 chars

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_018FXRjdHkkd6M736DXEm6Cu)_