### PR TITLE
fix(eval): make redact-tape actually rewrite session_start.cwd as documented

### DIFF
--- a/scripts/redact-tape.ts
+++ b/scripts/redact-tape.ts
@@ -81,6 +81,42 @@ function buildRules(username: string): ReplacementRule[] {
   ];
 }
 
+/**
+ * Pre-pass: parse each line as JSON and rewrite the `cwd` field on any
+ * `session_start` entry to a generic placeholder. This catches cwds that
+ * the string-replacement rules would otherwise miss — e.g.
+ * `/Workspace/<project>` or `/opt/<project>` paths that don't contain the
+ * author's username. Non-JSON / non-session_start lines pass through
+ * untouched.
+ *
+ * Returns the rewritten content and the number of session_start entries
+ * normalised.
+ */
+function normaliseSessionStarts(input: string): { out: string; rewrites: number } {
+  let rewrites = 0;
+  const outLines = input.split("\n").map((line) => {
+    if (!line.trim()) return line;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return line;
+    }
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      (parsed as { type?: unknown }).type === "session_start" &&
+      typeof (parsed as { cwd?: unknown }).cwd === "string"
+    ) {
+      (parsed as { cwd: string }).cwd = "/Users/REPLAY-USER/Workspace/replay-project";
+      rewrites++;
+      return JSON.stringify(parsed);
+    }
+    return line;
+  });
+  return { out: outLines.join("\n"), rewrites };
+}
+
 function redactString(input: string, rules: ReplacementRule[]): { out: string; counts: number[] } {
   let out = input;
   const counts = rules.map(() => 0);
@@ -149,9 +185,16 @@ function main(): void {
     truncation = { fromLine: from, toLine: to };
   }
 
+  // Pass 1: normalise any session_start.cwd to a generic placeholder.
+  // This catches cwds that the string-replace rules would miss (paths
+  // that don't contain the author's username).
+  const { out: normalised, rewrites: sessionStartRewrites } = normaliseSessionStarts(processInput);
+
+  // Pass 2: string-replace home paths and bare username references in
+  // every remaining byte (tool args, tool results, code content).
   const rules = buildRules(username);
-  const { out, counts } = redactString(processInput, rules);
-  const totalReplacements = counts.reduce((a, b) => a + b, 0);
+  const { out, counts } = redactString(normalised, rules);
+  const totalReplacements = counts.reduce((a, b) => a + b, 0) + sessionStartRewrites;
 
   if (totalReplacements === 0) {
     process.stderr.write(
@@ -186,6 +229,7 @@ function main(): void {
     outputBytes: out.length,
     truncation,
     totalReplacements,
+    sessionStartRewrites,
     rules: rules.map((r, i) => ({
       find: r.find,
       replace: r.replace,


### PR DESCRIPTION
## Summary

Follow-up to the [PR #231 review comment](https://github.com/zjshen14/opencli/pull/231#issuecomment-from-zjshen14). The docstring on `scripts/redact-tape.ts` claimed item 3:

> The `cwd` field on `session_start` is rewritten to a generic path.

…but there was no code that did this. The script's passes were both pure string replacement, so a `cwd` only got redacted incidentally if it contained `/Users/<username>/`. Tapes with cwds like `/Workspace/<project>` or `/opt/<project>` would leak the project name even after redaction.

## Fix

Adds a structured pre-pass that JSON-parses each line, finds `session_start` entries, and rewrites the `cwd` field to a single placeholder (`/Users/REPLAY-USER/Workspace/replay-project`). This also generalises the project name — before, even when the home path was redacted, the project directory name (e.g. `card_trade`) survived because the string rules wouldn't touch it.

Log adds a `sessionStartRewrites` field so reviewers can verify the structured pass fired the expected number of times.

## Verified

- **Committed truncated tape (lines 33–105)** has no `session_start`, so the new pass is a no-op. Sealed file's sha256 is unchanged (`adcf702b…`). No tape refresh needed in this PR.
- **Full untruncated input** now produces `sessionStartRewrites: 1` and the cwd becomes `/Users/REPLAY-USER/Workspace/replay-project` (was `/Users/REPLAY-USER/Workspace/card_trade` under string-only rules).

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — 711 passed
- [x] `npx eslint scripts/redact-tape.ts` — clean
- [x] sha256 of the committed tape unchanged after re-running the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)