### PR TITLE
fix(openai): omit temperature for o1/o1-mini/o1-preview reasoning models

### DIFF
--- a/src/providers/openai.test.ts
+++ b/src/providers/openai.test.ts
@@ -144,6 +144,101 @@ describe("OpenAIClient message format", () => {
     expect(callArgs[0].max_tokens).toBe(16384);
   });
 
+  it("passes temperature to the API call for non-o1 models", async () => {
+    const tempClient = new OpenAIClient("fake-key", "gpt-4o", { temperature: 0.5 });
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of tempClient.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].temperature).toBe(0.5);
+  });
+
+  it("passes temperature to the API call for o3-mini (supports temperature)", async () => {
+    vi.mocked(OpenAI).mockImplementation(
+      () =>
+        ({
+          chat: { completions: { create: mockCreate } },
+        }) as unknown as InstanceType<typeof OpenAI>,
+    );
+    const tempClient = new OpenAIClient("fake-key", "o3-mini", { temperature: 0.7 });
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of tempClient.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].temperature).toBe(0.7);
+  });
+
+  it("omits temperature for o1 (temperature is fixed at 1)", async () => {
+    vi.mocked(OpenAI).mockImplementation(
+      () =>
+        ({
+          chat: { completions: { create: mockCreate } },
+        }) as unknown as InstanceType<typeof OpenAI>,
+    );
+    const o1Client = new OpenAIClient("fake-key", "o1", { temperature: 0.5 });
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of o1Client.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].temperature).toBeUndefined();
+  });
+
+  it("omits temperature for o1-mini (temperature is fixed at 1)", async () => {
+    vi.mocked(OpenAI).mockImplementation(
+      () =>
+        ({
+          chat: { completions: { create: mockCreate } },
+        }) as unknown as InstanceType<typeof OpenAI>,
+    );
+    const o1MiniClient = new OpenAIClient("fake-key", "o1-mini", { temperature: 0.5 });
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of o1MiniClient.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].temperature).toBeUndefined();
+  });
+
+  it("omits temperature for o1-preview (temperature is fixed at 1)", async () => {
+    vi.mocked(OpenAI).mockImplementation(
+      () =>
+        ({
+          chat: { completions: { create: mockCreate } },
+        }) as unknown as InstanceType<typeof OpenAI>,
+    );
+    const o1PreviewClient = new OpenAIClient("fake-key", "o1-preview", { temperature: 0.5 });
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of o1PreviewClient.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].temperature).toBeUndefined();
+  });
+
+  it("omits temperature when not configured regardless of model", async () => {
+    mockCreate.mockResolvedValue(
+      makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),
+    );
+    for await (const e of client.stream([], "sys", [])) {
+      void e;
+    }
+    const [callArgs] = mockCreate.mock.calls;
+    expect(callArgs[0].temperature).toBeUndefined();
+  });
+
   it("injects system instruction as first message", async () => {
     mockCreate.mockResolvedValue(
       makeStream([{ choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] }]),

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -11,6 +11,12 @@ function isReasoningModel(model: string): boolean {
   return /^o[134](-|$)/.test(model);
 }
 
+// o1/o1-mini/o1-preview do not accept a temperature parameter (it is fixed at 1).
+// o3 and o4 variants do support temperature; only the original o1 family is excluded.
+function lacksTemperatureSupport(model: string): boolean {
+  return /^o1(-|$)/.test(model);
+}
+
 export class OpenAIClient implements LLMClient {
   private client: OpenAI;
   private model: string;
@@ -74,7 +80,9 @@ export class OpenAIClient implements LLMClient {
       tools: openaiTools.length > 0 ? openaiTools : undefined,
       stream: true,
       stream_options: this.includeUsage ? { include_usage: true } : undefined,
-      ...(this.temperature !== undefined ? { temperature: this.temperature } : {}),
+      ...(this.temperature !== undefined && !lacksTemperatureSupport(this.model)
+        ? { temperature: this.temperature }
+        : {}),
     });
 
     const pendingCalls = new Map<number, { id: string; name: string; args: string }>();


### PR DESCRIPTION
## Summary

- The o1/o1-mini/o1-preview family of OpenAI reasoning models does not accept a `temperature` parameter (it is fixed at 1 server-side). Passing temperature to these models causes a `400 Invalid parameter` API error.
- Added a `lacksTemperatureSupport()` helper that matches the o1 family specifically; o3 and o4 variants do support temperature and are unaffected.
- The bug is triggered today when a user runs `opencli run "..." --model o1-mini --temperature 0.5`.

## Related issue

Part of #43

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (699 tests)
- [x] New tests verify temperature is omitted for `o1`, `o1-mini`, `o1-preview`
- [x] New tests verify temperature IS passed for `gpt-4o` and `o3-mini`
- [x] Existing test for `developer` role on o-series models still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKYui4x6xKJ1V8KJyk8bSp)_