### PR TITLE
docs(D2): flip replay sub-item status to Implemented; link tracking issue for remaining surfaces

### DIFF
--- a/docs/design/d2-context-management-replay.md
+++ b/docs/design/d2-context-management-replay.md
@@ -1,6 +1,6 @@
 # Design: D2 — Context-management replay (session-tape contract eval)
 
-_Status: Ready for implementation. Phase: [Roadmap D2](../roadmap.md#phase-d--evaluation). Sibling of [D1](./d1-eval-harness.md)._
+_Status: Implemented — replay harness skeleton merged in [`bb8fe3f`](https://github.com/zjshen14/opencli/commit/bb8fe3f) (#229, 2026-06-06); real card_trade tape + redaction in [`99b4905`](https://github.com/zjshen14/opencli/commit/99b4905) (#231) and [`acfd4da`](https://github.com/zjshen14/opencli/commit/acfd4da) (#232, 2026-06-07); synthesised edge-case tapes in [`cc01444`](https://github.com/zjshen14/opencli/commit/cc01444) (#233, 2026-06-07). Other D2 contract evals (sandbox / plan-mode / HITL / headless schema) tracked in [#234](https://github.com/zjshen14/opencli/issues/234). Phase: [Roadmap D2](../roadmap.md#phase-d--evaluation). Sibling of [D1](./d1-eval-harness.md)._
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,7 +78,7 @@ See [`docs/evaluation.md`](evaluation.md) for the full strategy, scoring rubric,
 |---|---|---|
 | **D0** | **Eval foundation** | Now — document current coverage; publish rubric |
 | **D1** | **Scenario suite + provider parity matrix** | Before Phase B — 20 tasks × N providers in CI; parity baseline must exist before B-work begins. First baseline published 2026-06-01: [`docs/eval/baseline-2026-06-01.md`](eval/baseline-2026-06-01.md) (Gemini only; Anthropic + OpenAI columns pending repo secrets). |
-| **D2** | **Contract evals** (sandbox, plan mode, HITL, headless schema, **context-management replay**) | Alongside A6 — all A-phase properties must be testable before A closes. Context-management replay design: [`docs/design/d2-context-management-replay.md`](design/d2-context-management-replay.md). |
+| **D2** | **Contract evals** (sandbox, plan mode, HITL, headless schema, **context-management replay**) | Alongside A6 — all A-phase properties must be testable before A closes. Context-management replay shipped 2026-06-06/07 via #229 + #231 + #232 + #233 — see [`docs/design/d2-context-management-replay.md`](design/d2-context-management-replay.md). Remaining contract evals tracked in [#234](https://github.com/zjshen14/opencli/issues/234). |
 | **D3** | **SWE-bench Verified harness** | After B5a — stable default config needed before publishing a number |
 | **D4** | **Custom cross-vendor routing benchmark** | After B5b — publishable artifact comparing single-vendor vs cross-vendor routing |
 


### PR DESCRIPTION
## Summary

Follow-up to PR #233 (noted in [the PR review](https://github.com/zjshen14/opencli/pull/233#issuecomment-from-zjshen14)). [CLAUDE.md convention](../blob/main/CLAUDE.md#issue-management--branching) says design-doc \`_Status:\` lines must never read *"Ready for implementation"* for code already on main. The replay sub-item of D2 shipped across **#229 + #231 + #232 + #233** on 2026-06-06/07.

## What changed

- [`docs/design/d2-context-management-replay.md`](docs/design/d2-context-management-replay.md) — `_Status:` line now records all four merge SHAs/PRs and references **#234** (the new tracking issue for the other D2 contract-eval surfaces: sandbox, plan-mode, HITL, headless schema).
- [`docs/roadmap.md`](docs/roadmap.md) — D2 row now notes the replay sub-item shipped and points to **#234** for the remainder.

## What this closes

The end of the D2 replay arc. Future D2 work (the four open contract-eval surfaces) is tracked in #234 as separate small PRs, sequenced to land before A6 closes Phase A.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check` — clean
- [x] All four referenced merge SHAs verified present on main (`bb8fe3f`, `99b4905`, `acfd4da`, `cc01444`)
- [x] Issue #234 exists and references this design doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)