### PR TITLE
fix: return synthetic functionResponse for activate_skill to keep conversation well-formed

### DIFF
--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Agent } from "./agent.js";
 import { ToolRegistry } from "../tools/registry.js";
 import { SkillRegistry } from "../skills/registry.js";
@@ -526,44 +526,6 @@ describe("Agent stuck-loop detection", () => {
   });
 });
 
-describe("Agent activate_skill — conversation well-formedness", () => {
-  it("includes a function_result for activate_skill in the next LLM call's messages", async () => {
-    // If the model calls activate_skill and no FunctionResultPart is produced,
-    // the conversation sent to the next stream() call has an orphaned functionCall
-    // with no matching functionResponse — Gemini/Anthropic return 400.
-    let callCount = 0;
-    let secondCallMessages: Message[] = [];
-
-    const client: LLMClient = {
-      async *stream(messages: Message[], _sys: string, _tools: ToolDefinition[]) {
-        callCount++;
-        if (callCount === 1) {
-          yield {
-            type: "function_call",
-            id: "skill-call-1",
-            name: "activate_skill",
-            args: { name: "review" },
-          } as StreamEvent;
-          yield { type: "done" } as StreamEvent;
-        } else {
-          secondCallMessages = messages;
-          yield { type: "text", text: "ok" } as StreamEvent;
-          yield { type: "done" } as StreamEvent;
-        }
-      },
-    };
-
-    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry());
-    await collectEvents(agent, "review the code");
-
-    expect(callCount).toBe(2);
-    const hasActivateSkillResult = secondCallMessages.some((m) =>
-      m.parts.some((p) => p.type === "function_result" && p.name === "activate_skill"),
-    );
-    expect(hasActivateSkillResult).toBe(true);
-  });
-});
-
 describe("Agent auto-compact (A5b)", () => {
   // Returns a quiet finishing client so each agent.run() emits no tool calls
   // and ends cleanly with a "done" event. The point of these tests is the
@@ -798,5 +760,50 @@ describe("Agent auto-compact (A5b)", () => {
     ]);
     await collectEvents(agent, "second");
     expect(events.filter((e) => e.type === "compact_threshold_warned")).toHaveLength(2);
+  });
+});
+
+describe("Agent activate_skill — conversation well-formedness", () => {
+  it("includes a function_result for activate_skill in the next LLM call's messages", async () => {
+    const captured: Message[][] = [];
+    let callCount = 0;
+    const client: LLMClient = {
+      async *stream(messages: Message[]) {
+        captured.push(messages);
+        callCount++;
+        if (callCount === 1) {
+          yield {
+            type: "function_call",
+            id: "skill-call-1",
+            name: "activate_skill",
+            args: { name: "review" },
+          } as StreamEvent;
+        }
+        yield { type: "done" } as StreamEvent;
+      },
+    };
+
+    const skillRegistry = {
+      load: vi.fn(async () => "Review instructions."),
+      has: vi.fn(),
+      list: vi.fn(() => []),
+      get: vi.fn(),
+      discover: vi.fn(),
+      catalogSummary: vi.fn(() => ""),
+    } as unknown as SkillRegistry;
+
+    const agent = new Agent(client, makeNoopRegistry(), skillRegistry);
+    await collectEvents(agent, "do a review");
+
+    // The second LLM call must receive a user message with a function_result
+    // for activate_skill — without it Gemini/Anthropic return 400 Bad Request.
+    expect(captured.length).toBeGreaterThanOrEqual(2);
+    const secondCallMessages = captured[1];
+    const lastUserMsg = [...secondCallMessages].reverse().find((m) => m.role === "user");
+    expect(lastUserMsg).toBeDefined();
+    const hasFnResult = lastUserMsg!.parts.some(
+      (p) => p.type === "function_result" && (p as { name: string }).name === "activate_skill",
+    );
+    expect(hasFnResult).toBe(true);
   });
 });

--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -526,6 +526,44 @@ describe("Agent stuck-loop detection", () => {
   });
 });
 
+describe("Agent activate_skill — conversation well-formedness", () => {
+  it("includes a function_result for activate_skill in the next LLM call's messages", async () => {
+    // If the model calls activate_skill and no FunctionResultPart is produced,
+    // the conversation sent to the next stream() call has an orphaned functionCall
+    // with no matching functionResponse — Gemini/Anthropic return 400.
+    let callCount = 0;
+    let secondCallMessages: Message[] = [];
+
+    const client: LLMClient = {
+      async *stream(messages: Message[], _sys: string, _tools: ToolDefinition[]) {
+        callCount++;
+        if (callCount === 1) {
+          yield {
+            type: "function_call",
+            id: "skill-call-1",
+            name: "activate_skill",
+            args: { name: "review" },
+          } as StreamEvent;
+          yield { type: "done" } as StreamEvent;
+        } else {
+          secondCallMessages = messages;
+          yield { type: "text", text: "ok" } as StreamEvent;
+          yield { type: "done" } as StreamEvent;
+        }
+      },
+    };
+
+    const agent = new Agent(client, makeNoopRegistry(), new SkillRegistry());
+    await collectEvents(agent, "review the code");
+
+    expect(callCount).toBe(2);
+    const hasActivateSkillResult = secondCallMessages.some((m) =>
+      m.parts.some((p) => p.type === "function_result" && p.name === "activate_skill"),
+    );
+    expect(hasActivateSkillResult).toBe(true);
+  });
+});
+
 describe("Agent auto-compact (A5b)", () => {
   // Returns a quiet finishing client so each agent.run() emits no tool calls
   // and ends cleanly with a "done" event. The point of these tests is the

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -255,7 +255,7 @@ export class Agent {
         stuckCount = 1;
       }
 
-      const { results } = await executeCalls(pendingCalls, {
+      const { results, skillResults } = await executeCalls(pendingCalls, {
         tools: this.tools,
         skills: this.skills,
         context: this.context,
@@ -328,10 +328,14 @@ export class Agent {
         yield { type: "tool_result", name: result.name, result: result.result };
       }
 
-      if (results.length > 0) {
+      // skillResults are added to context for conversation well-formedness but
+      // not yielded as tool_result events — skill activation is already surfaced
+      // via the skill_activated event above.
+      const allParts = [...skillResults, ...results];
+      if (allParts.length > 0) {
         this.context.addMessage({
           role: "user",
-          parts: results,
+          parts: allParts,
         });
       }
     }

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -328,14 +328,11 @@ export class Agent {
         yield { type: "tool_result", name: result.name, result: result.result };
       }
 
-      // skillResults are added to context for conversation well-formedness but
-      // not yielded as tool_result events — skill activation is already surfaced
-      // via the skill_activated event above.
-      const allParts = [...skillResults, ...results];
-      if (allParts.length > 0) {
+      const allResultParts = [...skillResults, ...results];
+      if (allResultParts.length > 0) {
         this.context.addMessage({
           role: "user",
-          parts: allParts,
+          parts: allResultParts,
         });
       }
     }

--- a/src/core/executor.test.ts
+++ b/src/core/executor.test.ts
@@ -212,38 +212,44 @@ describe("executeCalls", () => {
     expect(results[0].result).toContain("Error: Exited with code 1");
   });
 
-  it("activates a skill, injects into context, and returns a synthetic skillResult", async () => {
+  it("activates a skill and produces a synthetic skillResult (no regular tool result)", async () => {
     const context = new ContextManager();
     const skillRegistry = makeSkillRegistry({ review: "Review instructions." });
 
     const { results, skillResults } = await executeCalls(
       [makeToolCall("activate_skill", { name: "review" })],
-      { tools: new ToolRegistry(), skills: skillRegistry, context },
+      {
+        tools: new ToolRegistry(),
+        skills: skillRegistry,
+        context,
+      },
     );
 
-    // No regular tool result — activate_skill is not a registry tool
+    // activate_skill does not produce a regular tool result
     expect(results).toHaveLength(0);
-    // Synthetic result keeps the conversation well-formed (providers require a
-    // functionResponse for every functionCall in the preceding model turn).
+    // but does produce a synthetic function_result to keep history well-formed
     expect(skillResults).toHaveLength(1);
     expect(skillResults[0].name).toBe("activate_skill");
-    expect(skillResults[0].result).toContain("review");
+    expect(skillResults[0].id).toBe("call-1");
     expect(context.hasSkill("review")).toBe(true);
   });
 
-  it("does not re-activate an already active skill but still returns a synthetic skillResult", async () => {
+  it("does not re-activate an already active skill", async () => {
     const context = new ContextManager();
     context.addSkillContent("review", "Already active.");
     const skillRegistry = makeSkillRegistry({ review: "Review instructions." });
 
     const { skillResults } = await executeCalls(
       [makeToolCall("activate_skill", { name: "review" })],
-      { tools: new ToolRegistry(), skills: skillRegistry, context },
+      {
+        tools: new ToolRegistry(),
+        skills: skillRegistry,
+        context,
+      },
     );
 
     expect(skillRegistry.load).not.toHaveBeenCalled();
-    // functionResponse is still needed for conversation well-formedness even
-    // when the skill was already loaded.
+    // synthetic function_result is still produced even when skill was already active
     expect(skillResults).toHaveLength(1);
   });
 

--- a/src/core/executor.test.ts
+++ b/src/core/executor.test.ts
@@ -212,33 +212,39 @@ describe("executeCalls", () => {
     expect(results[0].result).toContain("Error: Exited with code 1");
   });
 
-  it("activates a skill and injects into context (no tool result)", async () => {
+  it("activates a skill, injects into context, and returns a synthetic skillResult", async () => {
     const context = new ContextManager();
     const skillRegistry = makeSkillRegistry({ review: "Review instructions." });
 
-    const { results } = await executeCalls([makeToolCall("activate_skill", { name: "review" })], {
-      tools: new ToolRegistry(),
-      skills: skillRegistry,
-      context,
-    });
+    const { results, skillResults } = await executeCalls(
+      [makeToolCall("activate_skill", { name: "review" })],
+      { tools: new ToolRegistry(), skills: skillRegistry, context },
+    );
 
-    // activate_skill does not produce a tool result
+    // No regular tool result — activate_skill is not a registry tool
     expect(results).toHaveLength(0);
+    // Synthetic result keeps the conversation well-formed (providers require a
+    // functionResponse for every functionCall in the preceding model turn).
+    expect(skillResults).toHaveLength(1);
+    expect(skillResults[0].name).toBe("activate_skill");
+    expect(skillResults[0].result).toContain("review");
     expect(context.hasSkill("review")).toBe(true);
   });
 
-  it("does not re-activate an already active skill", async () => {
+  it("does not re-activate an already active skill but still returns a synthetic skillResult", async () => {
     const context = new ContextManager();
     context.addSkillContent("review", "Already active.");
     const skillRegistry = makeSkillRegistry({ review: "Review instructions." });
 
-    await executeCalls([makeToolCall("activate_skill", { name: "review" })], {
-      tools: new ToolRegistry(),
-      skills: skillRegistry,
-      context,
-    });
+    const { skillResults } = await executeCalls(
+      [makeToolCall("activate_skill", { name: "review" })],
+      { tools: new ToolRegistry(), skills: skillRegistry, context },
+    );
 
     expect(skillRegistry.load).not.toHaveBeenCalled();
+    // functionResponse is still needed for conversation well-formedness even
+    // when the skill was already loaded.
+    expect(skillResults).toHaveLength(1);
   });
 
   it("truncates bash output exceeding the limit (middle-truncation)", async () => {

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -62,11 +62,9 @@ export function truncateOutput(output: string, callId: string, tmpDir?: string):
 
 export interface ExecutionResult {
   results: FunctionResultPart[];
-  /** Synthetic function_results for activate_skill calls. Providers (Gemini,
-   *  Anthropic) require a functionResponse for every functionCall in the
-   *  preceding model turn — without these the next API call returns 400.
-   *  Kept separate from results so the agent loop can add them to context
-   *  without surfacing them as tool_result events. */
+  // Synthetic function_result entries for activate_skill calls — not surfaced as
+  // tool_result events but required so every functionCall has a matching
+  // functionResponse in the conversation history (Gemini/Anthropic require this).
   skillResults: FunctionResultPart[];
 }
 
@@ -151,7 +149,9 @@ export async function executeCalls(
   const skillCalls = calls.filter((c) => c.name === "activate_skill");
   const toolCalls = calls.filter((c) => c.name !== "activate_skill");
 
-  // Handle skill activations (context mutation)
+  // Handle skill activations: mutate context and build synthetic function_result
+  // entries so every functionCall has a matching functionResponse in history.
+  const skillResults: FunctionResultPart[] = [];
   for (const call of skillCalls) {
     const name = call.args.name as string;
     if (!deps.context.hasSkill(name)) {
@@ -160,21 +160,15 @@ export async function executeCalls(
         deps.context.addSkillContent(name, body);
       }
     }
-  }
-
-  // Build synthetic function_results for each skill activation. Providers
-  // require a functionResponse for every functionCall in the preceding model
-  // turn — without these the next API call returns 400.
-  const skillResults: FunctionResultPart[] = skillCalls.map((call) => {
     const sig = call.thoughtSignature ? { thoughtSignature: call.thoughtSignature } : {};
-    return {
+    skillResults.push({
       type: "function_result",
       id: call.id,
       name: call.name,
-      result: `Skill "${call.args.name as string}" activated.`,
+      result: "Skill activated.",
       ...sig,
-    };
-  });
+    });
+  }
 
   // If any call mutates state, execute all sequentially in declared order to
   // prevent race conditions (e.g. two edits to the same file, or a write

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -62,7 +62,12 @@ export function truncateOutput(output: string, callId: string, tmpDir?: string):
 
 export interface ExecutionResult {
   results: FunctionResultPart[];
-  // Skill activations return no tool result — they mutate context directly
+  /** Synthetic function_results for activate_skill calls. Providers (Gemini,
+   *  Anthropic) require a functionResponse for every functionCall in the
+   *  preceding model turn — without these the next API call returns 400.
+   *  Kept separate from results so the agent loop can add them to context
+   *  without surfacing them as tool_result events. */
+  skillResults: FunctionResultPart[];
 }
 
 async function executeOneCall(
@@ -146,7 +151,7 @@ export async function executeCalls(
   const skillCalls = calls.filter((c) => c.name === "activate_skill");
   const toolCalls = calls.filter((c) => c.name !== "activate_skill");
 
-  // Handle skill activations (context mutation, no tool result needed)
+  // Handle skill activations (context mutation)
   for (const call of skillCalls) {
     const name = call.args.name as string;
     if (!deps.context.hasSkill(name)) {
@@ -156,6 +161,20 @@ export async function executeCalls(
       }
     }
   }
+
+  // Build synthetic function_results for each skill activation. Providers
+  // require a functionResponse for every functionCall in the preceding model
+  // turn — without these the next API call returns 400.
+  const skillResults: FunctionResultPart[] = skillCalls.map((call) => {
+    const sig = call.thoughtSignature ? { thoughtSignature: call.thoughtSignature } : {};
+    return {
+      type: "function_result",
+      id: call.id,
+      name: call.name,
+      result: `Skill "${call.args.name as string}" activated.`,
+      ...sig,
+    };
+  });
 
   // If any call mutates state, execute all sequentially in declared order to
   // prevent race conditions (e.g. two edits to the same file, or a write
@@ -175,5 +194,5 @@ export async function executeCalls(
     results = await Promise.all(toolCalls.map((call) => executeOneCall(call, deps)));
   }
 
-  return { results };
+  return { results, skillResults };
 }


### PR DESCRIPTION
## Summary

- `activate_skill` calls were handled entirely inside `executeCalls` (context mutation) but returned **no `FunctionResultPart`**. This left the conversation history with an orphaned `functionCall` in the model message and no matching `functionResponse` in the next user message.
- Both Gemini and Anthropic reject such conversations with `400 Bad Request` on the next `client.stream()` call.
- Fixed by adding `skillResults: FunctionResultPart[]` to `ExecutionResult`. Each `activate_skill` call produces a synthetic `"Skill '…' activated."` result that is added to `context.addMessage` (for wire correctness) but **not** yielded as a `tool_result` event (the existing `skill_activated` event remains the UI signal).

## Related issue

Closes #241

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (710 tests)
- [x] New test in `agent.test.ts` verifies the second `stream()` call receives a `function_result` part for `activate_skill` in its conversation messages
- [x] Updated `executor.test.ts` checks `skillResults` is populated correctly and `results` remains empty for activate_skill-only calls

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNxZavtYneGiLCTSvsjnXX)_