### PR TITLE
feat(eval): add plan-mode and HITL contract evals (D2 follow-up)

### DIFF
--- a/src/eval/replay-tapes/README.md
+++ b/src/eval/replay-tapes/README.md
@@ -31,6 +31,14 @@ Two hand-written JSONL tapes covering safety-guard behaviours the real card_trad
 | `stuck-loop` | Three identical (name, args) tool calls in a row fire `guard_triggered('stuck_loop')`. Only iters 1+2 execute — iter 3 aborts before tool execution. |
 | `env-error-loop` | Three consecutive tool results containing `EPERM` fire `guard_triggered('env_error_loop')`. All three iters execute; the guard fires AFTER the third. Args differ across iters so stuck-loop does not also fire. |
 
+### `synthesized/plan-mode-write-block`
+
+A hand-written JSONL tape covering the plan-mode contract. Driven by [`src/eval/replay/contract.test.ts`](../replay/contract.test.ts).
+
+| Tape | Asserts |
+|---|---|
+| `plan-mode-write-block` | A `/plan`-prefixed turn containing a `write` call fires `tool_denied(plan_mode)` and produces zero `tool_exec_start` events — the write never reaches the registry. |
+
 ### Nested compaction (programmatic, lives in `synthesized.test.ts`)
 
 The third synthesised case — two compactions in one replay, the second one nested inside the prune anchor preserved by the first — needs ≥ 500 KB of synthetic content (5 × 100 KB `read` results) to push the agent above the 75 % auto-compact threshold twice. Committing that as JSONL would bloat the repo for zero inspection value, so the tape is generated programmatically in the test. The assertion checks that the original user input survives both compactions via the verbatim-block anchor preservation in `extractOriginalTask`.

--- a/src/eval/replay-tapes/synthesized/plan-mode-write-block.expected.json
+++ b/src/eval/replay-tapes/synthesized/plan-mode-write-block.expected.json
@@ -1,0 +1,27 @@
+{
+  "source": "synthesised — plan mode blocks write tool; tool_denied(plan_mode) must fire, no tool_exec_start",
+  "tapeStats": {
+    "turns": 1,
+    "totalIterations": 2,
+    "totalToolCalls": 1
+  },
+  "observability": {
+    "exact": {
+      "tool_exec_start": 0,
+      "tool_exec_end": 0,
+      "tool_denied": 1,
+      "llm_call_start": 2,
+      "llm_call_end": 2
+    }
+  },
+  "cleanExit": {
+    "tapeExhausted": true,
+    "unconsumedResults": 0
+  },
+  "toolDenied": [
+    {
+      "name": "write",
+      "reason": "plan_mode"
+    }
+  ]
+}

--- a/src/eval/replay-tapes/synthesized/plan-mode-write-block.jsonl
+++ b/src/eval/replay-tapes/synthesized/plan-mode-write-block.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","content":"/plan create a new output file","timestamp":"2026-06-01T00:00:00.000Z"}
+{"type":"tool_call","name":"write","args":{"file_path":"output.ts","content":"const x = 1;"},"timestamp":"2026-06-01T00:00:01.000Z"}
+{"type":"assistant","content":"I see that write is unavailable in plan mode. Here is my plan: step 1 — create output.ts with const x = 1.","timestamp":"2026-06-01T00:00:02.000Z"}

--- a/src/eval/replay/contract.test.ts
+++ b/src/eval/replay/contract.test.ts
@@ -1,0 +1,175 @@
+/**
+ * D2 contract evals — plan-mode and HITL surfaces.
+ *
+ * Plan-mode contract: assert that when agent.run() receives mode="plan",
+ * the executor denies write-tool calls (tool_denied reason="plan_mode")
+ * before they reach the registry. Tests two layers of the plan-mode defence:
+ *   1. Executor readOnly guard — verified here via tool_denied events.
+ *   2. Tool-definition filtering — write is absent from toolDefinitions sent
+ *      to the LLM in plan mode; the TapeClient ignores toolDefs so this layer
+ *      is not directly assertable from replay, but the executor layer is the
+ *      stronger safety property.
+ *
+ * HITL contract: assert that tool_denied fires with the correct reason when
+ * a tool is gated behind a confirmFn:
+ *   - "user_denied"    — confirmFn present, returns "deny"
+ *   - "non_interactive" — no confirmFn (headless / non-interactive context)
+ *   - tool allowed     — confirmFn present, returns "allow" → tool executes normally
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { parseJsonlString, buildTape } from "./tape.js";
+import type { Tape, LLMIteration } from "./tape.js";
+import { runTape } from "./runner.js";
+import { countOfType, eventsOfType } from "./assertions.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TAPES = join(HERE, "..", "replay-tapes", "synthesized");
+
+function iter(
+  text: string,
+  toolCalls: { name: string; args?: Record<string, unknown> }[] = [],
+  toolResults: { name: string; result: string }[] = [],
+): LLMIteration {
+  return {
+    text,
+    toolCalls: toolCalls.map((c) => ({ name: c.name, args: c.args ?? {} })),
+    toolResults,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plan-mode contract eval
+// ---------------------------------------------------------------------------
+
+describe("plan-mode contract — executor blocks write tools", () => {
+  const jsonl = readFileSync(join(TAPES, "plan-mode-write-block.jsonl"), "utf8");
+  const entries = parseJsonlString(jsonl);
+  const tape = buildTape(entries, "plan-mode-write-block");
+
+  it("tape parses to 1 plan-mode turn × 2 iterations × 1 tool call", () => {
+    expect(tape.turns).toHaveLength(1);
+    expect(tape.turns[0].mode).toBe("plan");
+    expect(tape.turns[0].iterations).toHaveLength(2);
+    expect(tape.turns[0].iterations[0].toolCalls).toHaveLength(1);
+    expect(tape.turns[0].iterations[0].toolCalls[0].name).toBe("write");
+  });
+
+  it("fires tool_denied(plan_mode) for the write call and never executes it", async () => {
+    const r = await runTape(tape, { model: "fake-model" });
+
+    const denied = eventsOfType(r.observability, "tool_denied");
+    expect(denied).toHaveLength(1);
+    expect(denied[0].name).toBe("write");
+    expect(denied[0].reason).toBe("plan_mode");
+
+    // write must not reach the registry
+    expect(countOfType(r.observability, "tool_exec_start")).toBe(0);
+    expect(countOfType(r.observability, "tool_exec_end")).toBe(0);
+    expect(r.executionLog).toHaveLength(0);
+  });
+
+  it("completes the tape cleanly — both LLM iterations consumed, no queued results left", async () => {
+    const r = await runTape(tape, { model: "fake-model" });
+    expect(r.tapeExhausted).toBe(true);
+    expect(r.unconsumedResults).toBe(0);
+    expect(countOfType(r.observability, "llm_call_start")).toBe(2);
+  });
+
+  it("no guards fire (write denial is not a guard — it is executor enforcement)", async () => {
+    const r = await runTape(tape, { model: "fake-model" });
+    expect(countOfType(r.observability, "guard_triggered")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HITL contract evals
+// ---------------------------------------------------------------------------
+
+function hitlTape(includeResult: boolean): Tape {
+  const callIter = iter(
+    "",
+    [{ name: "bash", args: { command: "echo hello" } }],
+    includeResult ? [{ name: "bash", result: "hello" }] : [],
+  );
+  return {
+    source: includeResult ? "synth-hitl-allow" : "synth-hitl-deny",
+    turns: [
+      {
+        userInput: "run a command",
+        mode: "react",
+        iterations: [callIter, iter("Done.")],
+      },
+    ],
+  };
+}
+
+describe("HITL contract — confirmFn deny → tool_denied(user_denied)", () => {
+  it("fires tool_denied(user_denied) and does not execute the tool", async () => {
+    const r = await runTape(hitlTape(false), {
+      model: "fake-model",
+      forcesConfirmation: (name) => name === "bash",
+      confirmFn: async () => "deny",
+    });
+
+    const denied = eventsOfType(r.observability, "tool_denied");
+    expect(denied).toHaveLength(1);
+    expect(denied[0].name).toBe("bash");
+    expect(denied[0].reason).toBe("user_denied");
+
+    expect(countOfType(r.observability, "tool_exec_start")).toBe(0);
+    expect(r.executionLog).toHaveLength(0);
+  });
+
+  it("tape exhausted cleanly — denial result feeds back to LLM for the second iteration", async () => {
+    const r = await runTape(hitlTape(false), {
+      model: "fake-model",
+      forcesConfirmation: (name) => name === "bash",
+      confirmFn: async () => "deny",
+    });
+    expect(r.tapeExhausted).toBe(true);
+    expect(r.unconsumedResults).toBe(0);
+  });
+});
+
+describe("HITL contract — no confirmFn (non-interactive) → tool_denied(non_interactive)", () => {
+  it("fires tool_denied(non_interactive) when confirmFn is absent", async () => {
+    const r = await runTape(hitlTape(false), {
+      model: "fake-model",
+      forcesConfirmation: (name) => name === "bash",
+      // intentionally no confirmFn
+    });
+
+    const denied = eventsOfType(r.observability, "tool_denied");
+    expect(denied).toHaveLength(1);
+    expect(denied[0].name).toBe("bash");
+    expect(denied[0].reason).toBe("non_interactive");
+  });
+});
+
+describe("HITL contract — confirmFn allow → tool executes normally", () => {
+  it("does not fire tool_denied and executes the tool when confirmFn returns allow", async () => {
+    const r = await runTape(hitlTape(true), {
+      model: "fake-model",
+      forcesConfirmation: (name) => name === "bash",
+      confirmFn: async () => "allow",
+    });
+
+    expect(countOfType(r.observability, "tool_denied")).toBe(0);
+    expect(countOfType(r.observability, "tool_exec_start")).toBe(1);
+    expect(r.executionLog).toHaveLength(1);
+    expect(r.executionLog[0].name).toBe("bash");
+  });
+
+  it("tape exhausted cleanly", async () => {
+    const r = await runTape(hitlTape(true), {
+      model: "fake-model",
+      forcesConfirmation: (name) => name === "bash",
+      confirmFn: async () => "allow",
+    });
+    expect(r.tapeExhausted).toBe(true);
+    expect(r.unconsumedResults).toBe(0);
+  });
+});

--- a/src/eval/replay/runner.ts
+++ b/src/eval/replay/runner.ts
@@ -17,6 +17,7 @@ import type { AgentEvent } from "../../core/agent.js";
 import type { ObservabilityEvent } from "../../core/observability.js";
 import type { LLMClient } from "../../providers/client.js";
 import type { StreamEvent } from "../../providers/types.js";
+import type { ConfirmFn } from "../../core/executor.js";
 import { SkillRegistry } from "../../skills/registry.js";
 import { TapeClient, type SentMessages } from "./client.js";
 import { TapeRegistry } from "./registry.js";
@@ -74,6 +75,13 @@ export interface RunTapeOptions {
   /** Override the system instruction (default empty — replay does not
    *  exercise the system prompt). */
   systemInstruction?: string;
+  /** Inject a confirmFn into the agent — used by HITL contract evals to
+   *  drive allow/deny decisions without an interactive terminal. */
+  confirmFn?: ConfirmFn;
+  /** Inject a forcesConfirmation predicate — marks specific tools as
+   *  requiring confirmation in tapes where TapeRegistry stubs have no
+   *  requiresConfirmation of their own. */
+  forcesConfirmation?: (toolName: string, args: Record<string, unknown>) => boolean;
 }
 
 export async function runTape(tape: Tape, opts: RunTapeOptions): Promise<ReplayResult> {
@@ -98,6 +106,9 @@ export async function runTape(tape: Tape, opts: RunTapeOptions): Promise<ReplayR
       autoCompact: opts.autoCompact !== false,
     },
   );
+
+  if (opts.confirmFn) agent.setConfirmFn(opts.confirmFn);
+  if (opts.forcesConfirmation) agent.setForcesConfirmationFn(opts.forcesConfirmation);
 
   for (const turn of tape.turns) {
     for await (const event of agent.run(turn.userInput, turn.mode)) {


### PR DESCRIPTION
## Summary

- Extends `RunTapeOptions` in the replay harness with `confirmFn?` and `forcesConfirmation?` so contract evals can drive HITL decisions without an interactive terminal.
- Adds a synthesised JSONL tape (`plan-mode-write-block`) whose single `/plan`-prefixed turn contains a `write` call, proving the executor's `readOnly` guard fires before the call reaches the registry.
- Adds `src/eval/replay/contract.test.ts` with 9 tests covering two D2 contract surfaces: plan-mode write-blocking and the three HITL paths (user_denied, non_interactive, allow).

## Related issue

Closes #234

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (713 tests, 9 new)
- [x] Plan-mode: `tool_denied(plan_mode)` fires, `tool_exec_start` count is 0, tape exhausted cleanly
- [x] HITL deny: `tool_denied(user_denied)` fires when `confirmFn` returns `"deny"`
- [x] HITL non-interactive: `tool_denied(non_interactive)` fires when no `confirmFn` is provided
- [x] HITL allow: no denial, `tool_exec_start` fires once when `confirmFn` returns `"allow"`

https://claude.ai/code/session_01HRHNetsbTUajSxK33fby1u

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRHNetsbTUajSxK33fby1u)_