### PR TITLE
fix: apply config.temperature to LLM client and expose it via opencli config

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -121,6 +121,7 @@ program
   .option("--model <model>", "Set the default model")
   .option("--provider <provider>", "Set the default provider: gemini | anthropic | openai")
   .option("--base-url <url>", "Set a custom base URL for proxy or local inference")
+  .option("--temperature <float>", "Set the default LLM temperature (0–2)", parseTemperature)
   .action(async (opts) => {
     if (opts.geminiApiKey) {
       await saveConfig({ geminiApiKey: opts.geminiApiKey });
@@ -146,13 +147,18 @@ program
       await saveConfig({ baseUrl: opts.baseUrl });
       printInfo(`Base URL set to ${opts.baseUrl}.`);
     }
+    if (opts.temperature !== undefined) {
+      await saveConfig({ temperature: opts.temperature as number });
+      printInfo(`Default temperature set to ${opts.temperature as number}.`);
+    }
     if (
       !opts.geminiApiKey &&
       !opts.anthropicApiKey &&
       !opts.openaiApiKey &&
       !opts.model &&
       !opts.provider &&
-      !opts.baseUrl
+      !opts.baseUrl &&
+      opts.temperature === undefined
     ) {
       const config = await loadConfig();
       console.log(
@@ -333,7 +339,7 @@ async function createAgent(
     maxTokens: config.maxTokens,
     provider,
     baseUrl,
-    temperature,
+    temperature: temperature ?? config.temperature,
   });
   const tools = createDefaultRegistry(model, runner);
 


### PR DESCRIPTION
## Summary

- **Core fix**: `createAgent()` now uses `temperature ?? config.temperature` instead of only the explicit CLI flag, so the value in `~/.opencli/config.json` is applied to every LLM call when no `--temperature` flag is given
- **Config command**: Adds `--temperature <float>` to `opencli config` so users can set the default temperature without manually editing the JSON file

## Why this was broken

`Config` declares `temperature: number` (default `0.7`) and `loadConfig()` reads it correctly, but `createAgent()` passed the raw `temperature` parameter to `createClient()` — which is `undefined` when neither `startChat` nor `runSingle` received an explicit value. The effect: `config.temperature` was dead config that had no effect on any LLM call, while `config.maxTokens`, `config.historySize`, and `config.autoCompact` were all applied correctly.

Related: `opencli config` had no `--temperature` option, making the field inaccessible via the CLI.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` — all pass (710 tests)
- [x] `opencli config --temperature 0.2` saves the value to `~/.opencli/config.json`
- [x] `opencli config` (no args) still prints current config
- [x] `opencli run --temperature 0.5 "…"` still takes precedence over config value (`??` operator)
- [x] No change to provider implementations, agent core, or tools

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6uuRCvUAXnjHew1Tqvui4)_