### PR TITLE
fix(renderer): remove misleading first-line "file path" from read result summary

### DIFF
--- a/src/cli/renderer.test.ts
+++ b/src/cli/renderer.test.ts
@@ -168,18 +168,19 @@ describe("compactArg", () => {
 
 describe("summariseResult", () => {
   describe("read", () => {
-    it("counts lines correctly", () => {
-      const result = stripAnsi(summariseResult("read", "line1\nline2\nline3"));
+    it("counts lines correctly for line-numbered output", () => {
+      const result = stripAnsi(summariseResult("read", "1\tline1\n2\tline2\n3\tline3"));
       expect(result).toContain("3 lines");
     });
 
-    it("shows first line as file path preview", () => {
-      const result = stripAnsi(summariseResult("read", "src/foo.ts\nconst x = 1;"));
-      expect(result).toContain("src/foo.ts");
+    it("does not show file content as file path", () => {
+      const result = stripAnsi(summariseResult("read", "1\tconst x = 1;\n2\tconst y = 2;"));
+      expect(result).toContain("2 lines");
+      expect(result).not.toContain("const x");
     });
 
     it("handles single line", () => {
-      const result = stripAnsi(summariseResult("read", "only one line"));
+      const result = stripAnsi(summariseResult("read", "1\tonly one line"));
       expect(result).toContain("1 lines");
     });
 

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -241,8 +241,7 @@ export function summariseResult(name: string, result: string): string {
 
   if (name === "read") {
     const lines = trimmed.split("\n").length;
-    const filePath = trimmed.split("\n")[0]?.slice(0, 60) ?? "";
-    return `${name.padEnd(6)}${chalk.dim(`${filePath}  (${lines} lines)`)}`;
+    return `${name.padEnd(6)}${chalk.dim(`(${lines} lines)`)}`;
   }
   if (name === "glob") {
     const files = trimmed ? trimmed.split("\n").length : 0;


### PR DESCRIPTION
## Summary

- `summariseResult("read", …)` was extracting the first line of the tool output and displaying it as a file-path label, producing nonsense like `✓ read   1	const x = 1;  (N lines)` in the REPL. The `read` tool always returns line-numbered content (`"1\tcode\n2\t…"`) — it never includes the file path in its result, so the "file path" shown was actually the first line of file content.
- Removed the erroneous `filePath` extraction; the summary now shows only the accurate line count: `✓ read   (N lines)`.
- Updated the test to use realistic line-numbered input (matching actual `read` tool output) and assert that file content is not leaked into the summary.

Closes #43 (Part of the code-quality audit tracked there)

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (650 tests)
- [x] `summariseResult("read", "1\tconst x = 1;\n2\tconst y = 2;")` → contains `"2 lines"`, does not contain `"const x"`
- [x] No regression in other `summariseResult` cases (glob, grep, bash, write, multi_edit, ls, todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLQVnT16oPkEJYhqrPVq1Z)_