### PR TITLE
feat(eval): D2 synthesised edge-case replay tapes — stuck-loop, env-error-loop, nested compaction

### DIFF
--- a/docs/design/d2-context-management-replay.md
+++ b/docs/design/d2-context-management-replay.md
@@ -162,9 +162,12 @@ Because the tape was recorded before A5b, after the first auto-compaction fires 
 
 ### Synthesized tapes
 
-For assertions that need behaviors the real session doesn't exhibit (nested compactions, stuck-loop, env-error loop), small hand-written tapes live alongside the real ones under `src/eval/replay-tapes/synthesized/`. These are explicitly marked as synthesized and have richer `expected.json` annotations.
+For assertions that need behaviors the real session doesn't exhibit (nested compactions, stuck-loop, env-error loop), the harness uses two formats depending on payload size:
 
-This is the same separation D1 uses between real-fixture scenarios (the YAML suite against `mini-ts/`) and edge-case fixtures (`mini-ts-partial/`).
+- **Small JSONL tapes committed under `src/eval/replay-tapes/synthesized/`** — for cases where the recorded sequence is short and inspectable on PR diff. `stuck-loop` (6 entries) and `env-error-loop` (7 entries) both fit. These have richer `expected.json` annotations including a `guards: [{guard, reasonContains}]` block that asserts the specific guard fires with the expected reason fragment.
+- **Programmatic tapes in `synthesized.test.ts`** — for cases that need ≥ 500 KB of synthetic content to push the agent past a threshold. Nested compaction is the canonical example: it requires five 100 KB tool_results to bloat the tail past 75 % both before and after the first compaction. Committing that as JSONL would bloat the repo for no inspection value.
+
+This is the same separation D1 uses between real-fixture scenarios (the YAML suite against `mini-ts/`) and edge-case fixtures (`mini-ts-partial/`) — committed when small, generated when not.
 
 ---
 

--- a/src/eval/replay-tapes/README.md
+++ b/src/eval/replay-tapes/README.md
@@ -22,6 +22,19 @@ A tape is a JSONL file with `SessionEntry` records (same format as `~/.opencli/p
 | What it proves | Realistic call patterns replay cleanly — every recorded `tool_call`/`tool_result` pair is consumed in order, every observability event fires as expected, no guards misfire. Catches regressions on real trajectory shapes that hand-written tapes wouldn't surface. |
 | What it doesn't prove | The session is too short (~11k token peak) to trigger A5b auto-compact. Compaction contract is asserted by the synthesized-pressure tapes in [`runner.test.ts`](../replay/runner.test.ts). |
 
+### `synthesized/stuck-loop` and `synthesized/env-error-loop`
+
+Two hand-written JSONL tapes covering safety-guard behaviours the real card_trade trajectory doesn't exercise. Small enough to inspect on PR diff (5–7 entries each); no redaction needed (no real paths or identifiers). Driven by [`src/eval/replay/synthesized.test.ts`](../replay/synthesized.test.ts).
+
+| Tape | Asserts |
+|---|---|
+| `stuck-loop` | Three identical (name, args) tool calls in a row fire `guard_triggered('stuck_loop')`. Only iters 1+2 execute — iter 3 aborts before tool execution. |
+| `env-error-loop` | Three consecutive tool results containing `EPERM` fire `guard_triggered('env_error_loop')`. All three iters execute; the guard fires AFTER the third. Args differ across iters so stuck-loop does not also fire. |
+
+### Nested compaction (programmatic, lives in `synthesized.test.ts`)
+
+The third synthesised case — two compactions in one replay, the second one nested inside the prune anchor preserved by the first — needs ≥ 500 KB of synthetic content (5 × 100 KB `read` results) to push the agent above the 75 % auto-compact threshold twice. Committing that as JSONL would bloat the repo for zero inspection value, so the tape is generated programmatically in the test. The assertion checks that the original user input survives both compactions via the verbatim-block anchor preservation in `extractOriginalTask`.
+
 ## Refreshing a tape
 
 If you change the agent loop and the `expected.json` diff is legitimate (the new event count is correct), commit the change with a brief note about *why* the count changed. Reviewers should:

--- a/src/eval/replay-tapes/synthesized/env-error-loop.expected.json
+++ b/src/eval/replay-tapes/synthesized/env-error-loop.expected.json
@@ -1,0 +1,33 @@
+{
+  "source": "synthesised — three iterations whose tool_results all contain ENV_ERROR_PATTERNS['EPERM']; agent.ts ENV_ERROR_THRESHOLD=3 must abort the loop after the third recurrence. Args differ across iterations so the stuck-loop guard does NOT fire.",
+  "tapeStats": {
+    "turns": 1,
+    "totalIterations": 3,
+    "totalToolCalls": 3
+  },
+  "observability": {
+    "exact": {
+      "compact_threshold_warned": 0,
+      "compact_started": 0,
+      "compact_completed": 0,
+      "compact_failed": 0,
+      "empty_response_retry": 0,
+      "llm_call_start": 3,
+      "llm_call_end": 3,
+      "context_snapshot": 3,
+      "guard_triggered": 1,
+      "tool_exec_start": 3,
+      "tool_exec_end": 3
+    }
+  },
+  "cleanExit": {
+    "tapeExhausted": true,
+    "unconsumedResults": 0
+  },
+  "guards": [
+    {
+      "guard": "env_error_loop",
+      "reasonContains": "EPERM"
+    }
+  ]
+}

--- a/src/eval/replay-tapes/synthesized/env-error-loop.jsonl
+++ b/src/eval/replay-tapes/synthesized/env-error-loop.jsonl
@@ -1,0 +1,7 @@
+{"type":"user","content":"try to access the protected dir","timestamp":"2026-06-01T00:00:00.000Z"}
+{"type":"tool_call","name":"bash","args":{"command":"ls /root"},"timestamp":"2026-06-01T00:00:01.000Z"}
+{"type":"tool_result","name":"bash","result":"ls: /root: EPERM: permission denied","timestamp":"2026-06-01T00:00:02.000Z"}
+{"type":"tool_call","name":"bash","args":{"command":"cat /root/secrets"},"timestamp":"2026-06-01T00:00:03.000Z"}
+{"type":"tool_result","name":"bash","result":"cat: /root/secrets: EPERM: still no","timestamp":"2026-06-01T00:00:04.000Z"}
+{"type":"tool_call","name":"bash","args":{"command":"touch /root/x"},"timestamp":"2026-06-01T00:00:05.000Z"}
+{"type":"tool_result","name":"bash","result":"touch: /root/x: EPERM: nope","timestamp":"2026-06-01T00:00:06.000Z"}

--- a/src/eval/replay-tapes/synthesized/stuck-loop.expected.json
+++ b/src/eval/replay-tapes/synthesized/stuck-loop.expected.json
@@ -1,0 +1,33 @@
+{
+  "source": "synthesised — three iterations with identical (name, args) tool calls; agent.ts STUCK_THRESHOLD=3 must abort the loop after the third recurrence",
+  "tapeStats": {
+    "turns": 1,
+    "totalIterations": 3,
+    "totalToolCalls": 3
+  },
+  "observability": {
+    "exact": {
+      "compact_threshold_warned": 0,
+      "compact_started": 0,
+      "compact_completed": 0,
+      "compact_failed": 0,
+      "empty_response_retry": 0,
+      "llm_call_start": 3,
+      "llm_call_end": 3,
+      "context_snapshot": 3,
+      "guard_triggered": 1,
+      "tool_exec_start": 2,
+      "tool_exec_end": 2
+    }
+  },
+  "cleanExit": {
+    "tapeExhausted": true,
+    "unconsumedResults": 0
+  },
+  "guards": [
+    {
+      "guard": "stuck_loop",
+      "reasonContains": "identical consecutive call signatures"
+    }
+  ]
+}

--- a/src/eval/replay-tapes/synthesized/stuck-loop.jsonl
+++ b/src/eval/replay-tapes/synthesized/stuck-loop.jsonl
@@ -1,0 +1,6 @@
+{"type":"user","content":"list the working directory","timestamp":"2026-06-01T00:00:00.000Z"}
+{"type":"tool_call","name":"bash","args":{"command":"ls"},"timestamp":"2026-06-01T00:00:01.000Z"}
+{"type":"tool_result","name":"bash","result":"file.txt","timestamp":"2026-06-01T00:00:02.000Z"}
+{"type":"tool_call","name":"bash","args":{"command":"ls"},"timestamp":"2026-06-01T00:00:03.000Z"}
+{"type":"tool_result","name":"bash","result":"file.txt","timestamp":"2026-06-01T00:00:04.000Z"}
+{"type":"tool_call","name":"bash","args":{"command":"ls"},"timestamp":"2026-06-01T00:00:05.000Z"}

--- a/src/eval/replay/synthesized.test.ts
+++ b/src/eval/replay/synthesized.test.ts
@@ -1,0 +1,218 @@
+/**
+ * End-to-end replay tests for synthesised tapes — edge-case behaviours
+ * the real card_trade tape doesn't exercise (guards, nested compaction).
+ *
+ * Two file-backed tapes live under `src/eval/replay-tapes/synthesized/`
+ * (small enough to be human-inspectable on PR diff). The
+ * nested-compaction case lives here as a programmatic tape because it
+ * needs hundreds of KB of synthetic content to push the agent above
+ * the auto-compact threshold twice — committing that to JSONL would
+ * bloat the repo for no inspection value.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { parseJsonlString, buildTape } from "./tape.js";
+import type { Tape, LLMIteration } from "./tape.js";
+import { runTape } from "./runner.js";
+import { countOfType, eventsOfType, compactStartedResolutions } from "./assertions.js";
+import type { ObservabilityEvent } from "../../core/observability.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TAPES = join(HERE, "..", "replay-tapes", "synthesized");
+
+interface Expected {
+  source: string;
+  tapeStats: { turns: number; totalIterations: number; totalToolCalls: number };
+  observability: {
+    exact: Partial<Record<ObservabilityEvent["type"], number>>;
+  };
+  cleanExit: { tapeExhausted: boolean; unconsumedResults: number };
+  guards?: { guard: string; reasonContains: string }[];
+}
+
+function loadTape(name: string): { tape: Tape; expected: Expected } {
+  const jsonl = readFileSync(join(TAPES, `${name}.jsonl`), "utf8");
+  const expected = JSON.parse(
+    readFileSync(join(TAPES, `${name}.expected.json`), "utf8"),
+  ) as Expected;
+  const entries = parseJsonlString(jsonl);
+  const tape = buildTape(entries, name);
+  return { tape, expected };
+}
+
+function iter(
+  text: string,
+  toolCalls: { name: string; args?: Record<string, unknown> }[] = [],
+  toolResults: { name: string; result: string }[] = [],
+): LLMIteration {
+  return {
+    text,
+    toolCalls: toolCalls.map((c) => ({ name: c.name, args: c.args ?? {} })),
+    toolResults,
+  };
+}
+
+function assertExpected(
+  observability: ObservabilityEvent[],
+  unconsumedResults: number,
+  tapeExhausted: boolean,
+  expected: Expected,
+): void {
+  expect(tapeExhausted).toBe(expected.cleanExit.tapeExhausted);
+  expect(unconsumedResults).toBe(expected.cleanExit.unconsumedResults);
+  for (const [type, count] of Object.entries(expected.observability.exact)) {
+    expect(
+      countOfType(observability, type as ObservabilityEvent["type"]),
+      `exact count for ${type}`,
+    ).toBe(count);
+  }
+  for (const g of expected.guards ?? []) {
+    const guards = eventsOfType(observability, "guard_triggered");
+    const matched = guards.find((e) => e.guard === g.guard && e.reason.includes(g.reasonContains));
+    expect(
+      matched,
+      `expected guard ${g.guard} with reason containing "${g.reasonContains}"`,
+    ).toBeDefined();
+  }
+}
+
+describe("synthesised replay — stuck-loop guard", () => {
+  const { tape, expected } = loadTape("stuck-loop");
+
+  it("parses to 1 turn × 3 iterations × 3 tool calls", () => {
+    expect(tape.turns).toHaveLength(expected.tapeStats.turns);
+    expect(tape.turns[0].iterations).toHaveLength(expected.tapeStats.totalIterations);
+    const calls = tape.turns[0].iterations.reduce((a, i) => a + i.toolCalls.length, 0);
+    expect(calls).toBe(expected.tapeStats.totalToolCalls);
+  });
+
+  it("fires guard_triggered('stuck_loop') after the third identical call", async () => {
+    const r = await runTape(tape, { model: "fake-model" });
+    assertExpected(r.observability, r.unconsumedResults, r.tapeExhausted, expected);
+    // Iter 3 must abort BEFORE tool execution, so only iters 1+2 run tools.
+    expect(r.executionLog.length).toBe(2);
+  });
+});
+
+describe("synthesised replay — env-error-loop guard", () => {
+  const { tape, expected } = loadTape("env-error-loop");
+
+  it("parses to 1 turn × 3 iterations × 3 tool calls", () => {
+    expect(tape.turns).toHaveLength(expected.tapeStats.turns);
+    expect(tape.turns[0].iterations).toHaveLength(expected.tapeStats.totalIterations);
+  });
+
+  it("fires guard_triggered('env_error_loop') after EPERM appears in 3 consecutive turns", async () => {
+    const r = await runTape(tape, { model: "fake-model" });
+    assertExpected(r.observability, r.unconsumedResults, r.tapeExhausted, expected);
+    // Unlike stuck-loop, env-error fires AFTER tool execution, so all 3
+    // tool calls run.
+    expect(r.executionLog.length).toBe(3);
+  });
+
+  it("does not also fire stuck_loop (args differ across iterations)", async () => {
+    const r = await runTape(tape, { model: "fake-model" });
+    const guards = eventsOfType(r.observability, "guard_triggered");
+    expect(guards.map((g) => g.guard)).toEqual(["env_error_loop"]);
+  });
+});
+
+describe("synthesised replay — nested compaction (programmatic, large payload)", () => {
+  /** Three react-mode turns. Turn 1 fills context with 5 × 100 k char
+   *  tool_results so post-first-compaction the tail (which always
+   *  contains 4 large user-result messages by the time turn 3 begins)
+   *  is still above the 75 k token threshold and a second auto-compact
+   *  fires — that's the "nested" case where the original task block
+   *  must survive an earlier summary. */
+  function nestedTape(): Tape {
+    const chunk = "x".repeat(100_000);
+    const tools: LLMIteration[] = [];
+    for (let i = 0; i < 5; i++) {
+      tools.push(
+        iter(
+          "",
+          [{ name: "read", args: { file_path: `f${i}.txt` } }],
+          [{ name: "read", result: chunk }],
+        ),
+      );
+    }
+    return {
+      source: "synth-nested-compaction",
+      turns: [
+        {
+          userInput: "round 1: read the big files",
+          mode: "react",
+          iterations: [...tools, iter("done 1.")],
+        },
+        {
+          userInput: "round 2: continue",
+          mode: "react",
+          iterations: [
+            iter(
+              "",
+              [{ name: "read", args: { file_path: "small1" } }],
+              [{ name: "read", result: "tiny" }],
+            ),
+            iter("done 2."),
+          ],
+        },
+        {
+          userInput: "round 3: keep going",
+          mode: "react",
+          iterations: [
+            iter(
+              "",
+              [{ name: "read", args: { file_path: "small2" } }],
+              [{ name: "read", result: "tiny" }],
+            ),
+            iter("done 3."),
+          ],
+        },
+      ],
+    };
+  }
+
+  it("fires compact_started TWICE (one nested), each paired with compact_completed", async () => {
+    const r = await runTape(nestedTape(), { model: "fake-model" });
+    expect(countOfType(r.observability, "compact_started")).toBe(2);
+    expect(countOfType(r.observability, "compact_completed")).toBe(2);
+    expect(countOfType(r.observability, "compact_failed")).toBe(0);
+    const resolutions = compactStartedResolutions(r.observability);
+    expect(resolutions).toHaveLength(2);
+    for (const res of resolutions) {
+      expect(res.resolved?.type).toBe("compact_completed");
+      if (res.resolved?.type === "compact_completed") {
+        expect(res.resolved.messagesRemoved).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("preserves the original task across nested compactions (prune-anchor contract)", async () => {
+    const r = await runTape(nestedTape(), { model: "fake-model" });
+    // After 2 compactions, the LAST stream() call's `messages` arg must
+    // still carry the original task — either inline as the first user
+    // message or embedded in a summary message's verbatim block. We check
+    // the simpler property: some message contains the literal user input
+    // from turn 1.
+    const last = r.sentMessages[r.sentMessages.length - 1];
+    const concatText = last.messages
+      .flatMap((m) => m.parts)
+      .filter((p) => p.type === "text")
+      .map((p) => (p as { type: "text"; text: string }).text)
+      .join("\n");
+    expect(concatText).toContain("round 1: read the big files");
+  });
+
+  it("the second compaction is provably nested — fires only after the first compaction completed", async () => {
+    const r = await runTape(nestedTape(), { model: "fake-model" });
+    const starts = r.observability
+      .map((e, i) => ({ i, e }))
+      .filter(({ e }) => e.type === "compact_started");
+    expect(starts).toHaveLength(2);
+    const firstCompletedIdx = r.observability.findIndex((e) => e.type === "compact_completed");
+    expect(firstCompletedIdx).toBeGreaterThanOrEqual(0);
+    expect(starts[1].i).toBeGreaterThan(firstCompletedIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Implements PR 3 of the D2 plan ([`docs/design/d2-context-management-replay.md`](docs/design/d2-context-management-replay.md)): the three synthesised edge-case scenarios the real `card_trade` tape doesn't exercise.

## Format decision

Two cases land as **committed JSONL** under `src/eval/replay-tapes/synthesized/` (small enough for reviewers to inspect on PR diff). One case lives **programmatically** in `synthesized.test.ts` because its synthetic payload would otherwise bloat the repo by ~500 KB for zero inspection value. Design doc updated to document this split.

## What landed

| Tape | Format | Asserts |
|---|---|---|
| `stuck-loop` | JSONL (6 entries) | Three identical `(name, args)` tool calls in a row fire `guard_triggered('stuck_loop')` after the third recurrence. Iter 3 aborts **before** tool execution (only iters 1+2 run tools). |
| `env-error-loop` | JSONL (7 entries) | Three iterations whose `tool_result`s contain `EPERM` with **different** args (so stuck-loop does NOT also fire) trigger `guard_triggered('env_error_loop')` after the third. All 3 tool calls execute — the guard fires **after** tool execution. |
| Nested compaction | Programmatic | Five × 100 KB `read` results in turn 1 → post-first-compaction tail (4 large messages preserved by `KEEP_RECENT=10`) is **still** above the 75 k token threshold → second auto-compact fires at turn 3 entry. Asserts: `compact_started` fires twice paired with `compact_completed`; second start fires *after* first completes; original user input survives both compactions via the prune-anchor verbatim block in `extractOriginalTask`. |

## What this finishes from D2

This closes the context-management replay sub-item of D2. The other items in the D2 row of the roadmap (sandbox / plan-mode / HITL contract evals) remain open and will be tracked as separate work.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — 719 passing (+8 from this PR)
- [x] All three new synthesised cases pass cleanly with no flakes across 10 local runs
- [ ] Reviewer: scan `synthesized.test.ts` lines 122–217 (nested-compaction case) — the token math is load-bearing and depends on `KEEP_RECENT=10`, `DEFAULT_CONTEXT_WINDOW=100_000`, and the 0.75 trigger ratio all staying as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)