### PR TITLE
fix(compact): add 128k context window entries for o1/o3/o4 mini reasoning models

### DIFF
--- a/src/core/compact.test.ts
+++ b/src/core/compact.test.ts
@@ -296,6 +296,22 @@ describe("contextWindowFor", () => {
     expect(contextWindowFor("gpt-4.1")).toBe(128_000);
   });
 
+  it("returns 200_000 for o1/o3/o4 base reasoning models", () => {
+    expect(contextWindowFor("o1")).toBe(200_000);
+    expect(contextWindowFor("o3")).toBe(200_000);
+    expect(contextWindowFor("o4")).toBe(200_000);
+  });
+
+  it("returns 128_000 for o1-mini and o1-preview (smaller context than base o1)", () => {
+    expect(contextWindowFor("o1-mini")).toBe(128_000);
+    expect(contextWindowFor("o1-preview")).toBe(128_000);
+  });
+
+  it("returns 128_000 for o3-mini and o4-mini (smaller context than base models)", () => {
+    expect(contextWindowFor("o3-mini")).toBe(128_000);
+    expect(contextWindowFor("o4-mini")).toBe(128_000);
+  });
+
   it("returns 100_000 for unknown model", () => {
     expect(contextWindowFor("unknown-model-xyz")).toBe(100_000);
   });

--- a/src/core/compact.ts
+++ b/src/core/compact.ts
@@ -19,6 +19,11 @@ const MODEL_CONTEXT_WINDOWS: [prefix: string, tokens: number][] = [
   ["claude-", 200_000],
   ["gpt-4.1", 128_000],
   ["gpt-4o", 128_000],
+  // Mini/preview reasoning models have 128k context; must come before the base o1/o3/o4 entries.
+  ["o1-mini", 128_000],
+  ["o1-preview", 128_000],
+  ["o3-mini", 128_000],
+  ["o4-mini", 128_000],
   ["o1", 200_000],
   ["o3", 200_000],
   ["o4", 200_000],


### PR DESCRIPTION
## Summary

- `contextWindowFor("o1-mini")`, `contextWindowFor("o3-mini")`, and `contextWindowFor("o4-mini")` were returning 200k instead of 128k because the `MODEL_CONTEXT_WINDOWS` prefix table lacked specific entries for mini/preview variants — they fell through to the base `o1`/`o3`/`o4` entries (200k)
- Added `o1-mini`, `o1-preview`, `o3-mini`, and `o4-mini` entries (128k) **before** the base model entries, consistent with the existing longest-prefix-first ordering requirement
- Added 3 test cases verifying both base model (200k) and mini/preview (128k) lookups

## Impact

Auto-compact was firing at ~150k tokens (75% of the incorrectly-estimated 200k) instead of ~96k (75% of the correct 128k) for users running `o1-mini`, `o3-mini`, or `o4-mini`. This could allow context to grow past the actual 128k limit before compaction triggered.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm test` — all 653 tests pass (3 new tests added)
- [x] New tests: `contextWindowFor("o1-mini")` → 128k, `contextWindowFor("o1-preview")` → 128k, `contextWindowFor("o3-mini")` → 128k, `contextWindowFor("o4-mini")` → 128k
- [x] Existing behaviour preserved: `contextWindowFor("o1")` → 200k, `contextWindowFor("o3")` → 200k, `contextWindowFor("o4")` → 200k

https://claude.ai/code/session_018QPhrvDrZ81qD5aNHU6ExV

---
_Generated by [Claude Code](https://claude.ai/code/session_018QPhrvDrZ81qD5aNHU6ExV)_